### PR TITLE
Integrate Optuna hyperparameter tuning into SUAVE tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,8 @@
-torch>=2.0.0
-scikit-learn>=1.0.2
-numpy>=1.9.3
-pandas>=1.3.5
-tqdm>=4.2.0
-matplotlib>=3.0.0
-tabulate>=0.8.10
+torch
+scikit-learn
+numpy
+pandas
+tqdm
+matplotlib
+tabulate
+optuna


### PR DESCRIPTION
## Summary
- Add Optuna to test suite for automated SUAVE hyperparameter search
- Use best Optuna-found parameters when training SUAVE in benchmarks
- Include Optuna dependency in project requirements and loosen version pins for compatibility
- Broaden SUAVE search with log-scale gamma (0.1–10000) and suppress Optuna logs, training longer for final fit

## Testing
- `pip install -r requirements.txt`
- `pytest tests/test_benchmarks.py::test_benchmarks -q -s`


------
https://chatgpt.com/codex/tasks/task_e_68c712d2455c8320a0abbd1bc1cd54e9