### PR TITLE
Implement decoder-driven sampling

### DIFF
--- a/suave/modules/decoder.py
+++ b/suave/modules/decoder.py
@@ -17,6 +17,15 @@ class LikelihoodHead(nn.Module):
 
     param_dim: int
 
+    def sample_from_params(
+        self,
+        params: Tensor,
+        norm_stats: Mapping[str, float | Iterable[object]] | None,
+    ) -> Dict[str, Tensor]:
+        """Return samples drawn from the likelihood defined by ``params``."""
+
+        raise NotImplementedError
+
     def forward(
         self,
         x: Tensor,
@@ -60,6 +69,23 @@ class RealHead(LikelihoodHead):
             "sample": sample,
         }
 
+    def sample_from_params(
+        self,
+        params: Tensor,
+        norm_stats: Mapping[str, float | Iterable[object]] | None,
+    ) -> Dict[str, Tensor]:
+        mean_raw, var_raw = params.split(1, dim=-1)
+        var = F.softplus(var_raw) + distributions.EPS
+        mean_scale = float(norm_stats.get("mean", 0.0)) if norm_stats else 0.0
+        std_scale = float(norm_stats.get("std", 1.0)) if norm_stats else 1.0
+        params_out = {
+            "mean": mean_raw * std_scale + mean_scale,
+            "var": var * (std_scale**2),
+        }
+        sample = distributions.sample_gaussian(mean_raw, var)
+        sample = sample * std_scale + mean_scale
+        return {"params": params_out, "sample": sample}
+
 
 class CatHead(LikelihoodHead):
     """Categorical head producing logits for the discrete features."""
@@ -94,6 +120,20 @@ class CatHead(LikelihoodHead):
             "sample": sample_codes,
         }
 
+    def sample_from_params(
+        self,
+        params: Tensor,
+        norm_stats: Mapping[str, float | Iterable[object]] | None,
+    ) -> Dict[str, Tensor]:
+        logits = params
+        sample_onehot = distributions.sample_categorical(logits)
+        params_out = {
+            "logits": logits,
+            "probs": torch.softmax(logits, dim=-1),
+        }
+        sample_codes = sample_onehot.argmax(dim=-1)
+        return {"params": params_out, "sample": sample_codes}
+
 
 class PosHead(LikelihoodHead):
     """Placeholder for the positive (log-normal) likelihood head."""
@@ -101,6 +141,11 @@ class PosHead(LikelihoodHead):
     param_dim = 2
 
     def forward(self, *args, **kwargs):  # pragma: no cover - future work
+        raise NotImplementedError(
+            "Positive-valued head is not implemented in the warm-start release"
+        )
+
+    def sample_from_params(self, *args, **kwargs):  # pragma: no cover - future work
         raise NotImplementedError(
             "Positive-valued head is not implemented in the warm-start release"
         )
@@ -116,6 +161,11 @@ class CountHead(LikelihoodHead):
             "Count head is not implemented in the warm-start release"
         )
 
+    def sample_from_params(self, *args, **kwargs):  # pragma: no cover - future work
+        raise NotImplementedError(
+            "Count head is not implemented in the warm-start release"
+        )
+
 
 class OrdinalHead(LikelihoodHead):
     """Placeholder for the ordinal cumulative link head."""
@@ -125,6 +175,11 @@ class OrdinalHead(LikelihoodHead):
         self.param_dim = n_classes
 
     def forward(self, *args, **kwargs):  # pragma: no cover - future work
+        raise NotImplementedError(
+            "Ordinal head is not implemented in the warm-start release"
+        )
+
+    def sample_from_params(self, *args, **kwargs):  # pragma: no cover - future work
         raise NotImplementedError(
             "Ordinal head is not implemented in the warm-start release"
         )
@@ -221,3 +276,21 @@ class Decoder(nn.Module):
             "log_px": log_px_terms,
             "log_px_missing": log_px_missing_terms,
         }
+
+    def sample(
+        self,
+        latents: Tensor,
+        norm_stats: Mapping[str, Mapping[str, float | Iterable[object]]],
+    ) -> Dict[str, Dict[str, Tensor]]:
+        """Generate samples for every feature given ``latents``."""
+
+        hidden = self.backbone(latents)
+        samples: dict[str, Tensor] = {}
+        params: dict[str, Dict[str, Tensor]] = {}
+        for column, head in self.heads.items():
+            params_tensor = self.param_projections[column](hidden)
+            stats = norm_stats.get(column, {})
+            generated = head.sample_from_params(params_tensor, stats)
+            samples[column] = generated["sample"]
+            params[column] = generated["params"]
+        return {"samples": samples, "params": params}

--- a/suave/sampling.py
+++ b/suave/sampling.py
@@ -1,22 +1,85 @@
-"""Sampling utilities for SUAVE."""
+"""Sampling utilities decoding latent variables into tabular samples."""
 
 from __future__ import annotations
 
