### PR TITLE
Support mini-batch training for SUAVE

### DIFF
--- a/suave/sklearn.py
+++ b/suave/sklearn.py
@@ -42,9 +42,17 @@ class SuaveClassifier:
             for c in task_classes
         ]
 
-    def fit(self, X: np.ndarray, Y: np.ndarray, epochs: int = 20, **_: object) -> "SuaveClassifier":
+    def fit(
+        self,
+        X: np.ndarray,
+        Y: np.ndarray,
+        epochs: int = 20,
+        *,
+        batch_size: int | None = None,
+        **_: object,
+    ) -> "SuaveClassifier":
         for model, y in zip(self.models, Y.T):
-            model.fit(X, y, epochs=epochs)
+            model.fit(X, y, epochs=epochs, batch_size=batch_size)
         return self
 
     def predict_proba(self, X: np.ndarray) -> List[np.ndarray]:

--- a/suave/trainers/train_suave.py
+++ b/suave/trainers/train_suave.py
@@ -7,9 +7,15 @@ import numpy as np
 from ..api import SUAVE
 
 
-def train_suave(X: np.ndarray, y: np.ndarray, epochs: int = 20) -> SUAVE:
+def train_suave(
+    X: np.ndarray,
+    y: np.ndarray,
+    epochs: int = 20,
+    *,
+    batch_size: int | None = None,
+) -> SUAVE:
     """Train a :class:`SUAVE` model on the provided data."""
 
     model = SUAVE(input_dim=X.shape[1])
-    model.fit(X, y, epochs=epochs)
+    model.fit(X, y, epochs=epochs, batch_size=batch_size)
     return model

--- a/tests/test_suave_minimal.py
+++ b/tests/test_suave_minimal.py
@@ -2,6 +2,7 @@ import os
 import sys
 
 import numpy as np
+import pytest
 import torch
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
@@ -63,3 +64,50 @@ def test_generation_calibration_tstr():
         Z[:50], method="tsne", max_iter=250, perplexity=5, init="random", learning_rate="auto"
     )
     assert emb.shape == (50, 2)
+
+
+def test_suave_fit_with_minibatches() -> None:
+    rng = np.random.default_rng(42)
+    torch.manual_seed(0)
+    X = rng.normal(size=(64, 5))
+    missing_mask = rng.random(X.shape) < 0.1
+    X[missing_mask] = np.nan
+    y = rng.integers(0, 2, size=64)
+
+    model = SUAVE(input_dim=5, latent_dim=3)
+    returned = model.fit(X, y, epochs=4, batch_size=16)
+    assert returned is model
+    assert np.isclose(model.label_distribution.sum(), 1.0)
+    proba = model.predict_proba(X)
+    assert proba.shape == (64, 2)
+    np.testing.assert_allclose(proba.sum(axis=1), np.ones(64), atol=1e-5)
+
+
+def test_suave_minibatch_matches_full_batch() -> None:
+    rng = np.random.default_rng(7)
+    X = rng.normal(size=(40, 3))
+    y = (X[:, 0] + 0.2 * rng.normal(size=40) > 0).astype(int)
+
+    torch.manual_seed(1)
+    full = SUAVE(input_dim=3, latent_dim=2)
+    full.fit(X, y, epochs=5)
+    full_proba = full.predict_proba(X)
+
+    torch.manual_seed(1)
+    mini = SUAVE(input_dim=3, latent_dim=2)
+    mini.fit(X, y, epochs=5, batch_size=8)
+    mini_proba = mini.predict_proba(X)
+
+    assert full_proba.shape == mini_proba.shape == (40, 2)
+    diff = np.abs(full_proba - mini_proba).mean()
+    assert diff < 0.15
+
+
+def test_suave_fit_invalid_batch_size() -> None:
+    rng = np.random.default_rng(3)
+    X = rng.normal(size=(10, 2))
+    y = rng.integers(0, 2, size=10)
+
+    model = SUAVE(input_dim=2, latent_dim=2)
+    with pytest.raises(ValueError):
+        model.fit(X, y, batch_size=0)

