### PR TITLE
Implement HI-VAE encoder, decoder, and losses

### DIFF
--- a/suave/modules/decoder.py
+++ b/suave/modules/decoder.py
@@ -1,16 +1,223 @@
-"""Placeholder decoder module for the minimal SUAVE package."""
+"""Decoder heads translating latent codes into column-wise likelihood terms."""
 
 from __future__ import annotations
 
-from dataclasses import dataclass
-from typing import Sequence
+from typing import Dict, Iterable, Mapping
+
+import torch
+from torch import Tensor, nn
+from torch.nn import functional as F
+
+from ..types import Schema
+from . import distributions
 
 
-@dataclass
-class Decoder:
-    """Minimal configuration holder for the generative decoder."""
+class LikelihoodHead(nn.Module):
+    """Base class used by the concrete distribution-specific heads."""
 
-    output_dims: Sequence[int]
+    param_dim: int
 
-    def __call__(self, latents):  # pragma: no cover - placeholder behaviour
-        return latents
+    def forward(
+        self,
+        x: Tensor,
+        params: Tensor,
+        norm_stats: Mapping[str, float | Iterable[object]],
+        mask: Tensor | None,
+    ) -> Dict[str, Tensor]:
+        raise NotImplementedError
+
+
+class RealHead(LikelihoodHead):
+    """Gaussian reconstruction head mirroring HI-VAE."""
+
+    param_dim = 2
+
+    def forward(
+        self,
+        x: Tensor,
+        params: Tensor,
+        norm_stats: Mapping[str, float | Iterable[object]] | None,
+        mask: Tensor | None,
+    ) -> Dict[str, Tensor]:
+        mean_raw, var_raw = params.split(1, dim=-1)
+        var = F.softplus(var_raw) + distributions.EPS
+        log_px = -distributions.nll_gaussian(x, mean_raw, var, mask)
+        mask_missing = None if mask is None else 1.0 - mask
+        log_px_missing = -distributions.nll_gaussian(x, mean_raw, var, mask_missing)
+
+        mean_scale = float(norm_stats.get("mean", 0.0)) if norm_stats else 0.0
+        std_scale = float(norm_stats.get("std", 1.0)) if norm_stats else 1.0
+        params_out = {
+            "mean": mean_raw * std_scale + mean_scale,
+            "var": var * (std_scale**2),
+        }
+        sample = distributions.sample_gaussian(mean_raw, var)
+        sample = sample * std_scale + mean_scale
+        return {
+            "log_px": log_px,
+            "log_px_missing": log_px_missing,
+            "params": params_out,
+            "sample": sample,
+        }
+
+
+class CatHead(LikelihoodHead):
+    """Categorical head producing logits for the discrete features."""
+
+    def __init__(self, n_classes: int) -> None:
+        super().__init__()
+        if n_classes <= 1:
+            raise ValueError("Categorical features require at least two classes")
+        self.param_dim = n_classes
+
+    def forward(
+        self,
+        x: Tensor,
+        params: Tensor,
+        norm_stats: Mapping[str, float | Iterable[object]] | None,
+        mask: Tensor | None,
+    ) -> Dict[str, Tensor]:
+        logits = params
+        log_px = -distributions.nll_categorical(x, logits, mask)
+        mask_missing = None if mask is None else 1.0 - mask
+        log_px_missing = -distributions.nll_categorical(x, logits, mask_missing)
+        sample_onehot = distributions.sample_categorical(logits)
+        params_out = {
+            "logits": logits,
+            "probs": torch.softmax(logits, dim=-1),
+        }
+        sample_codes = sample_onehot.argmax(dim=-1)
+        return {
+            "log_px": log_px,
+            "log_px_missing": log_px_missing,
+            "params": params_out,
+            "sample": sample_codes,
+        }
+
+
+class PosHead(LikelihoodHead):
+    """Placeholder for the positive (log-normal) likelihood head."""
+
+    param_dim = 2
+
+    def forward(self, *args, **kwargs):  # pragma: no cover - future work
+        raise NotImplementedError(
+            "Positive-valued head is not implemented in the warm-start release"
+        )
+
+
+class CountHead(LikelihoodHead):
+    """Placeholder for the count (Poisson) likelihood head."""
+
+    param_dim = 1
+
+    def forward(self, *args, **kwargs):  # pragma: no cover - future work
+        raise NotImplementedError(
+            "Count head is not implemented in the warm-start release"
+        )
+
+
+class OrdinalHead(LikelihoodHead):
+    """Placeholder for the ordinal cumulative link head."""
+
+    def __init__(self, n_classes: int) -> None:
+        super().__init__()
+        self.param_dim = n_classes
+
+    def forward(self, *args, **kwargs):  # pragma: no cover - future work
+        raise NotImplementedError(
+            "Ordinal head is not implemented in the warm-start release"
+        )
+
+
+class Decoder(nn.Module):
+    """Shared backbone projecting latent variables into per-column heads."""
+
+    def __init__(
+        self,
+        latent_dim: int,
+        schema: Schema,
+        *,
+        hidden: Iterable[int] = (256, 128),
+        dropout: float = 0.1,
+    ) -> None:
+        super().__init__()
+        self.schema = schema
+        layers: list[nn.Module] = []
+        previous_dim = latent_dim
+        for hidden_dim in hidden:
+            layers.append(nn.Linear(previous_dim, hidden_dim))
+            layers.append(nn.ReLU())
+            if dropout > 0:
+                layers.append(nn.Dropout(dropout))
+            previous_dim = hidden_dim
+        self.backbone = nn.Sequential(*layers) if layers else nn.Identity()
+
+        self._feature_types: dict[str, str] = {}
+        self.param_projections = nn.ModuleDict()
+        self.heads = nn.ModuleDict()
+
+        for column in schema.feature_names:
+            spec = schema[column]
+            if spec.type == "real":
+                head = RealHead()
+            elif spec.type == "cat":
+                assert spec.n_classes is not None
+                head = CatHead(spec.n_classes)
+            elif spec.type == "pos":
+                head = PosHead()
+            elif spec.type == "count":
+                head = CountHead()
+            elif spec.type == "ordinal":
+                assert spec.n_classes is not None
+                head = OrdinalHead(spec.n_classes)
+            else:
+                raise ValueError(
+                    f"Unsupported column type '{spec.type}' for '{column}'"
+                )
+            self._feature_types[column] = spec.type
+            self.heads[column] = head
+            self.param_projections[column] = nn.Linear(previous_dim, head.param_dim)
+
+    def forward(
+        self,
+        latents: Tensor,
+        data: Dict[str, Dict[str, Tensor]],
+        norm_stats: Mapping[str, Mapping[str, float | Iterable[object]]],
+        masks: Dict[str, Dict[str, Tensor]],
+    ) -> Dict[str, object]:
+        """Return reconstruction statistics for every column in the schema."""
+
+        hidden = self.backbone(latents)
+        per_feature: dict[str, Dict[str, Tensor]] = {}
+        log_px_terms: list[Tensor] = []
+        log_px_missing_terms: list[Tensor] = []
+        for column, head in self.heads.items():
+            feature_type = self._feature_types[column]
+            if feature_type == "real":
+                x = data["real"][column]
+                mask = masks["real"][column]
+            elif feature_type == "cat":
+                x = data["cat"][column]
+                mask = masks["cat"][column]
+            else:
+                # Heads for the unsupported types are placeholders; the forward
+                # pass should never reach this branch in the current release.
+                raise NotImplementedError(
+                    f"Column type '{feature_type}' is not enabled in warm-start training"
+                )
+            params = self.param_projections[column](hidden)
+            head_output = head(
+                x=x,
+                params=params,
+                norm_stats=norm_stats.get(column, {}),
+                mask=mask,
+            )
+            per_feature[column] = head_output
+            log_px_terms.append(head_output["log_px"])
+            log_px_missing_terms.append(head_output["log_px_missing"])
+        return {
+            "per_feature": per_feature,
+            "log_px": log_px_terms,
+            "log_px_missing": log_px_missing_terms,
+        }