+from typing import Mapping, Sequence
+
 import numpy as np
 import pandas as pd
+from torch import Tensor
+
+from .modules.decoder import Decoder
+from .types import Schema
 
 
-def sample(
-    n_samples: int,
-    n_features: int,
-    conditional: bool = False,
-    y: np.ndarray | None = None,
+def _empty_frame(
+    schema: Schema,
+    norm_stats: Mapping[str, Mapping[str, float | Sequence[object]]],
 ) -> pd.DataFrame:
-    """Return a dataframe of zeros as a placeholder sample."""
+    """Return an empty dataframe that preserves schema column types."""
 
-    data = np.zeros((n_samples, n_features))
-    columns = [f"feature_{idx}" for idx in range(n_features)]
-    samples = pd.DataFrame(data, columns=columns)
-    if conditional and y is not None:
-        samples["condition"] = y
-    return samples
+    data: dict[str, pd.Series] = {}
+    for column in schema.feature_names:
+        spec = schema[column]
+        if spec.type == "real":
+            data[column] = pd.Series(dtype=np.float32)
+        elif spec.type == "cat":
+            categories = norm_stats.get(column, {}).get("categories", [])
+            categorical = pd.Categorical([], categories=categories)
+            data[column] = pd.Series(categorical)
+        else:  # pragma: no cover - defensive: unsupported heads disabled upstream
+            data[column] = pd.Series(dtype=np.float32)
+    return pd.DataFrame(data)
+
+
+def decode_from_latents(
+    *,
+    decoder: Decoder,
+    latents: Tensor,
+    schema: Schema,
+    norm_stats: Mapping[str, Mapping[str, float | Sequence[object]]],
+) -> pd.DataFrame:
+    """Decode ``latents`` with ``decoder`` into a pandas dataframe."""
+
+    if latents.ndim != 2:
+        raise ValueError("latents must be a 2D tensor")
+    n_samples = latents.size(0)
+    if n_samples == 0:
+        return _empty_frame(schema, norm_stats)
+
+    decoded = decoder.sample(latents, norm_stats)
+    samples = decoded["samples"]
+
+    columns: dict[str, pd.Series] = {}
+    for column in schema.feature_names:
+        spec = schema[column]
+        column_tensor = samples[column].detach().cpu()
+        if spec.type == "real":
+            values = (
+                column_tensor.reshape(n_samples, -1)
+                .squeeze(-1)
+                .numpy()
+                .astype(np.float32)
+            )
+            columns[column] = pd.Series(values, dtype=np.float32)
+        elif spec.type == "cat":
+            codes = column_tensor.numpy().astype(np.int64)
+            categories = norm_stats.get(column, {}).get("categories", [])
+            if categories:
+                mapped: list[object | None] = []
+                for code in codes.tolist():
+                    if 0 <= code < len(categories):
+                        mapped.append(categories[code])
+                    else:
+                        mapped.append(None)
+                categorical = pd.Categorical(mapped, categories=categories)
+            else:
+                categorical = pd.Categorical(codes.tolist())
+            columns[column] = pd.Series(categorical)
+        else:  # pragma: no cover - unsupported types not enabled yet
+            raise NotImplementedError(
+                f"Sampling for column type '{spec.type}' is not implemented"
+            )
+
+    frame = pd.DataFrame(columns)
+    return frame

--- a/tests/test_minimal.py
+++ b/tests/test_minimal.py
@@ -67,6 +67,28 @@ def test_encode_returns_latent_means():
     assert model._encoder.training == was_training
 
 
+def test_hivae_behaviour_disables_classifier():
+    X, _, schema = make_dataset()
+    model = SUAVE(schema=schema, behaviour="hivae")
+    model.fit(X, epochs=1)
+    latent = model.encode(X)
+    assert latent.shape[0] == len(X)
+    with pytest.raises(RuntimeError):
+        model.predict_proba(X)
+
+
+def test_hivae_behaviour_persists_after_save(tmp_path: Path):
+    X, _, schema = make_dataset()
+    model = SUAVE(schema=schema, behaviour="hivae")
+    model.fit(X, epochs=1)
+    save_path = tmp_path / "model.json"
+    model.save(save_path)
+    loaded = SUAVE.load(save_path)
+    assert loaded.behaviour == "hivae"
+    with pytest.raises(RuntimeError):
+        loaded.predict_proba(X)
+
+
 def test_sample_decodes_latents_to_dataframe():
     X, y, schema = make_dataset()
     model = SUAVE(schema=schema, latent_dim=3, batch_size=2)


### PR DESCRIPTION
## Summary
- add decoder-level sampling helpers and dataframe reconstruction utilities
- extend SUAVE to reuse the encoder during encode() and decode latent draws via the trained decoder
- cover decoder-driven sampling with tests for unconditional and conditional paths

## Testing
- `pytest -q`
- `black .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68cb7a34e5748320a59ab862a5832736