### PR TITLE
Add mixed feature support and decoder heads for HI-VAE modalities

### DIFF
--- a/suave/data.py
+++ b/suave/data.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Dict, Tuple
+from typing import Dict, Iterable, Tuple
 
 import numpy as np
 import pandas as pd
@@ -101,8 +101,13 @@ def standardize(
 ) -> Tuple[pd.DataFrame, Dict[str, Dict[str, float | list[object]]]]:
     """Standardise the dataframe using schema information.
 
-    ``real`` columns are z-scored. ``cat`` columns are cast to categorical
-    dtype; their categories are recorded but left untouched.
+    ``real`` columns are z-scored. ``pos`` columns are log transformed (using
+    ``log1p``) and normalised with mean/standard deviation of the transformed
+    values. ``count`` columns are log transformed (adding a one-offset when the
+    observed minimum is zero). ``cat`` columns are cast to categorical dtype
+    and ``ordinal`` columns are validated to fall inside the configured class
+    range. The function returns the transformed dataframe alongside the
+    metadata required to reconstruct the original values.
 
     Returns
     -------
@@ -126,12 +131,65 @@ def standardize(
         transformed[column] = (values - mean) / max(std, _EPS)
         stats[column] = {"type": "real", "mean": mean, "std": std}
 
+    for column in schema.positive_features:
+        if column not in transformed:
+            continue
+        values = pd.to_numeric(transformed[column], errors="coerce")
+        finite = values[values.notna()]
+        if not finite.empty and (finite < -1.0 + _EPS).any():
+            raise ValueError(
+                f"Column '{column}' of type 'pos' must be >= -1 to apply log1p"
+            )
+        log_values = np.log1p(values)
+        mean = float(np.nanmean(log_values)) if log_values.size else 0.0
+        std = float(np.nanstd(log_values, ddof=0)) if log_values.size else 1.0
+        if not np.isfinite(std) or std < _EPS:
+            std = 1.0
+        normalised = (log_values - mean) / max(std, _EPS)
+        transformed[column] = normalised
+        stats[column] = {"type": "pos", "mean_log": mean, "std_log": std}
+
+    for column in schema.count_features:
+        if column not in transformed:
+            continue
+        values = pd.to_numeric(transformed[column], errors="coerce")
+        finite = values[values.notna()]
+        if not finite.empty and (finite < 0).any():
+            raise ValueError(f"Column '{column}' of type 'count' must be non-negative")
+        offset = 1.0 if (not finite.empty and (finite <= 0).any()) else 0.0
+        shifted = values + offset
+        log_values = np.log(shifted)
+        transformed[column] = log_values
+        stats[column] = {"type": "count", "offset": offset}
+
     for column in schema.categorical_features:
         if column not in transformed:
             continue
         transformed[column] = transformed[column].astype("category")
         categories = transformed[column].cat.categories.tolist()
         stats[column] = {"type": "cat", "categories": categories}
+
+    for column in schema.ordinal_features:
+        if column not in transformed:
+            continue
+        spec = schema[column]
+        n_classes = int(spec.n_classes or 0)
+        series = pd.to_numeric(transformed[column], errors="coerce")
+        if not series.dropna().between(0, n_classes - 1).all():
+            raise ValueError(
+                f"Column '{column}' must contain values in [0, {n_classes - 1}]"
+            )
+        categories: Iterable[object]
+        if isinstance(transformed[column].dtype, pd.CategoricalDtype):
+            categories = transformed[column].cat.categories.tolist()
+        else:
+            categories = list(range(n_classes))
+        transformed[column] = series
+        stats[column] = {
+            "type": "ordinal",
+            "n_classes": n_classes,
+            "categories": list(categories),
+        }
 
     return transformed, stats
 
@@ -152,4 +210,20 @@ def inverse_standardize(
         elif meta["type"] == "cat":
             categories = meta.get("categories", [])
             restored[column] = pd.Categorical(restored[column], categories=categories)
+        elif meta["type"] == "pos":
+            mean_log = float(meta.get("mean_log", 0.0))
+            std_log = float(meta.get("std_log", 1.0))
+            values = pd.to_numeric(restored[column], errors="coerce")
+            log_values = values * std_log + mean_log
+            restored[column] = np.expm1(log_values)
+        elif meta["type"] == "count":
+            offset = float(meta.get("offset", 0.0))
+            values = pd.to_numeric(restored[column], errors="coerce")
+            restored[column] = np.exp(values) - offset
+        elif meta["type"] == "ordinal":
+            categories = meta.get("categories")
+            if categories is not None:
+                restored[column] = pd.Categorical(
+                    restored[column], categories=categories, ordered=True
+                )
     return restored

--- a/suave/model.py
+++ b/suave/model.py
@@ -119,7 +119,13 @@ class SUAVE:
         self._encoder: EncoderMLP | None = None
         self._decoder: Decoder | None = None
         self._classifier: ClassificationHead | None = None
-        self._feature_layout: dict[str, dict[str, int]] = {"real": {}, "cat": {}}
+        self._feature_layout: dict[str, dict[str, int]] = {
+            "real": {},
+            "pos": {},
+            "count": {},
+            "cat": {},
+            "ordinal": {},
+        }
         self._class_to_index: dict[object, int] | None = None
         self._cached_logits: np.ndarray | None = None
         self._cached_probabilities: np.ndarray | None = None
@@ -173,18 +179,6 @@ class SUAVE:
         if self.schema is None:
             raise ValueError("A schema must be provided to fit the model")
         self.schema.require_columns(X.columns)
-        unsupported = [
-            column
-            for column in self.schema.feature_names
-            if self.schema[column].type not in {"real", "cat"}
-        ]
-        if unsupported:
-            joined = ", ".join(unsupported)
-            raise ValueError(
-                f"Columns {joined} use unsupported feature types. "
-                "Enable positive/count/ordinal heads in a future release."
-            )
-
         if self.behaviour == "suave" and y is None:
             raise ValueError("Targets must be provided when behaviour='suave'")
 
@@ -372,11 +366,17 @@ class SUAVE:
         value_parts: list[Tensor] = []
         mask_parts: list[Tensor] = []
         real_data: Dict[str, Tensor] = {}
+        pos_data: Dict[str, Tensor] = {}
+        count_data: Dict[str, Tensor] = {}
         cat_data: Dict[str, Tensor] = {}
+        ordinal_data: Dict[str, Tensor] = {}
         real_masks: Dict[str, Tensor] = {}
+        pos_masks: Dict[str, Tensor] = {}
+        count_masks: Dict[str, Tensor] = {}
         cat_masks: Dict[str, Tensor] = {}
+        ordinal_masks: Dict[str, Tensor] = {}
 
-        feature_layout = {"real": {}, "cat": {}}
+        feature_layout = {"real": {}, "pos": {}, "count": {}, "cat": {}, "ordinal": {}}
 
         for column in self.schema.real_features:
             values = pd.to_numeric(X[column], errors="coerce").to_numpy(
@@ -392,6 +392,36 @@ class SUAVE:
             value_parts.append(tensor)
             mask_parts.append(mask_tensor)
             feature_layout["real"][column] = 1
+
+        for column in self.schema.positive_features:
+            values = pd.to_numeric(X[column], errors="coerce").to_numpy(
+                dtype=np.float32
+            )
+            values = np.nan_to_num(values, nan=0.0).reshape(n_samples, 1)
+            tensor = torch.from_numpy(values)
+            missing = mask[column].to_numpy().astype(bool)
+            observed = (~missing).astype(np.float32).reshape(n_samples, 1)
+            mask_tensor = torch.from_numpy(observed)
+            pos_data[column] = tensor
+            pos_masks[column] = mask_tensor
+            value_parts.append(tensor)
+            mask_parts.append(mask_tensor)
+            feature_layout["pos"][column] = 1
+
+        for column in self.schema.count_features:
+            values = pd.to_numeric(X[column], errors="coerce").to_numpy(
+                dtype=np.float32
+            )
+            values = np.nan_to_num(values, nan=0.0).reshape(n_samples, 1)
+            tensor = torch.from_numpy(values)
+            missing = mask[column].to_numpy().astype(bool)
+            observed = (~missing).astype(np.float32).reshape(n_samples, 1)
+            mask_tensor = torch.from_numpy(observed)
+            count_data[column] = tensor
+            count_masks[column] = mask_tensor
+            value_parts.append(tensor)
+            mask_parts.append(mask_tensor)
+            feature_layout["count"][column] = 1
 
         for column in self.schema.categorical_features:
             series = X[column]
@@ -416,12 +446,45 @@ class SUAVE:
             mask_parts.append(mask_tensor)
             feature_layout["cat"][column] = n_classes
 
+        for column in self.schema.ordinal_features:
+            series = pd.to_numeric(X[column], errors="coerce")
+            n_classes = int(self.schema[column].n_classes or 0)
+            thermo = np.zeros((n_samples, n_classes), dtype=np.float32)
+            valid_mask = series.notna().to_numpy()
+            valid_indices = np.where(valid_mask)[0]
+            if valid_indices.size:
+                values = series.iloc[valid_indices].astype(int).to_numpy()
+                values = np.clip(values, 0, n_classes - 1)
+                for row, value in zip(valid_indices, values):
+                    thermo[row, : value + 1] = 1.0
+            tensor = torch.from_numpy(thermo)
+            missing = mask[column].to_numpy().astype(bool)
+            observed = (~missing).astype(np.float32).reshape(n_samples, 1)
+            mask_tensor = torch.from_numpy(observed)
+            ordinal_data[column] = tensor
+            ordinal_masks[column] = mask_tensor
+            value_parts.append(tensor)
+            mask_parts.append(mask_tensor)
+            feature_layout["ordinal"][column] = n_classes
+
         if not value_parts:
             raise ValueError("No supported features present in the training data")
 
         encoder_inputs = torch.cat(value_parts + mask_parts, dim=1).float()
-        data_tensors = {"real": real_data, "cat": cat_data}
-        mask_tensors = {"real": real_masks, "cat": cat_masks}
+        data_tensors = {
+            "real": real_data,
+            "pos": pos_data,
+            "count": count_data,
+            "cat": cat_data,
+            "ordinal": ordinal_data,
+        }
+        mask_tensors = {
+            "real": real_masks,
+            "pos": pos_masks,
+            "count": count_masks,
+            "cat": cat_masks,
+            "ordinal": ordinal_masks,
+        }
         if update_layout:
             self._feature_layout = feature_layout
         return encoder_inputs, data_tensors, mask_tensors
@@ -449,6 +512,29 @@ class SUAVE:
                 std = 1.0
             values = pd.to_numeric(normalised[column], errors="coerce")
             normalised[column] = (values - mean) / max(std, 1e-6)
+        for column in self.schema.positive_features:
+            stats = self._norm_stats_per_col.get(column, {})
+            mean_log = float(stats.get("mean_log", 0.0))
+            std_log = float(stats.get("std_log", 1.0))
+            values = pd.to_numeric(normalised[column], errors="coerce")
+            finite = values[values.notna()]
+            if not finite.empty and (finite < -1.0 + 1e-6).any():
+                raise ValueError(
+                    f"Column '{column}' of type 'pos' must be >= -1 to apply log1p"
+                )
+            log_values = np.log1p(values)
+            normalised[column] = (log_values - mean_log) / max(std_log, 1e-6)
+        for column in self.schema.count_features:
+            stats = self._norm_stats_per_col.get(column, {})
+            offset = float(stats.get("offset", 0.0))
+            values = pd.to_numeric(normalised[column], errors="coerce")
+            finite = values[values.notna()]
+            if not finite.empty and (finite < 0).any():
+                raise ValueError(
+                    f"Column '{column}' of type 'count' must be non-negative"
+                )
+            shifted = values + offset
+            normalised[column] = np.log(shifted)
         for column in self.schema.categorical_features:
             stats = self._norm_stats_per_col.get(column, {})
             categories = stats.get("categories")
@@ -458,6 +544,25 @@ class SUAVE:
                 )
             else:
                 normalised[column] = normalised[column].astype("category")
+        for column in self.schema.ordinal_features:
+            stats = self._norm_stats_per_col.get(column, {})
+            series = pd.to_numeric(normalised[column], errors="coerce")
+            n_classes = int(
+                stats.get(
+                    "n_classes",
+                    (
+                        self.schema[column].n_classes
+                        if self.schema[column].n_classes
+                        else 0
+                    ),
+                )
+            )
+            if n_classes:
+                if not series.dropna().between(0, n_classes - 1).all():
+                    raise ValueError(
+                        f"Column '{column}' must contain values in [0, {n_classes - 1}]"
+                    )
+            normalised[column] = series
         return normalised
 
     def _prepare_inference_inputs(self, X: pd.DataFrame) -> Tensor:

--- a/suave/modules/distributions.py
+++ b/suave/modules/distributions.py
@@ -12,7 +12,7 @@ from typing import Optional
 
 import torch
 from torch import Tensor
-from torch.distributions import Categorical, Normal
+from torch.distributions import Categorical, Normal, Poisson
 from torch.nn import functional as F
 
 EPS = 1e-6
@@ -85,3 +85,90 @@ def make_normal(mu: Tensor, var: Tensor) -> Normal:
 
     std = torch.sqrt(torch.clamp(var, min=EPS))
     return Normal(mu, std)
+
+
+def nll_lognormal(
+    log_x: Tensor, mean_log: Tensor, var_log: Tensor, mask: Optional[Tensor]
+) -> Tensor:
+    """Return the negative log-likelihood of log-normal variables.
+
+    Parameters
+    ----------
+    log_x:
+        ``log(1 + x)`` representation of the observed data.
+    mean_log, var_log:
+        Parameters of the Gaussian distribution in log-space.
+    mask:
+        Observation mask with ones for observed entries and zeros for missing.
+    """
+
+    var_log = torch.clamp(var_log, min=EPS)
+    log_var = torch.log(var_log)
+    nll = 0.5 * (_LOG_2PI + log_var + (log_x - mean_log) ** 2 / var_log) + log_x
+    nll = _apply_mask(nll, mask)
+    return nll.sum(dim=-1)
+
+
+def sample_lognormal(mean_log: Tensor, var_log: Tensor) -> Tensor:
+    """Sample positive values from a log-normal distribution."""
+
+    std = torch.sqrt(torch.clamp(var_log, min=EPS))
+    eps = torch.randn_like(std)
+    return torch.exp(mean_log + eps * std) - 1.0
+
+
+def nll_poisson(x: Tensor, rate: Tensor, mask: Optional[Tensor]) -> Tensor:
+    """Return the negative log-likelihood of count data under a Poisson model."""
+
+    rate = torch.clamp(rate, min=EPS)
+    distribution = Poisson(rate)
+    nll = -distribution.log_prob(x)
+    nll = _apply_mask(nll, mask)
+    return nll.sum(dim=-1)
+
+
+def sample_poisson(rate: Tensor) -> Tensor:
+    """Sample from a Poisson distribution with intensity ``rate``."""
+
+    distribution = Poisson(rate)
+    return distribution.sample()
+
+
+def ordinal_probabilities(partition: Tensor, mean: Tensor) -> tuple[Tensor, Tensor]:
+    """Return class probabilities and ordered thresholds for ordinal variables."""
+
+    epsilon = EPS
+    spacings = F.softplus(partition) + epsilon
+    thresholds = torch.cumsum(spacings, dim=-1)
+    mean_expanded = mean
+    if mean_expanded.dim() < thresholds.dim():
+        mean_expanded = mean_expanded.unsqueeze(-1)
+    logits = thresholds - mean_expanded
+    sigmoid = torch.sigmoid(logits)
+    probs = torch.cat([sigmoid, torch.ones_like(sigmoid[..., :1])], dim=-1)
+    probs = probs - torch.cat([torch.zeros_like(sigmoid[..., :1]), sigmoid], dim=-1)
+    probs = torch.clamp(probs, min=EPS, max=1.0)
+    return probs, thresholds
+
+
+def nll_ordinal(probs: Tensor, targets: Tensor, mask: Optional[Tensor]) -> Tensor:
+    """Negative log-likelihood for ordinal observations."""
+
+    log_probs = torch.log(torch.clamp(probs, min=EPS))
+    gathered = log_probs.gather(-1, targets.unsqueeze(-1)).squeeze(-1)
+    nll = -gathered
+    if mask is not None:
+        if mask.shape != nll.shape:
+            mask = mask.expand_as(nll)
+        nll = nll * mask
+    return nll
+
+
+def sample_ordinal(probs: Tensor) -> Tensor:
+    """Sample thermometer-encoded ordinal observations from ``probs``."""
+
+    distribution = Categorical(probs=probs)
+    indices = distribution.sample()
+    n_classes = probs.size(-1)
+    arange = torch.arange(n_classes, device=probs.device)
+    return (arange.unsqueeze(0) <= indices.unsqueeze(-1)).float()

--- a/tests/test_data_processing.py
+++ b/tests/test_data_processing.py
@@ -1,0 +1,47 @@
+import numpy as np
+import pandas as pd
+
+from suave.data import inverse_standardize, standardize
+from suave.types import Schema
+
+
+def test_standardize_inverse_handles_mixed_types():
+    schema = Schema(
+        {
+            "real_val": {"type": "real"},
+            "positive": {"type": "pos"},
+            "count": {"type": "count"},
+            "category": {"type": "cat", "n_classes": 3},
+            "ordinal": {"type": "ordinal", "n_classes": 4},
+        }
+    )
+    frame = pd.DataFrame(
+        {
+            "real_val": [1.0, 2.0, np.nan, 4.0],
+            "positive": [0.0, 3.0, 7.0, np.nan],
+            "count": [0.0, 5.0, 2.0, 1.0],
+            "category": ["a", "b", "a", "c"],
+            "ordinal": [0, 2, 3, 1],
+        }
+    )
+
+    transformed, stats = standardize(frame, schema)
+    assert set(stats) == set(frame.columns)
+    assert np.isfinite(transformed["real_val"].dropna()).all()
+    assert np.isfinite(transformed["positive"].dropna()).all()
+    assert np.isfinite(transformed["count"].dropna()).all()
+    assert stats["count"]["offset"] == 1.0
+
+    restored = inverse_standardize(transformed, schema, stats)
+    for column in ["real_val", "positive", "count"]:
+        original = frame[column].to_numpy()
+        recovered = restored[column].to_numpy()
+        mask = ~np.isnan(original)
+        assert np.allclose(original[mask], recovered[mask], atol=1e-6)
+
+    restored_cat = restored["category"].astype(str).tolist()
+    assert restored_cat == frame["category"].tolist()
+    assert (
+        list(restored["ordinal"].astype(float))
+        == frame["ordinal"].astype(float).tolist()
+    )

--- a/tests/test_minimal.py
+++ b/tests/test_minimal.py
@@ -66,6 +66,7 @@ def test_encode_returns_latent_means():
     assert model._encoder is not None
     assert model._encoder.training == was_training
 
+
 def test_hivae_behaviour_disables_classifier():
     X, _, schema = make_dataset()
     model = SUAVE(schema=schema, behaviour="hivae")
@@ -86,4 +87,3 @@ def test_hivae_behaviour_persists_after_save(tmp_path: Path):
     assert loaded.behaviour == "hivae"
     with pytest.raises(RuntimeError):
         loaded.predict_proba(X)
-

--- a/tests/test_vae_components.py
+++ b/tests/test_vae_components.py
@@ -5,8 +5,14 @@ import math
 import torch
 from torch import nn
 
-from suave.modules.decoder import Decoder, RealHead
-from suave.modules.distributions import nll_gaussian
+from suave.modules.decoder import CountHead, Decoder, OrdinalHead, PosHead, RealHead
+from suave.modules.distributions import (
+    nll_gaussian,
+    nll_lognormal,
+    nll_ordinal,
+    nll_poisson,
+    ordinal_probabilities,
+)
 from suave.modules.encoder import EncoderMLP
 from suave.types import Schema
 
@@ -35,35 +41,58 @@ def test_real_head_output_shapes():
     assert sample.shape == (2, 1)
 
 
-def test_decoder_forward_real_cat():
+def test_decoder_forward_mixed_types():
     schema = Schema(
         {
             "age": {"type": "real"},
             "gender": {"type": "cat", "n_classes": 2},
+            "income": {"type": "pos"},
+            "visits": {"type": "count"},
+            "severity": {"type": "ordinal", "n_classes": 3},
         }
     )
     decoder = Decoder(latent_dim=2, schema=schema, hidden=(4,), dropout=0.0)
     latents = torch.zeros(3, 2)
     data = {
         "real": {"age": torch.zeros(3, 1)},
+        "pos": {"income": torch.zeros(3, 1)},
+        "count": {"visits": torch.zeros(3, 1)},
         "cat": {
             "gender": nn.functional.one_hot(
                 torch.tensor([0, 1, 0]), num_classes=2
             ).float()
         },
+        "ordinal": {
+            "severity": torch.tensor(
+                [[1.0, 0.0, 0.0], [1.0, 1.0, 0.0], [1.0, 1.0, 1.0]]
+            )
+        },
     }
     masks = {
         "real": {"age": torch.ones(3, 1)},
+        "pos": {"income": torch.ones(3, 1)},
+        "count": {"visits": torch.ones(3, 1)},
         "cat": {"gender": torch.ones(3, 1)},
+        "ordinal": {"severity": torch.ones(3, 1)},
     }
     stats = {
         "age": {"mean": 0.0, "std": 1.0},
         "gender": {"categories": [0, 1]},
+        "income": {"mean_log": 0.0, "std_log": 1.0},
+        "visits": {"offset": 0.0},
+        "severity": {"n_classes": 3},
     }
     output = decoder(latents, data, stats, masks)
-    assert set(output["per_feature"]) == {"age", "gender"}
-    assert len(output["log_px"]) == 2
+    assert set(output["per_feature"]) == {
+        "age",
+        "gender",
+        "income",
+        "visits",
+        "severity",
+    }
+    assert len(output["log_px"]) == 5
     assert output["per_feature"]["age"]["params"]["mean"].shape == (3, 1)
+    assert output["per_feature"]["severity"]["sample"].shape == (3, 3)
 
 
 def test_nll_gaussian_matches_closed_form():
@@ -74,3 +103,68 @@ def test_nll_gaussian_matches_closed_form():
     nll = nll_gaussian(x, mu, var, mask)
     expected = 0.5 * (math.log(2 * math.pi * 2.0))
     assert torch.allclose(nll, torch.full((4,), expected), atol=1e-5)
+
+
+def test_pos_head_output_shapes():
+    head = PosHead()
+    x = torch.zeros(2, 1)
+    params = torch.tensor([[0.0, 0.0], [0.5, -0.2]])
+    mask = torch.ones(2, 1)
+    stats = {"mean_log": 0.0, "std_log": 1.0}
+    output = head(x=x, params=params, norm_stats=stats, mask=mask)
+    assert output["log_px"].shape == (2,)
+    assert torch.isfinite(output["log_px"]).all()
+    assert output["sample"].min() >= -1.0
+
+
+def test_count_head_respects_offset():
+    head = CountHead()
+    counts = torch.log(torch.tensor([[2.0], [3.0]]))
+    params = torch.tensor([[0.1], [0.5]])
+    mask = torch.ones(2, 1)
+    stats = {"offset": 0.0}
+    output = head(x=counts, params=params, norm_stats=stats, mask=mask)
+    assert output["params"]["rate"].shape == (2, 1)
+    assert torch.isfinite(output["log_px"]).all()
+
+
+def test_ordinal_head_shapes():
+    head = OrdinalHead(n_classes=3)
+    thermo = torch.tensor([[1.0, 1.0, 0.0], [1.0, 0.0, 0.0]])
+    params = torch.tensor([[0.0, 0.5, 0.2], [0.1, -0.3, -0.1]])
+    mask = torch.ones(2, 1)
+    output = head(x=thermo, params=params, norm_stats={}, mask=mask)
+    assert output["params"]["probs"].shape == (2, 3)
+    assert torch.isfinite(output["log_px"]).all()
+
+
+def test_nll_lognormal_matches_closed_form():
+    log_x = torch.log(torch.tensor([[2.0], [3.0]]))
+    mean = torch.zeros_like(log_x)
+    var = torch.ones_like(log_x)
+    mask = torch.ones_like(log_x)
+    nll = nll_lognormal(log_x, mean, var, mask)
+    expected = 0.5 * (math.log(2 * math.pi) + log_x.squeeze(-1) ** 2) + log_x.squeeze(
+        -1
+    )
+    assert torch.allclose(nll, expected, atol=1e-5)
+
+
+def test_nll_poisson_matches_distribution():
+    counts = torch.tensor([[0.0], [2.0]])
+    rate = torch.full_like(counts, 1.5)
+    mask = torch.ones_like(counts)
+    nll = nll_poisson(counts, rate, mask)
+    expected = -torch.distributions.Poisson(rate).log_prob(counts)
+    assert torch.allclose(nll, expected.squeeze(-1))
+
+
+def test_nll_ordinal_with_manual_probabilities():
+    partition = torch.tensor([[0.2, 0.3]])
+    mean = torch.tensor([[0.1]])
+    probs, _ = ordinal_probabilities(partition, mean)
+    mask = torch.ones(1)
+    targets = torch.tensor([1])
+    nll = nll_ordinal(probs, targets, mask)
+    log_prob = torch.log(probs[:, 1])
+    assert torch.allclose(nll, -log_prob)


### PR DESCRIPTION
## Summary
- extend the schema and preprocessing utilities to accept positive, count and ordinal feature types alongside real/categorical columns
- implement log-normal, Poisson and ordinal decoder heads with matching distribution helpers so all modalities contribute to the ELBO
- update SUAVE tensor preparation/normalisation to pass the new modalities end-to-end and add regression tests for the data pipeline and decoder components

## Testing
- pytest -q
- black suave tests
- ruff check .

------
https://chatgpt.com/codex/tasks/task_e_68cb7cd297188320b48122f0c7efd1b4