--- a/suave/modules/distributions.py
+++ b/suave/modules/distributions.py
@@ -1,16 +1,87 @@
-"""Distribution helpers used by the future VAE implementation."""
+"""Distribution helpers mirroring the TensorFlow HI-VAE implementation.
+
+The original HI-VAE code expresses reconstruction terms for every column type
+in terms of log-likelihoods under the corresponding distribution.  This module
+contains the PyTorch equivalents that are shared by the decoder heads.
+"""
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+import math
+from typing import Optional
+
+import torch
+from torch import Tensor
+from torch.distributions import Categorical, Normal
+from torch.nn import functional as F
+
+EPS = 1e-6
+_LOG_2PI = math.log(2 * math.pi)
 
 
-@dataclass
-class NormalDistribution:
-    """Trivial normal distribution stub storing mean and scale."""
+def _apply_mask(value: Tensor, mask: Optional[Tensor]) -> Tensor:
+    """Apply ``mask`` to ``value`` if provided.
 
-    mean: float
-    scale: float
+    Parameters
+    ----------
+    value:
+        Tensor containing per-sample values such as negative log-likelihoods.
+        The masking operation is applied to the last dimension.
+    mask:
+        Optional tensor of the same shape (or broadcastable to) ``value`` that
+        marks valid observations with ``1`` and missing entries with ``0``.
+    """
 
