### PR TITLE
Add minimal SUAVE package skeleton

### DIFF
--- a/examples/data/sepsis_toy.csv
+++ b/examples/data/sepsis_toy.csv
@@ -1,0 +1,6 @@
+subject_id,age,sofa_score,gender,outcome
+1,65,5,M,0
+2,72,7,F,1
+3,58,4,F,0
+4,61,6,M,1
+5,70,8,M,1

--- a/examples/sepsis_minimal.py
+++ b/examples/sepsis_minimal.py
@@ -1,0 +1,42 @@
+"""Minimal end-to-end example for the placeholder SUAVE package."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+
+from suave import SUAVE, Schema
+from suave.plots import plot_reliability_curve
+
+
+def main() -> None:
+    """Run the minimal training, prediction, calibration, and plotting loop."""
+
+    data_path = Path(__file__).parent / "data" / "sepsis_toy.csv"
+    df = pd.read_csv(data_path)
+
+    feature_columns = ["age", "sofa_score", "gender"]
+    schema = Schema(
+        {
+            "age": {"type": "real"},
+            "sofa_score": {"type": "real"},
+            "gender": {"type": "cat", "n_classes": 2},
+        }
+    )
+
+    X = df[feature_columns]
+    y = df["outcome"]
+
+    model = SUAVE(schema=schema)
+    model.fit(X, y, epochs=1)
+    probabilities = model.predict_proba(X)
+    model.calibrate(X, y)
+
+    output_path = data_path.with_name("reliability_placeholder.png")
+    plot_reliability_curve(probabilities[:, 1], y, output_path=output_path)
+    print(f"Reliability curve saved to {output_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/suave/__init__.py
+++ b/suave/__init__.py
@@ -1,0 +1,11 @@
+"""Top-level package for the lightweight SUAVE API.
+
+This module exposes the user-facing classes that are required for the
+minimal runnable skeleton requested in the roadmap.  The real
+implementation will iterate on top of these public entry points.
+"""
+
+from .model import SUAVE
+from .types import Schema
+
+__all__ = ["SUAVE", "Schema"]

--- a/suave/data.py
+++ b/suave/data.py
@@ -1,0 +1,155 @@
+"""Data utilities for the minimal SUAVE implementation."""
+
+from __future__ import annotations
+
+from typing import Dict, Tuple
+
+import numpy as np
+import pandas as pd
+
+from .types import Schema
+
+_EPS = 1e-6
+
+
+def split_train_val(
+    X: pd.DataFrame,
+    y: pd.Series | pd.DataFrame | np.ndarray,
+    val_split: float,
+    stratify: bool,
+) -> Tuple[
+    pd.DataFrame,
+    pd.DataFrame,
+    pd.Series | pd.DataFrame | np.ndarray,
+    pd.Series | pd.DataFrame | np.ndarray,
+]:
+    """Split training data into train and validation subsets.
+
+    Parameters
+    ----------
+    X:
+        Feature matrix with shape ``(n_samples, n_features)``.
+    y:
+        Targets aligned with ``X``. Accepts :class:`pandas.Series`,
+        :class:`pandas.DataFrame`, or :class:`numpy.ndarray`.
+    val_split:
+        Proportion of samples that should end up in the validation split.  Must
+        satisfy ``0 < val_split < 1``.
+    stratify:
+        If ``True`` the split preserves label frequencies using ``y``.
+
+    Returns
+    -------
+    (X_train, X_val, y_train, y_val)
+        Tuple of training and validation subsets.
+    """
+
+    if not 0 < val_split < 1:
+        raise ValueError("val_split must be between 0 and 1 (exclusive)")
+
+    n_samples = len(X)
+    indices = np.arange(n_samples)
+
+    if stratify:
+        if y is None:
+            raise ValueError("Stratified split requested but no targets provided")
+        y_array = np.asarray(y)
+        val_indices: list[int] = []
+        rng = np.random.default_rng(0)
+        for cls in np.unique(y_array):
+            cls_indices = indices[y_array == cls]
+            if len(cls_indices) == 0:
+                continue
+            n_val = max(1, int(round(len(cls_indices) * val_split)))
+            n_val = min(n_val, len(cls_indices))
+            selected = rng.choice(cls_indices, size=n_val, replace=False)
+            val_indices.extend(selected.tolist())
+        val_indices = np.array(sorted(set(val_indices)))
+    else:
+        rng = np.random.default_rng(0)
+        n_val = int(round(n_samples * val_split))
+        n_val = max(1, min(n_samples, n_val))
+        val_indices = np.array(sorted(rng.choice(indices, size=n_val, replace=False)))
+
+    train_mask = np.ones(n_samples, dtype=bool)
+    train_mask[val_indices] = False
+    train_indices = indices[train_mask]
+
+    X_train = X.iloc[train_indices].reset_index(drop=True)
+    X_val = X.iloc[val_indices].reset_index(drop=True)
+
+    if isinstance(y, (pd.Series, pd.DataFrame)):
+        y_train = y.iloc[train_indices].reset_index(drop=True)
+        y_val = y.iloc[val_indices].reset_index(drop=True)
+    else:
+        y = np.asarray(y)
+        y_train = y[train_indices]
+        y_val = y[val_indices]
+
+    return X_train, X_val, y_train, y_val
+
+
+def build_missing_mask(X: pd.DataFrame) -> pd.DataFrame:
+    """Return a boolean mask indicating missing entries in ``X``."""
+
+    return X.isna()
+
+
+def standardize(
+    X: pd.DataFrame,
+    schema: Schema,
+) -> Tuple[pd.DataFrame, Dict[str, Dict[str, float | list[object]]]]:
+    """Standardise the dataframe using schema information.
+
+    ``real`` columns are z-scored. ``cat`` columns are cast to categorical
+    dtype; their categories are recorded but left untouched.
+
+    Returns
+    -------
+    transformed, stats
+        ``transformed`` is the normalised dataframe and ``stats`` contains
+        per-column metadata for :func:`inverse_standardize`.
+    """
+
+    schema.require_columns(X.columns)
+    transformed = X.copy()
+    stats: Dict[str, Dict[str, float | list[object]]] = {}
+
+    for column in schema.real_features:
+        if column not in transformed:
+            continue
+        values = pd.to_numeric(transformed[column], errors="coerce")
+        mean = float(values.mean()) if len(values) > 0 else 0.0
+        std = float(values.std(ddof=0)) if len(values) > 0 else 1.0
+        if std < _EPS:
+            std = 1.0
+        transformed[column] = (values - mean) / max(std, _EPS)
+        stats[column] = {"type": "real", "mean": mean, "std": std}
+
+    for column in schema.categorical_features:
+        if column not in transformed:
+            continue
+        transformed[column] = transformed[column].astype("category")
+        categories = transformed[column].cat.categories.tolist()
+        stats[column] = {"type": "cat", "categories": categories}
+
+    return transformed, stats
+
+
+def inverse_standardize(
+    X: pd.DataFrame,
+    schema: Schema,
+    stats: Dict[str, Dict[str, float | list[object]]],
+) -> pd.DataFrame:
+    """Undo :func:`standardize` using the stored statistics."""
+
+    restored = X.copy()
+    for column, meta in stats.items():
+        if meta["type"] == "real":
+            mean = float(meta["mean"])
+            std = float(meta["std"])
+            restored[column] = restored[column] * std + mean
+        elif meta["type"] == "cat":
+            categories = meta.get("categories", [])
+            restored[column] = pd.Categorical(restored[column], categories=categories)
+    return restored

--- a/suave/evaluate.py
+++ b/suave/evaluate.py
@@ -1,0 +1,17 @@
+"""Evaluation helpers for SUAVE."""
+
+from __future__ import annotations
+
+from typing import Dict
+
+import numpy as np
+
+
+def evaluate_classification(
+    probabilities: np.ndarray, targets: np.ndarray
+) -> Dict[str, float]:
+    """Return dummy metrics for the minimal implementation."""
+
+    if probabilities.shape[0] != len(targets):
+        raise ValueError("probabilities and targets must share the first dimension")
+    return {"accuracy": float(np.mean(targets == targets))}

--- a/suave/model.py
+++ b/suave/model.py
@@ -1,0 +1,284 @@
+"""Core model definitions for the minimal SUAVE package."""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+from pathlib import Path
+from typing import Iterable, Optional
+
+import numpy as np
+import pandas as pd
+
+from . import data as data_utils
+from .modules.calibrate import TemperatureScaler
+from .sampling import sample as sampling_stub
+from .types import Schema
+
+LOGGER = logging.getLogger(__name__)
+
+
+class SUAVE:
+    """Minimal SUAVE model stub.
+
+    Parameters
+    ----------
+    schema:
+        Optional :class:`Schema` describing the dataset. If not provided during
+        initialisation it must be supplied to :meth:`fit`.
+    latent_dim:
+        Dimensionality of the latent representation. Default is ``32``.
+    beta:
+        Weighting factor for the KL term. Default is ``1.5``.
+    hidden_dims:
+        Shape of the encoder and decoder multilayer perceptrons. Default is
+        ``(256, 128)``.
+    dropout:
+        Dropout probability applied inside neural modules. Default is ``0.1``.
+    learning_rate:
+        Optimiser learning rate. Default is ``1e-3``.
+    val_split:
+        Validation split ratio used inside :meth:`fit`. Default is ``0.2``.
+    stratify:
+        Whether to preserve class balance when creating the validation split.
+    random_state:
+        Seed controlling deterministic behaviour in helper utilities.
+
+    Examples
+    --------
+    >>> import pandas as pd
+    >>> from suave.model import SUAVE
+    >>> from suave.types import Schema
+    >>> X = pd.DataFrame({"age": [1.0, 2.0], "gender": [0, 1]})
+    >>> y = pd.Series([0, 1])
+    >>> schema = Schema({"age": {"type": "real"}, "gender": {"type": "cat", "n_classes": 2}})
+    >>> model = SUAVE(schema=schema)
+    >>> _ = model.fit(X, y)
+    >>> proba = model.predict_proba(X)
+    >>> proba.shape
+    (2, 2)
+    """
+
+    def __init__(
+        self,
+        schema: Optional[Schema] = None,
+        *,
+        latent_dim: int = 32,
+        beta: float = 1.5,
+        hidden_dims: Iterable[int] = (256, 128),
+        dropout: float = 0.1,
+        learning_rate: float = 1e-3,
+        val_split: float = 0.2,
+        stratify: bool = True,
+        random_state: int = 0,
+    ) -> None:
+        self.schema = schema
+        self.latent_dim = latent_dim
+        self.beta = beta
+        self.hidden_dims = tuple(hidden_dims)
+        self.dropout = dropout
+        self.learning_rate = learning_rate
+        self.val_split = val_split
+        self.stratify = stratify
+        self.random_state = random_state
+
+        self._is_fitted = False
+        self._is_calibrated = False
+        self._classes: np.ndarray | None = None
+        self._normalization_stats: dict[str, dict[str, float | list[str]]] = {}
+        self._temperature_scaler = TemperatureScaler()
+
+    # ------------------------------------------------------------------
+    # Training utilities
+    # ------------------------------------------------------------------
+    def fit(
+        self,
+        X: pd.DataFrame,
+        y: pd.Series | pd.DataFrame | np.ndarray,
+        *,
+        schema: Optional[Schema] = None,
+        epochs: int = 1,
+    ) -> "SUAVE":
+        """Train the minimal SUAVE model.
+
+        Parameters
+        ----------
+        X:
+            Training features with shape ``(n_samples, n_features)``.
+        y:
+            Training targets with shape ``(n_samples,)``.
+        schema:
+            Optional schema overriding the instance-level schema.
+        epochs:
+            Number of placeholder epochs to simulate. Each epoch logs a short
+            message and sleeps for a few milliseconds.
+
+        Returns
+        -------
+        SUAVE
+            The fitted model (``self``) for fluent-style chaining.
+
+        Examples
+        --------
+        >>> model = SUAVE(schema=schema)
+        >>> model.fit(X, y, epochs=2)
+        SUAVE(...)
+        """
+
+        if schema is not None:
+            self.schema = schema
+        if self.schema is None:
+            raise ValueError("A schema must be provided to fit the model")
+
+        LOGGER.info("Starting fit: n_samples=%s, n_features=%s", len(X), X.shape[1])
+        X_train, X_val, y_train, y_val = data_utils.split_train_val(
+            X, y, val_split=self.val_split, stratify=self.stratify
+        )
+        LOGGER.info("Train/val split: %s/%s", len(X_train), len(X_val))
+
+        missing_mask = data_utils.build_missing_mask(X_train)
+        LOGGER.debug(
+            "Missing mask summary: %s missing values", int(missing_mask.sum().sum())
+        )
+
+        X_train, stats = data_utils.standardize(X_train, self.schema)
+        self._normalization_stats = stats
+        _ = data_utils.standardize(X_val, self.schema)
+
+        y_train_array = np.asarray(y_train)
+        self._classes = np.unique(y_train_array)
+        if self._classes.size == 0:
+            raise ValueError("Training targets must contain at least one class")
+
+        for epoch in range(epochs):
+            LOGGER.info("Epoch %s/%s - placeholder training step", epoch + 1, epochs)
+            time.sleep(0.01)
+
+        self._is_fitted = True
+        LOGGER.info("Fit complete")
+        return self
+
+    # ------------------------------------------------------------------
+    # Prediction utilities
+    # ------------------------------------------------------------------
+    def predict_proba(self, X: pd.DataFrame) -> np.ndarray:
+        """Return placeholder class probabilities.
+
+        Parameters
+        ----------
+        X:
+            Input features with shape ``(n_samples, n_features)``.
+
+        Returns
+        -------
+        numpy.ndarray
+            Array of shape ``(n_samples, n_classes)`` containing uniform
+            probabilities across the observed classes.
+
+        Examples
+        --------
+        >>> proba = model.predict_proba(X)
+        >>> proba.sum(axis=1)
+        array([1., 1.])
+        """
+
+        if not self._is_fitted or self._classes is None:
+            raise RuntimeError("Model must be fitted before calling predict_proba")
+        n_samples = len(X)
+        n_classes = len(self._classes)
+        probabilities = np.full((n_samples, n_classes), 1.0 / n_classes)
+        if self._is_calibrated:
+            logits = np.log(probabilities + 1e-8)
+            logits = self._temperature_scaler(logits)
+            probabilities = np.exp(logits)
+            probabilities /= probabilities.sum(axis=1, keepdims=True)
+        return probabilities
+
+    def predict(self, X: pd.DataFrame) -> np.ndarray:
+        """Return the most likely class for each sample."""
+
+        probabilities = self.predict_proba(X)
+        indices = probabilities.argmax(axis=1)
+        return self._classes[indices]
+
+    # ------------------------------------------------------------------
+    # Calibration utilities
+    # ------------------------------------------------------------------
+    def calibrate(self, X: pd.DataFrame, y: pd.Series | np.ndarray) -> "SUAVE":
+        """Apply temperature scaling using placeholder logits."""
+
+        if not self._is_fitted:
+            raise RuntimeError("Fit must be called before calibrate")
+        if len(X) != len(y):
+            raise ValueError("X and y must have matching first dimensions")
+        self._is_calibrated = True
+        self._temperature_scaler = TemperatureScaler(temperature=1.0)
+        return self
+
+    # ------------------------------------------------------------------
+    # Latent utilities and sampling
+    # ------------------------------------------------------------------
+    def encode(self, X: pd.DataFrame) -> np.ndarray:
+        """Return zero latent representations matching ``latent_dim``."""
+
+        if not self._is_fitted:
+            raise RuntimeError("Model must be fitted before encoding data")
+        return np.zeros((len(X), self.latent_dim))
+
+    def sample(
+        self, n_samples: int, conditional: bool = False, y: Optional[np.ndarray] = None
+    ) -> pd.DataFrame:
+        """Generate placeholder samples using :mod:`suave.sampling`."""
+
+        if not self._is_fitted:
+            raise RuntimeError("Model must be fitted before sampling")
+        n_features = len(self.schema.feature_names) if self.schema else 0
+        return sampling_stub(n_samples, n_features, conditional=conditional, y=y)
+
+    # ------------------------------------------------------------------
+    # Persistence helpers
+    # ------------------------------------------------------------------
+    def save(self, path: str | Path) -> Path:
+        """Serialise minimal model state to ``path``."""
+
+        if not self._is_fitted:
+            raise RuntimeError("Model must be fitted before saving")
+        path = Path(path)
+        state = {
+            "schema": self.schema.to_dict() if self.schema else None,
+            "classes": self._classes.tolist() if self._classes is not None else None,
+            "normalization": self._normalization_stats,
+        }
+        path.write_text(json.dumps(state))
+        return path
+
+    @classmethod
+    def load(cls, path: str | Path) -> "SUAVE":
+        """Load a model saved with :meth:`save`."""
+
+        data = json.loads(Path(path).read_text())
+        schema_dict = data.get("schema") or {}
+        schema = Schema(schema_dict) if schema_dict else None
+        model = cls(schema=schema)
+        classes = data.get("classes")
+        if classes is not None:
+            model._classes = np.array(classes)
+            model._is_fitted = True
+        model._normalization_stats = data.get("normalization", {})
+        return model
+
+    # ------------------------------------------------------------------
+    # Representation helpers
+    # ------------------------------------------------------------------
+    def __repr__(self) -> str:  # pragma: no cover - debugging helper
+        return (
+            "SUAVE(latent_dim={latent_dim}, beta={beta}, hidden_dims={hidden_dims}, "
+            "dropout={dropout}, learning_rate={learning_rate})"
+        ).format(
+            latent_dim=self.latent_dim,
+            beta=self.beta,
+            hidden_dims=self.hidden_dims,
+            dropout=self.dropout,
+            learning_rate=self.learning_rate,
+        )

--- a/suave/modules/calibrate.py
+++ b/suave/modules/calibrate.py
@@ -1,0 +1,18 @@
+"""Calibration utilities for SUAVE."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import numpy as np
+
+
+@dataclass
+class TemperatureScaler:
+    """Simple temperature scaling stub that rescales logits."""
+
+    temperature: float = 1.0
+
+    def __call__(self, logits: np.ndarray) -> np.ndarray:
+        if self.temperature <= 0:
+            raise ValueError("temperature must be positive")
+        return logits / self.temperature

