### PR TITLE
Support multi-class evaluation metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,14 @@ z = model.latent(X_test)
 * ``generate(n, conditional=None, seed=None)`` – create synthetic samples.
 * ``latent(X)`` – extract latent representations.
 
+## Evaluation helpers
+
+The ``suave.eval.classification_metrics`` utility reports AUROC, AUPRC, Brier
+score and negative log-likelihood for both binary and multi-class classification
+problems. It accepts either a probability vector for the positive class or a
+full probability matrix with one column per class and transparently selects the
+appropriate reduction strategy (binary vs. one-vs-rest macro averages).
+
 ## License
 
 BSD-3-Clause

--- a/suave/eval/metrics.py
+++ b/suave/eval/metrics.py
@@ -1,4 +1,13 @@
-"""Basic classification metrics used in tests."""
+"""Basic classification metrics used in tests.
+
+The helper transparently handles binary and multi-class inputs. Probabilities can
+either be provided as a one-dimensional array containing the positive class
+scores or as a two-dimensional matrix with one column per class. Multi-class
+support follows the one-vs-rest convention with macro averaging for the AUC and
+average precision metrics. The function raises a :class:`ValueError` when given
+an inconsistent combination of labels and probabilities (e.g. multi-class labels
+with a one-dimensional probability vector).
+"""
 
 from __future__ import annotations
 
@@ -11,13 +20,88 @@ from sklearn.metrics import (
     log_loss,
     roc_auc_score,
 )
+from sklearn.preprocessing import label_binarize
 
 
 def classification_metrics(y_true: np.ndarray, proba: np.ndarray) -> Dict[str, float]:
-    """Return a dictionary of common classification metrics."""
+    """Return a dictionary of common classification metrics.
+
+    Parameters
+    ----------
+    y_true
+        Ground-truth labels.
+    proba
+        Predicted probabilities, either as a one-dimensional array for binary
+        classification or a two-dimensional array of shape ``(n_samples,
+        n_classes)`` for multi-class problems.
+
+    Returns
+    -------
+    dict
+        Dictionary containing AUROC, AUPRC, Brier score and negative
+        log-likelihood.
+
+    Raises
+    ------
+    ValueError
+        If multi-class targets are provided together with a one-dimensional
+        probability array or when the probability matrix has a column count that
+        does not match the number of observed classes.
+    """
+
+    y_true = np.asarray(y_true)
+    proba = np.asarray(proba)
+
+    unique_classes = np.unique(y_true)
+    proba_is_matrix = proba.ndim == 2
+    # Detection covers both probability matrices and label sets with more than
+    # two unique classes.
+    has_multiclass_indicators = proba_is_matrix or unique_classes.size > 2
+
+    if has_multiclass_indicators:
+        if proba_is_matrix and proba.shape[1] == 2 and unique_classes.size <= 2:
+            # Binary classification represented with two probability columns.
+            positive_proba = proba[:, 1]
+            return {
+                "auroc": float(roc_auc_score(y_true, positive_proba)),
+                "auprc": float(average_precision_score(y_true, positive_proba)),
+                "brier": float(brier_score_loss(y_true, positive_proba)),
+                "nll": float(log_loss(y_true, positive_proba)),
+            }
+
+        if not proba_is_matrix:
+            raise ValueError(
+                "Multi-class classification requires `proba` to be a 2D array "
+                "with one column per class."
+            )
+
+        classes = np.sort(unique_classes)
+        if proba.shape[1] != classes.size:
+            raise ValueError(
+                "`proba` must have one column per unique class observed in "
+                "`y_true` to compute multi-class metrics."
+            )
+
+        y_true_bin = label_binarize(y_true, classes=classes)
+        return {
+            "auroc": float(
+                roc_auc_score(y_true, proba, multi_class="ovr", average="macro")
+            ),
+            "auprc": float(
+                average_precision_score(y_true_bin, proba, average="macro")
+            ),
+            "brier": float(np.mean(np.sum((proba - y_true_bin) ** 2, axis=1))),
+            "nll": float(log_loss(y_true, proba, labels=classes)),
+        }
+
+    if proba_is_matrix:
+        positive_proba = proba[:, 1]
+    else:
+        positive_proba = proba
+
     return {
-        "auroc": roc_auc_score(y_true, proba),
-        "auprc": average_precision_score(y_true, proba),
-        "brier": brier_score_loss(y_true, proba),
-        "nll": log_loss(y_true, proba),
+        "auroc": float(roc_auc_score(y_true, positive_proba)),
+        "auprc": float(average_precision_score(y_true, positive_proba)),
+        "brier": float(brier_score_loss(y_true, positive_proba)),
+        "nll": float(log_loss(y_true, positive_proba)),
     }