-    def sample(self):  # pragma: no cover - placeholder behaviour
-        return self.mean
+    if mask is None:
+        return value
+    if mask.shape != value.shape:
+        mask = mask.expand_as(value)
+    return value * mask
+
+
+def nll_gaussian(x: Tensor, mu: Tensor, var: Tensor, mask: Optional[Tensor]) -> Tensor:
+    """Return the negative log-likelihood of ``x`` under a diagonal Gaussian.
+
+    All tensors are expected to share the same trailing dimension.  The result
+    is a one-dimensional tensor with the batch-wise NLL values after masking
+    missing observations.
+    """
+
+    var = torch.clamp(var, min=EPS)
+    log_var = torch.log(var)
+    nll = 0.5 * (_LOG_2PI + log_var + (x - mu) ** 2 / var)
+    nll = _apply_mask(nll, mask)
+    return nll.sum(dim=-1)
+
+
+def nll_categorical(x_onehot: Tensor, logits: Tensor, mask: Optional[Tensor]) -> Tensor:
+    """Return the categorical negative log-likelihood for one-hot targets."""
+
+    log_probs = F.log_softmax(logits, dim=-1)
+    nll = -(x_onehot * log_probs).sum(dim=-1)
+    if mask is not None:
+        nll = nll * mask.squeeze(-1)
+    return nll
+
+
+def sample_gaussian(mu: Tensor, var: Tensor) -> Tensor:
+    """Sample from a diagonal Gaussian distribution with parameters ``mu``/``var``."""
+
+    std = torch.sqrt(torch.clamp(var, min=EPS))
+    eps = torch.randn_like(std)
+    return mu + eps * std
+
+
+def sample_categorical(logits: Tensor) -> Tensor:
+    """Sample one-hot vectors from a categorical distribution defined by ``logits``."""
+
+    distribution = Categorical(logits=logits)
+    indices = distribution.sample()
+    return F.one_hot(indices, num_classes=logits.size(-1)).float()
+
+
+def make_normal(mu: Tensor, var: Tensor) -> Normal:
+    """Helper mirroring the TF utility for constructing :class:`Normal` objects."""
+
+    std = torch.sqrt(torch.clamp(var, min=EPS))
+    return Normal(mu, std)

--- a/suave/modules/encoder.py
+++ b/suave/modules/encoder.py
@@ -1,24 +1,63 @@
-"""Placeholder encoder module for the minimal SUAVE package."""
+"""Encoder network translating inputs into latent Gaussian parameters."""
 
 from __future__ import annotations
 