--- a/suave/modules/decoder.py
+++ b/suave/modules/decoder.py
@@ -1,0 +1,16 @@
+"""Placeholder decoder module for the minimal SUAVE package."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Sequence
+
+
+@dataclass
+class Decoder:
+    """Minimal configuration holder for the generative decoder."""
+
+    output_dims: Sequence[int]
+
+    def __call__(self, latents):  # pragma: no cover - placeholder behaviour
+        return latents

--- a/suave/modules/distributions.py
+++ b/suave/modules/distributions.py
@@ -1,0 +1,16 @@
+"""Distribution helpers used by the future VAE implementation."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass
+class NormalDistribution:
+    """Trivial normal distribution stub storing mean and scale."""
+
+    mean: float
+    scale: float
+
+    def sample(self):  # pragma: no cover - placeholder behaviour
+        return self.mean

--- a/suave/modules/encoder.py
+++ b/suave/modules/encoder.py
@@ -1,0 +1,24 @@
+"""Placeholder encoder module for the minimal SUAVE package."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Sequence
+
+
+@dataclass
+class Encoder:
+    """Lightweight placeholder for the hierarchical VAE encoder.
+
+    Parameters
+    ----------
+    hidden_dims:
+        Sequence describing the hidden layer sizes.  The class does not
+        perform any computation yet; it merely stores configuration so the
+        training pipeline can be wired in subsequent iterations.
+    """
+
+    hidden_dims: Sequence[int]
+
+    def __call__(self, inputs):  # pragma: no cover - placeholder behaviour
+        return inputs

--- a/suave/modules/heads.py
+++ b/suave/modules/heads.py
@@ -1,0 +1,15 @@
+"""Classification heads for the minimal SUAVE placeholder implementation."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass
+class ClassificationHead:
+    """Placeholder classification head returning zero logits."""
+
+    n_classes: int
+
+    def __call__(self, latents):  # pragma: no cover - placeholder behaviour
+        return [0.0] * self.n_classes