--- a/tests/test_eval_metrics.py
+++ b/tests/test_eval_metrics.py
@@ -1,0 +1,92 @@
+"""Unit tests for the lightweight evaluation metrics helper."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from sklearn.metrics import average_precision_score, log_loss, roc_auc_score
+from sklearn.preprocessing import label_binarize
+
+from suave.eval.metrics import classification_metrics
+
+
+def _binary_reference_metrics(y_true: np.ndarray, proba: np.ndarray) -> dict[str, float]:
+    return {
+        "auroc": roc_auc_score(y_true, proba),
+        "auprc": average_precision_score(y_true, proba),
+        "brier": np.mean((y_true - proba) ** 2),
+        "nll": log_loss(y_true, proba),
+    }
+
+
+def test_classification_metrics_binary_vector() -> None:
+    """Binary inputs with a probability vector should be supported."""
+
+    y_true = np.array([0, 1, 1, 0, 1, 0])
+    proba = np.array([0.2, 0.8, 0.7, 0.3, 0.9, 0.1])
+
+    expected = _binary_reference_metrics(y_true, proba)
+    result = classification_metrics(y_true, proba)
+
+    for key, value in expected.items():
+        assert result[key] == pytest.approx(value)
+
+
+def test_classification_metrics_binary_matrix() -> None:
+    """Binary probability matrices should reduce to the positive column."""
+
+    y_true = np.array([0, 1, 1, 0, 1, 0])
+    proba = np.array([0.2, 0.8, 0.7, 0.3, 0.9, 0.1])
+    proba_matrix = np.column_stack([1 - proba, proba])
+
+    expected = _binary_reference_metrics(y_true, proba)
+    result = classification_metrics(y_true, proba_matrix)
+
+    for key, value in expected.items():
+        assert result[key] == pytest.approx(value)
+
+
+def test_classification_metrics_multiclass() -> None:
+    """Multi-class metrics use macro-averaged one-vs-rest reductions."""
+
+    y_true = np.array([0, 1, 2, 1, 0, 2, 1, 0, 2, 0])
+    proba = np.array(
+        [
+            [0.7, 0.2, 0.1],
+            [0.1, 0.6, 0.3],
+            [0.2, 0.2, 0.6],
+            [0.1, 0.7, 0.2],
+            [0.6, 0.3, 0.1],
+            [0.2, 0.2, 0.6],
+            [0.2, 0.6, 0.2],
+            [0.8, 0.1, 0.1],
+            [0.3, 0.3, 0.4],
+            [0.6, 0.2, 0.2],
+        ]
+    )
+
+    classes = np.sort(np.unique(y_true))
+    y_bin = label_binarize(y_true, classes=classes)
+
+    expected = {
+        "auroc": roc_auc_score(y_true, proba, multi_class="ovr", average="macro"),
+        "auprc": average_precision_score(y_bin, proba, average="macro"),
+        "brier": np.mean(np.sum((proba - y_bin) ** 2, axis=1)),
+        "nll": log_loss(y_true, proba, labels=classes),
+    }
+    result = classification_metrics(y_true, proba)
+
+    for key, value in expected.items():
+        assert result[key] == pytest.approx(value)
+
+
+def test_classification_metrics_multiclass_invalid_probability_shape() -> None:
+    """Multi-class labels require a probability matrix with matching columns."""
+
+    y_true = np.array([0, 1, 2, 1])
+
+    with pytest.raises(ValueError, match="Multi-class classification requires"):
+        classification_metrics(y_true, np.array([0.2, 0.5, 0.3, 0.4]))
+
+    with pytest.raises(ValueError, match="must have one column per unique class"):
+        classification_metrics(y_true, np.array([[0.6, 0.4], [0.2, 0.8], [0.3, 0.7], [0.5, 0.5]]))


### PR DESCRIPTION
## Summary
- extend `classification_metrics` to detect multi-class inputs, compute macro one-vs-rest metrics, and raise clear errors for incompatible probabilities
- add targeted unit tests covering binary vectors/matrices, multiclass inputs, and invalid shapes
- document the evaluation helper and its multi-class support in the README

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c94398776c83208235508c2d31f7ff