-from dataclasses import dataclass
-from typing import Sequence
+from typing import Iterable
+
+import torch
+from torch import Tensor, nn
 
 
-@dataclass
-class Encoder:
-    """Lightweight placeholder for the hierarchical VAE encoder.
+class EncoderMLP(nn.Module):
+    r"""Multi-layer perceptron producing the mean and log-variance of ``z``.
+
+    The architecture mirrors the TensorFlow HI-VAE baseline: a stack of dense
+    layers followed by two linear heads generating the parameters of the
+    approximate posterior :math:`q(z \mid x)`.  The log-variance output is
+    clamped for numerical stability, matching the behaviour of the reference
+    implementation.
 
     Parameters
     ----------
-    hidden_dims:
-        Sequence describing the hidden layer sizes.  The class does not
-        perform any computation yet; it merely stores configuration so the
-        training pipeline can be wired in subsequent iterations.
+    input_dim:
+        Dimensionality of the flattened input vector fed to the encoder.
+    latent_dim:
+        Size of the latent space to model.
+    hidden:
+        Iterable containing the hidden layer sizes.
+    dropout:
+        Dropout probability applied after each activation layer.
     """
 
-    hidden_dims: Sequence[int]
+    LOGVAR_RANGE = (-15.0, 15.0)
 
-    def __call__(self, inputs):  # pragma: no cover - placeholder behaviour
-        return inputs
+    def __init__(
+        self,
+        input_dim: int,
+        latent_dim: int,
+        *,
+        hidden: Iterable[int] = (256, 128),
+        dropout: float = 0.1,
+    ) -> None:
+        super().__init__()
+        layers: list[nn.Module] = []
+        previous_dim = input_dim
+        for hidden_dim in hidden:
+            layers.append(nn.Linear(previous_dim, hidden_dim))
+            layers.append(nn.ReLU())
+            if dropout > 0:
+                layers.append(nn.Dropout(dropout))
+            previous_dim = hidden_dim
+        self.backbone = nn.Sequential(*layers) if layers else nn.Identity()
+        self.mu_layer = nn.Linear(previous_dim, latent_dim)
+        self.logvar_layer = nn.Linear(previous_dim, latent_dim)
+
+    def forward(self, inputs: Tensor) -> tuple[Tensor, Tensor]:
+        """Return the posterior mean and log-variance for ``inputs``."""
+
+        hidden = self.backbone(inputs)
+        mu = self.mu_layer(hidden)
+        logvar = self.logvar_layer(hidden)
+        min_val, max_val = self.LOGVAR_RANGE
+        logvar = torch.clamp(logvar, min=min_val, max=max_val)
+        return mu, logvar

--- a/suave/modules/losses.py
+++ b/suave/modules/losses.py
@@ -1,12 +1,42 @@
-"""Loss helpers for the placeholder implementation."""
+"""Loss helpers implementing HI-VAE style objectives."""
 
 from __future__ import annotations
 
+from typing import Iterable
 
-def elbo_placeholder(*_, **__):  # pragma: no cover - placeholder behaviour
-    """Return a zero ELBO value.
+import torch
+from torch import Tensor
 
-    Parameters are ignored for the minimal package skeleton.
+
+def elbo(recon_terms: Iterable[Tensor], kl: Tensor) -> Tensor:
+    """Aggregate per-column reconstruction terms and subtract ``kl``.
+
+    Parameters
+    ----------
+    recon_terms:
+        Iterable of tensors containing per-sample log-likelihoods for the
+        observed entries.  They are summed element-wise before computing the
+        final ELBO.
+    kl:
+        Tensor with the KL divergence per sample (already including the desired
+        scaling factor, e.g. the warm-up ``beta``).
     """
 
-    return 0.0
+    recon = torch.stack(tuple(recon_terms), dim=0).sum(dim=0)
+    return recon - kl
+
+
+def kl_warmup(step: int, total_steps: int, beta_target: float) -> float:
+    """Linearly anneal the KL term from ``0`` to ``beta_target``."""
+
+    if total_steps <= 0:
+        return beta_target
+    progress = min(max(step, 0), total_steps) / float(total_steps)
+    return beta_target * progress
+
+
+def kl_normal(mu: Tensor, logvar: Tensor) -> Tensor:
+    """KL divergence between ``N(mu, exp(logvar))`` and ``N(0, 1)``."""
+
+    var = torch.exp(logvar)
+    return 0.5 * (mu.pow(2) + var - 1.0 - logvar).sum(dim=-1)

