### PR TITLE
Fix macro F1 handling in binary metrics

### DIFF
--- a/tests/utils/benchmarking.py
+++ b/tests/utils/benchmarking.py
@@ -56,7 +56,7 @@ def compute_task_metrics(
             "auprc_macro": float(average_precision_score(y_true, proba[:, 1])),
             "auprc_micro": float(average_precision_score(y_true, proba[:, 1])),
             "acc_top1": float(accuracy_score(y_true, pred)),
-            "f1_macro": float(f1_score(y_true, pred)),
+            "f1_macro": float(f1_score(y_true, pred, average="macro")),
         }
     return metrics
 

--- a/tools/evaluate_hard_beta_info.py
+++ b/tools/evaluate_hard_beta_info.py
@@ -95,7 +95,7 @@ def _compute_task_metrics(
         metrics["auprc_macro"] = float(average_precision_score(y_true, proba[:, 1]))
         metrics["auprc_micro"] = metrics["auprc_macro"]
         metrics["acc_top1"] = float(accuracy_score(y_true, pred))
-        metrics["f1_macro"] = float(f1_score(y_true, pred))
+        metrics["f1_macro"] = float(f1_score(y_true, pred, average="macro"))
     return metrics
 
 


### PR DESCRIPTION
## Summary
- compute macro-averaged F1 in the binary metric branch used by the benchmarking helpers
- align the beta/InfoVAE evaluation script with the corrected macro averaging so downstream reports stay consistent

## Testing
- pytest tests/test_benchmarks_smoke.py -s

------
https://chatgpt.com/codex/tasks/task_e_68c9438b6524832092b468ea2853d739