--- a/tests/utils/benchmarking.py
+++ b/tests/utils/benchmarking.py
@@ -141,6 +141,7 @@ def run_suave_models(
     variants: Iterable[str] = ("suave", "suave-impute", "suave-single"),
     latent_dim: int = 8,
     epochs: int = 20,
+    batch_size: int | None = None,
     base_seed: int = 0,
 ) -> Dict[str, Dict[str, object]]:
     """Train and evaluate SUAVE-based models."""
@@ -152,7 +153,7 @@ def run_suave_models(
     if "suave" in variant_set:
         _set_seed(base_seed)
         model = create_suave_classifier(input_dim, list(task_classes), latent_dim=latent_dim)
-        model.fit(X_train, y_train, epochs=epochs)
+        model.fit(X_train, y_train, epochs=epochs, batch_size=batch_size)
         probas = model.predict_proba(X_test)
         preds = model.predict(X_test)
         metrics = {
@@ -173,7 +174,7 @@ def run_suave_models(
             latent_dim=latent_dim,
             random_state=base_seed + 1,
         )
-        wrapper.fit(X_train, y_train, epochs=epochs)
+        wrapper.fit(X_train, y_train, epochs=epochs, batch_size=batch_size)
         probas = wrapper.predict_proba(X_test)
         preds = wrapper.predict(X_test)
         metrics = {
@@ -191,7 +192,7 @@ def run_suave_models(
         for idx, num_classes in enumerate(task_classes):
             _set_seed(base_seed + 2 + idx)
             model = SingleTaskSuave(input_dim=input_dim, num_classes=num_classes, latent_dim=latent_dim)
-            model.fit(X_train, y_train[:, idx], epochs=epochs)
+            model.fit(X_train, y_train[:, idx], epochs=epochs, batch_size=batch_size)
             proba = model.predict_proba(X_test)
             pred = model.predict(X_test)
             single_metrics[f"y{idx + 1}"] = compute_task_metrics(

--- a/tests/utils/models.py
+++ b/tests/utils/models.py
@@ -42,8 +42,15 @@ class SingleTaskSuave:
             num_classes=self.num_classes,
         )
 
-    def fit(self, X: np.ndarray, y: np.ndarray, epochs: int = 20) -> "SingleTaskSuave":
-        self.model.fit(X, y, epochs=epochs)
+    def fit(
+        self,
+        X: np.ndarray,
+        y: np.ndarray,
+        epochs: int = 20,
+        *,
+        batch_size: int | None = None,
+    ) -> "SingleTaskSuave":
+        self.model.fit(X, y, epochs=epochs, batch_size=batch_size)
         return self
 
     def predict_proba(self, X: np.ndarray) -> np.ndarray:
@@ -78,9 +85,16 @@ class SuaveImputeWrapper:
             latent_dim=latent_dim,
         )
 
-    def fit(self, X: np.ndarray, Y: np.ndarray, epochs: int = 20) -> "SuaveImputeWrapper":
+    def fit(
+        self,
+        X: np.ndarray,
+        Y: np.ndarray,
+        epochs: int = 20,
+        *,
+        batch_size: int | None = None,
+    ) -> "SuaveImputeWrapper":
         X_imp = self.imputer.fit_transform(X)
-        self.model.fit(X_imp, Y, epochs=epochs)
+        self.model.fit(X_imp, Y, epochs=epochs, batch_size=batch_size)
         return self
 
     def predict_proba(self, X: np.ndarray) -> List[np.ndarray]:


### PR DESCRIPTION
## Summary
- add mini-batch training support to `SUAVE.fit` with configurable batch size
- propagate batch size through benchmark utilities and CLI defaults
- extend unit tests to cover mini-batch behaviour and validation

## Testing
- `pytest tests/test_suave_minimal.py`
- `pytest tests/test_benchmarks.py -s`


------
https://chatgpt.com/codex/tasks/task_e_68c9157c6b5c8320930c2aca8a81c9fb