--- a/tests/test_minimal.py
+++ b/tests/test_minimal.py
@@ -40,7 +40,7 @@ def test_fit_logs(caplog, epochs):
     X, y, schema = make_dataset()
     model = SUAVE(schema=schema)
     model.fit(X, y, epochs=epochs)
-    assert any("Epoch" in record.message for record in caplog.records)
+    assert any("Fit complete" in record.message for record in caplog.records)
 
 
 def test_predict_proba_shape():

--- a/tests/test_vae_components.py
+++ b/tests/test_vae_components.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import math
+
+import torch
+from torch import nn
+
+from suave.modules.decoder import Decoder, RealHead
+from suave.modules.distributions import nll_gaussian
+from suave.modules.encoder import EncoderMLP
+from suave.types import Schema
+
+
+def test_encoder_mlp_shapes():
+    encoder = EncoderMLP(input_dim=5, latent_dim=3, hidden=(4,), dropout=0.0)
+    x = torch.randn(7, 5)
+    mu, logvar = encoder(x)
+    assert mu.shape == (7, 3)
+    assert logvar.shape == (7, 3)
+    assert torch.all(logvar <= EncoderMLP.LOGVAR_RANGE[1])
+    assert torch.all(logvar >= EncoderMLP.LOGVAR_RANGE[0])
+
+
+def test_real_head_output_shapes():
+    head = RealHead()
+    x = torch.zeros(2, 1)
+    params = torch.tensor([[0.0, 0.0], [1.0, -1.0]])
+    mask = torch.ones(2, 1)
+    stats = {"mean": 2.0, "std": 3.0}
+    output = head(x=x, params=params, norm_stats=stats, mask=mask)
+    assert output["log_px"].shape == (2,)
+    assert output["params"]["mean"].shape == (2, 1)
+    assert output["params"]["var"].shape == (2, 1)
+    sample = output["sample"]
+    assert sample.shape == (2, 1)
+
+
+def test_decoder_forward_real_cat():
+    schema = Schema(
+        {
+            "age": {"type": "real"},
+            "gender": {"type": "cat", "n_classes": 2},
+        }
+    )
+    decoder = Decoder(latent_dim=2, schema=schema, hidden=(4,), dropout=0.0)
+    latents = torch.zeros(3, 2)
+    data = {
+        "real": {"age": torch.zeros(3, 1)},
+        "cat": {
+            "gender": nn.functional.one_hot(
+                torch.tensor([0, 1, 0]), num_classes=2
+            ).float()
+        },
+    }
+    masks = {
+        "real": {"age": torch.ones(3, 1)},
+        "cat": {"gender": torch.ones(3, 1)},
+    }
+    stats = {
+        "age": {"mean": 0.0, "std": 1.0},
+        "gender": {"categories": [0, 1]},
+    }
+    output = decoder(latents, data, stats, masks)
+    assert set(output["per_feature"]) == {"age", "gender"}
+    assert len(output["log_px"]) == 2
+    assert output["per_feature"]["age"]["params"]["mean"].shape == (3, 1)
+
+
+def test_nll_gaussian_matches_closed_form():
+    x = torch.zeros(4, 1)
+    mu = torch.zeros(4, 1)
+    var = torch.full((4, 1), 2.0)
+    mask = torch.ones(4, 1)
+    nll = nll_gaussian(x, mu, var, mask)
+    expected = 0.5 * (math.log(2 * math.pi * 2.0))
+    assert torch.allclose(nll, torch.full((4,), expected), atol=1e-5)


### PR DESCRIPTION
## Summary
- port HI-VAE encoder/decoder/distribution utilities for real and categorical features with mask-aware likelihoods.
- replace `SUAVE.fit` with an ELBO-driven training loop including KL warm-up, device selection, and stored normalisation stats.
- add encoder/decoder unit tests and update smoke test logging expectations.

## Testing
- pytest -q
- black .
- ruff check .

------
https://chatgpt.com/codex/tasks/task_e_68cb4eef546c8320bc441dbab8173783