--- a/suave/modules/losses.py
+++ b/suave/modules/losses.py
@@ -1,0 +1,12 @@
+"""Loss helpers for the placeholder implementation."""
+
+from __future__ import annotations
+
+
+def elbo_placeholder(*_, **__):  # pragma: no cover - placeholder behaviour
+    """Return a zero ELBO value.
+
+    Parameters are ignored for the minimal package skeleton.
+    """
+
+    return 0.0

--- a/suave/plots.py
+++ b/suave/plots.py
@@ -1,0 +1,31 @@
+"""Plotting helpers for SUAVE."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable
+
+import matplotlib.pyplot as plt
+
+
+def plot_reliability_curve(
+    probabilities: Iterable[float],
+    targets: Iterable[int],
+    output_path: str | Path | None = None,
+) -> Path | None:
+    """Create an empty reliability curve as a placeholder."""
+
+    fig, ax = plt.subplots()
+    ax.set_title("Reliability Curve (placeholder)")
+    ax.set_xlabel("Predicted probability")
+    ax.set_ylabel("Observed frequency")
+    ax.plot([0, 1], [0, 1], linestyle="--", color="tab:blue")
+
+    if output_path is None:
+        plt.close(fig)
+        return None
+
+    output_path = Path(output_path)
+    fig.savefig(output_path)
+    plt.close(fig)
+    return output_path

--- a/suave/sampling.py
+++ b/suave/sampling.py
@@ -1,0 +1,22 @@
+"""Sampling utilities for SUAVE."""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+
+def sample(
+    n_samples: int,
+    n_features: int,
+    conditional: bool = False,
+    y: np.ndarray | None = None,
+) -> pd.DataFrame:
+    """Return a dataframe of zeros as a placeholder sample."""
+
+    data = np.zeros((n_samples, n_features))
+    columns = [f"feature_{idx}" for idx in range(n_features)]
+    samples = pd.DataFrame(data, columns=columns)
+    if conditional and y is not None:
+        samples["condition"] = y
+    return samples

--- a/suave/types.py
+++ b/suave/types.py
@@ -1,0 +1,146 @@
+"""Type definitions and helpers for the SUAVE package."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Iterable, Mapping, MutableMapping, Optional
+
+
+@dataclass(frozen=True)
+class ColumnSpec:
+    """Specification for a single column in the :class:`Schema`.
+
+    Parameters
+    ----------
+    type:
+        Logical feature type. Only ``"real"`` and ``"cat"`` are currently
+        supported in the minimal implementation.
+    n_classes:
+        Number of distinct categories for categorical features. It must be
+        provided when ``type`` is ``"cat"``.
+    """
+
+    type: str
+    n_classes: Optional[int] = None
+
+
+class Schema:
+    """Container describing the tabular data layout expected by :class:`SUAVE`.
+
+    The schema is intentionally lightweight: users provide a mapping from
+    column name to a :class:`ColumnSpec`.  Automatic inference is outside the
+    scope of this first iteration, which keeps the public API explicit and
+    predictable.
+
+    Parameters
+    ----------
+    columns:
+        Mapping from column names to ``dict`` (or :class:`ColumnSpec`) objects
+        containing the ``type`` key and, for categorical features, the
+        ``n_classes`` key.
+
+    Examples
+    --------
+    >>> from suave.types import Schema
+    >>> schema = Schema(
+    ...     {
+    ...         "age": {"type": "real"},
+    ...         "gender": {"type": "cat", "n_classes": 2},
+    ...     }
+    ... )
+    >>> schema.feature_names
+    ['age', 'gender']
+    >>> schema.categorical_features
+    ['gender']
+    """
+
+    _SUPPORTED_TYPES = {"real", "cat"}
+
+    def __init__(self, columns: Mapping[str, Mapping[str, object]]):
+        self._columns: Dict[str, ColumnSpec] = {}
+        for name, raw_spec in columns.items():
+            spec_dict = dict(raw_spec)
+            column_type = spec_dict.get("type")
+            if column_type not in self._SUPPORTED_TYPES:
+                raise ValueError(
+                    f"Unsupported column type '{column_type}' for '{name}'. "
+                    "Supported types: real, cat."
+                )
+            n_classes = spec_dict.get("n_classes")
+            if column_type == "cat" and n_classes is None:
+                raise ValueError(
+                    f"Column '{name}' is categorical but missing 'n_classes'."
+                )
+            if column_type == "real" and n_classes is not None:
+                raise ValueError(
+                    f"Column '{name}' is real-valued and should not provide 'n_classes'."
+                )
+            self._columns[name] = ColumnSpec(type=column_type, n_classes=n_classes)
+
+    # ------------------------------------------------------------------
+    # Convenience properties
+    # ------------------------------------------------------------------
+    @property
+    def feature_names(self) -> Iterable[str]:
+        """Return an iterable with the schema's feature names."""
+
+        return tuple(self._columns.keys())
+
+    @property
+    def real_features(self) -> Iterable[str]:
+        """Names of columns declared as ``"real"``."""
+
+        return tuple(
+            name for name, spec in self._columns.items() if spec.type == "real"
+        )
+
+    @property
+    def categorical_features(self) -> Iterable[str]:
+        """Names of columns declared as ``"cat"``."""
+
+        return tuple(name for name, spec in self._columns.items() if spec.type == "cat")
+
+    # ------------------------------------------------------------------
+    # Mapping protocol helpers
+    # ------------------------------------------------------------------
+    def to_dict(self) -> Dict[str, MutableMapping[str, object]]:
+        """Return a JSON-serialisable representation of the schema."""
+
+        return {
+            name: {
+                "type": spec.type,
+                **({"n_classes": spec.n_classes} if spec.n_classes else {}),
+            }
+            for name, spec in self._columns.items()
+        }
+
+    def __contains__(self, item: str) -> bool:  # pragma: no cover - trivial
+        return item in self._columns
+
+    def __getitem__(self, item: str) -> ColumnSpec:  # pragma: no cover - trivial
+        return self._columns[item]
+
+    def __len__(self) -> int:  # pragma: no cover - trivial
+        return len(self._columns)
+
+    def __iter__(self):  # pragma: no cover - trivial
+        return iter(self._columns)
+
+    # ------------------------------------------------------------------
+    # Mutating operations
+    # ------------------------------------------------------------------
+    def update(self, other: Mapping[str, Mapping[str, object]]) -> None:
+        """Update the schema with additional column specifications."""
+
+        for name, spec in other.items():
+            self._columns[name] = Schema({name: spec})[name]
+
+    # ------------------------------------------------------------------
+    # Utility helpers
+    # ------------------------------------------------------------------
+    def require_columns(self, columns: Iterable[str]) -> None:
+        """Validate that all ``columns`` are present in the schema."""
+
+        missing = [column for column in columns if column not in self._columns]
+        if missing:
+            raise KeyError(f"Columns {missing} missing from schema")

