### PR TITLE
Add class-conditional generation to SUAVE

### DIFF
--- a/suave/models/suave.py
+++ b/suave/models/suave.py
@@ -24,7 +24,12 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
-from ..modules.losses import gaussian_nll, kl_divergence, linear_anneal
+from ..modules.losses import (
+    gaussian_nll,
+    kl_divergence,
+    kl_divergence_between_normals,
+    linear_anneal,
+)
 
 
 @dataclass
@@ -70,12 +75,24 @@ class Encoder(nn.Module):
 
 
 class Decoder(nn.Module):
-    """Shared decoder with a Gaussian head for continuous variables."""
+    """Shared decoder with Gaussian heads for continuous variables.
 
-    def __init__(self, latent_dim: int, output_dim: int, dropout: float) -> None:
+    The decoder can be conditioned on class information by concatenating a
+    one-hot encoding to the latent variable ``z``.  When ``conditional_dim`` is
+    zero the module reduces to the unconditional decoder used previously.
+    """
+
+    def __init__(
+        self,
+        latent_dim: int,
+        output_dim: int,
+        dropout: float,
+        conditional_dim: int = 0,
+    ) -> None:
         super().__init__()
+        in_dim = latent_dim + conditional_dim
         self.net = nn.Sequential(
-            nn.Linear(latent_dim, 256),
+            nn.Linear(in_dim, 256),
             nn.BatchNorm1d(256),
             nn.SiLU(),
             nn.Dropout(dropout),
@@ -90,7 +107,11 @@ class Decoder(nn.Module):
         self.mu = nn.Linear(128, output_dim)
         self.log_sigma = nn.Linear(128, output_dim)
 
-    def forward(self, z: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
+    def forward(
+        self, z: torch.Tensor, y_cond: Optional[torch.Tensor] = None
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        if y_cond is not None:
+            z = torch.cat([z, y_cond], dim=-1)
         h = self.net(z)
         return self.mu(h), self.log_sigma(h)
 
@@ -160,9 +181,16 @@ class SUAVE(nn.Module):
         self.device = device or torch.device("cpu")
 
         self.encoder = Encoder(input_dim, latent_dim, dropout)
-        self.decoder = Decoder(latent_dim, input_dim, dropout)
+        self.decoder = Decoder(latent_dim, input_dim, dropout, num_classes)
         # Classifier consumes latent code concatenated with last encoder layer
         self.classifier = Classifier(latent_dim + 128, num_classes, dropout)
+
+        # class-conditional prior parameters p(z | y)
+        self.prior_mu = nn.Linear(num_classes, latent_dim, bias=False)
+        self.prior_log_var = nn.Linear(num_classes, latent_dim)
+        nn.init.zeros_(self.prior_mu.weight)
+        nn.init.zeros_(self.prior_log_var.weight)
+        nn.init.zeros_(self.prior_log_var.bias)
 
         self.beta_schedule = beta_schedule or AnnealSchedule(0.0, 0.7, 15)
         self.lambda_schedule = lambda_schedule or AnnealSchedule(0.5, 1.0, 15)
@@ -178,17 +206,49 @@ class SUAVE(nn.Module):
 
     # ----------------------------------------------------------------- forward
     def forward(
-        self, x: torch.Tensor, m: Optional[torch.Tensor] = None
+        self,
+        x: torch.Tensor,
+        m: Optional[torch.Tensor] = None,
+        y: Optional[torch.Tensor] = None,
     ) -> Tuple[
-        torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor
+        torch.Tensor,
+        torch.Tensor,
+        torch.Tensor,
+        torch.Tensor,
+        torch.Tensor,
+        torch.Tensor,
+        Optional[torch.Tensor],
+        Optional[torch.Tensor],
+        Optional[torch.Tensor],
     ]:
         if m is None:
             m = torch.ones_like(x)
         mu, log_var, h = self.encoder(x, m)
         z = self._reparameterize(mu, log_var)
-        recon_mu, recon_log_sigma = self.decoder(z)
+        y_onehot = None
+        prior_mu = None
+        prior_log_var = None
+        if y is not None:
+            y_onehot = F.one_hot(y, num_classes=self.num_classes).float()
+            prior_mu = self.prior_mu(y_onehot)
+            prior_log_var = self.prior_log_var(y_onehot)
+        else:
+            y_onehot = torch.zeros(
+                x.size(0), self.num_classes, device=x.device, dtype=torch.float32
+            )
+        recon_mu, recon_log_sigma = self.decoder(z, y_onehot)
         logits = self.classifier(torch.cat([z, h], dim=-1))
-        return z, recon_mu, recon_log_sigma, mu, log_var, logits
+        return (
+            z,
+            recon_mu,
+            recon_log_sigma,
+            mu,
+            log_var,
+            logits,
+            y_onehot,
+            prior_mu,
+            prior_log_var,
+        )
 
     # ---------------------------------------------------------------- training
     def fit(
@@ -211,14 +271,32 @@ class SUAVE(nn.Module):
         self.X_train = X
         self.y_train = y
 
+        counts = np.bincount(y, minlength=self.num_classes)
+        self.label_distribution = (counts / counts.sum()).astype(float)
+
         opt = torch.optim.AdamW(self.parameters(), lr=lr, weight_decay=1e-4)
         for epoch in range(epochs):
             opt.zero_grad()
-            z, recon_mu, recon_log_sigma, mu, log_var, logits = self.forward(
-                X_t, mask
+            (
+                z,
+                recon_mu,
+                recon_log_sigma,
+                mu,
+                log_var,
+                logits,
+                _,
+                prior_mu,
+                prior_log_var,
+            ) = self.forward(
+                X_t, mask, y_t
             )
             nll = gaussian_nll(recon_mu, recon_log_sigma, X_t, mask)
-            kl = kl_divergence(mu, log_var)
+            if prior_mu is not None and prior_log_var is not None:
+                kl = kl_divergence_between_normals(
+                    mu, log_var, prior_mu, prior_log_var
+                )
+            else:
+                kl = kl_divergence(mu, log_var)
             ce = F.cross_entropy(logits, y_t)
             beta = linear_anneal(epoch, self.beta_schedule)
             lam = linear_anneal(epoch, self.lambda_schedule)
@@ -235,7 +313,7 @@ class SUAVE(nn.Module):
             X_t = torch.as_tensor(X, dtype=torch.float32, device=self.device)
             mask = torch.isfinite(X_t).float()
             X_t = torch.nan_to_num(X_t, nan=0.0)
-            z, _, _, _, _, logits = self.forward(X_t, mask)
+            _, _, _, _, _, logits, _, _, _ = self.forward(X_t, mask)
         return logits.cpu()
 
     def predict_proba(self, X: np.ndarray) -> np.ndarray:
@@ -269,8 +347,6 @@ class SUAVE(nn.Module):
         rng = np.random.default_rng(seed)
 
         if conditional and "y" in conditional:
-            if not hasattr(self, "X_train"):
-                raise RuntimeError("Model must be fitted before conditional generation")
             y_cond = conditional["y"]
             if np.ndim(y_cond) == 0:
                 y_vec = np.full(n_samples, int(y_cond))
@@ -278,29 +354,26 @@ class SUAVE(nn.Module):
                 y_vec = np.asarray(y_cond, dtype=int)
                 if len(y_vec) != n_samples:
                     raise ValueError("Length of conditional labels must match n_samples")
-            idxs = []
-            for lbl in y_vec:
-                candidates = np.where(self.y_train == lbl)[0]
-                if len(candidates) == 0:
-                    raise ValueError(f"No training samples with label {lbl}")
-                idxs.append(rng.choice(candidates))
-            X_sel = self.X_train[idxs]
-            X_t = torch.as_tensor(X_sel, dtype=torch.float32, device=self.device)
-            mask = torch.isfinite(X_t).float()
-            X_t = torch.nan_to_num(X_t, nan=0.0)
-            with torch.no_grad():
-                mu, log_var, _ = self.encoder(X_t, mask)
-                z = self._reparameterize(mu, log_var)
-                mu_x, log_sigma = self.decoder(z)
-                sigma = torch.exp(log_sigma)
-                x = mu_x + sigma * torch.randn_like(mu_x)
         else:
-            z = torch.from_numpy(rng.standard_normal((n_samples, self.latent_dim))).float()
-            z = z.to(self.device)
-            with torch.no_grad():
-                mu, log_sigma = self.decoder(z)
-                sigma = torch.exp(log_sigma)
-                x = mu + sigma * torch.randn_like(mu)
+            if hasattr(self, "label_distribution"):
+                probs = self.label_distribution
+            elif hasattr(self, "y_train"):
+                counts = np.bincount(self.y_train, minlength=self.num_classes)
+                probs = counts / counts.sum()
+            else:
+                probs = np.full(self.num_classes, 1.0 / self.num_classes)
+            y_vec = rng.choice(self.num_classes, size=n_samples, p=probs)
+
+        y_tensor = torch.as_tensor(y_vec, dtype=torch.long, device=self.device)
+        y_onehot = F.one_hot(y_tensor, num_classes=self.num_classes).float()
+
+        with torch.no_grad():
+            prior_mu = self.prior_mu(y_onehot)
+            prior_log_var = self.prior_log_var(y_onehot)
+            z = self._reparameterize(prior_mu, prior_log_var)
+            mu_x, log_sigma = self.decoder(z, y_onehot)
+            sigma = torch.exp(log_sigma)
+            x = mu_x + sigma * torch.randn_like(mu_x)
 
         cols = [f"x{i}" for i in range(self.input_dim)]
         df = pd.DataFrame(x.cpu().numpy(), columns=cols)
@@ -331,11 +404,26 @@ class SUAVE(nn.Module):
         mask = torch.isfinite(X_t).float()
         X_t = torch.nan_to_num(X_t, nan=0.0)
         with torch.no_grad():
-            z, recon_mu, recon_log_sigma, mu, log_var, logits = self.forward(
-                X_t, mask
+            (
+                _,
+                recon_mu,
+                recon_log_sigma,
+                mu,
+                log_var,
+                logits,
+                _,
+                prior_mu,
+                prior_log_var,
+            ) = self.forward(
+                X_t, mask, y_t
             )
             nll = gaussian_nll(recon_mu, recon_log_sigma, X_t, mask).item()
-            kl = kl_divergence(mu, log_var).item()
+            if prior_mu is not None and prior_log_var is not None:
+                kl = kl_divergence_between_normals(
+                    mu, log_var, prior_mu, prior_log_var
+                ).item()
+            else:
+                kl = kl_divergence(mu, log_var).item()
             ce = F.cross_entropy(logits, y_t).item()
             loss = nll + kl + ce
         return float(loss), float(nll), float(kl), float(ce), 0.0, 0.0

--- a/suave/modules/losses.py
+++ b/suave/modules/losses.py
@@ -38,6 +38,33 @@ def kl_divergence(mu: torch.Tensor, logvar: torch.Tensor) -> torch.Tensor:
     return -0.5 * torch.mean(1 + logvar - mu.pow(2) - logvar.exp())
 
 
+def kl_divergence_between_normals(
+    mu_q: torch.Tensor,
+    logvar_q: torch.Tensor,
+    mu_p: torch.Tensor,
+    logvar_p: torch.Tensor,
+) -> torch.Tensor:
+    """KL divergence ``KL(q || p)`` for diagonal Gaussians.
+
+    Parameters
+    ----------
+    mu_q, logvar_q:
+        Mean and log-variance of the approximate posterior ``q(z|x, y)``.
+    mu_p, logvar_p:
+        Mean and log-variance of the conditional prior ``p(z|y)``.
+    """
+
+    var_q = logvar_q.exp()
+    var_p = logvar_p.exp()
+    kl = 0.5 * (
+        (var_q / var_p)
+        + ((mu_q - mu_p) ** 2) / var_p
+        - 1
+        + (logvar_p - logvar_q)
+    )
+    return kl.sum(dim=1).mean()
+
+
 def linear_anneal(step: int, schedule: "AnnealSchedule") -> float:
     """Linearly anneal ``schedule.start`` to ``schedule.end`` over ``schedule.epochs``."""
 


### PR DESCRIPTION
## Summary
- make the decoder conditional on class information and learn a class-dependent latent prior to enable CVAE-style sampling
- update SUAVE training, evaluation and generation flows to use the conditional prior and store label distributions for sampling
- add a KL utility for diagonal Gaussians to support the new conditional KL term

## Testing
- pytest tests/test_benchmarks.py -s

------
https://chatgpt.com/codex/tasks/task_e_68c839cd80b08320b4f08774b7b2e436