### PR TITLE
Add runtime requirements manifest

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+# Core runtime dependencies for the minimal SUAVE package.
+numpy>=1.24,<2
+pandas>=1.5
+torch>=2.2,<2.3
+matplotlib>=3.7
+tqdm>=4.65

--- a/suave/model.py
+++ b/suave/model.py
@@ -540,7 +540,9 @@ class SUAVE:
         if targets is None:
             raise ValueError("Targets must be provided when conditional=True")
         if self._train_latent_mu is None or self._train_latent_logvar is None:
-            raise RuntimeError("Latent posterior statistics are unavailable for sampling")
+            raise RuntimeError(
+                "Latent posterior statistics are unavailable for sampling"
+            )
         if self._class_to_index is None or self._train_target_indices is None:
             raise RuntimeError(
                 "Conditional sampling requires supervised targets from the training data"
@@ -548,7 +550,9 @@ class SUAVE:
 
         target_array = np.asarray(targets).reshape(-1)
         if target_array.shape[0] != n_samples:
-            raise ValueError("y must have length equal to n_samples when conditional=True")
+            raise ValueError(
+                "y must have length equal to n_samples when conditional=True"
+            )
 
         latents = torch.zeros((n_samples, self.latent_dim), device=device)
         rng = np.random.default_rng()

--- a/suave/sampling.py
+++ b/suave/sampling.py
@@ -37,7 +37,9 @@ def build_placeholder_batches(
             else:
                 shape = (n_samples, int(width))
             data_tensors[feature_type][column] = torch.zeros(shape, device=device)
-            mask_tensors[feature_type][column] = torch.ones((n_samples, 1), device=device)
+            mask_tensors[feature_type][column] = torch.ones(
+                (n_samples, 1), device=device
+            )
     return data_tensors, mask_tensors
 
 


### PR DESCRIPTION
## Summary
- add a top-level `requirements.txt` that lists the core runtime dependencies for SUAVE with bounds compatible with the current PyTorch build
- apply `black` formatting to long error strings in the sampling helpers so style checks remain clean

## Testing
- pytest -q
- ruff check .
- black --check .

------
https://chatgpt.com/codex/tasks/task_e_68cba6b729c083208165a39ee6b0aeb6