--- a/tests/test_minimal.py
+++ b/tests/test_minimal.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import pandas as pd
+import pytest
+
+from suave import SUAVE, Schema
+
+
+def make_dataset() -> tuple[pd.DataFrame, pd.Series, Schema]:
+    X = pd.DataFrame(
+        {
+            "age": [65, 72, 58, 61, 70],
+            "sofa_score": [5, 7, 4, 6, 8],
+            "gender": [0, 1, 1, 0, 0],
+        }
+    )
+    y = pd.Series([0, 1, 0, 1, 1], name="outcome")
+    schema = Schema(
+        {
+            "age": {"type": "real"},
+            "sofa_score": {"type": "real"},
+            "gender": {"type": "cat", "n_classes": 2},
+        }
+    )
+    return X, y, schema
+
+
+def test_package_importable():
+    import suave  # noqa: F401
+
+
+@pytest.mark.parametrize("epochs", [1])
+def test_fit_logs(caplog, epochs):
+    caplog.set_level("INFO")
+    X, y, schema = make_dataset()
+    model = SUAVE(schema=schema)
+    model.fit(X, y, epochs=epochs)
+    assert any("Epoch" in record.message for record in caplog.records)
+
+
+def test_predict_proba_shape():
+    X, y, schema = make_dataset()
+    model = SUAVE(schema=schema)
+    model.fit(X, y)
+    probabilities = model.predict_proba(X)
+    assert probabilities.shape == (len(X), 2)


### PR DESCRIPTION
## Summary
- add the `suave` package skeleton with schema utilities, data helpers, and a placeholder `SUAVE` model API
- include stubbed modules, evaluation, sampling, and plotting helpers to satisfy the minimal architecture
- provide an end-to-end example script and pytest coverage for import, fitting logs, and probability shapes

## Testing
- `pytest -q`
- `black .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68cb122811c48320833b570bfdf7b682