### PR TITLE
Add HI-VAE mixture latent support

### DIFF
--- a/suave/modules/losses.py
+++ b/suave/modules/losses.py
@@ -26,6 +26,12 @@ def elbo(recon_terms: Iterable[Tensor], kl: Tensor) -> Tensor:
     return recon - kl
 
 
+def sum_reconstruction_terms(recon_terms: Iterable[Tensor]) -> Tensor:
+    """Return the aggregated reconstruction log-likelihood per sample."""
+
+    return torch.stack(tuple(recon_terms), dim=0).sum(dim=0)
+
+
 def kl_warmup(step: int, total_steps: int, beta_target: float) -> float:
     """Linearly anneal the KL term from ``0`` to ``beta_target``."""
 
@@ -40,3 +46,39 @@ def kl_normal(mu: Tensor, logvar: Tensor) -> Tensor:
 
     var = torch.exp(logvar)
     return 0.5 * (mu.pow(2) + var - 1.0 - logvar).sum(dim=-1)
+
+
+def kl_categorical(logits_q: Tensor, logits_p: Tensor) -> Tensor:
+    """Return KL divergence between categorical distributions given logits."""
+
+    log_q = torch.log_softmax(logits_q, dim=-1)
+    log_p = torch.log_softmax(logits_p, dim=-1)
+    probs_q = torch.softmax(logits_q, dim=-1)
+    return (probs_q * (log_q - log_p)).sum(dim=-1)
+
+
+def kl_normal_mixture(
+    mu_q: Tensor,
+    logvar_q: Tensor,
+    mu_p: Tensor,
+    logvar_p: Tensor,
+    posterior_probs: Tensor,
+) -> Tensor:
+    """KL for diagonal Gaussians conditioned on mixture assignments."""
+
+    if mu_q.dim() != 3 or logvar_q.dim() != 3:
+        raise ValueError(
+            "Expected posterior parameters with shape (batch, components, latent)"
+        )
+    if posterior_probs.shape != mu_q.shape[:2]:
+        raise ValueError("posterior_probs must match the first two dimensions of mu_q")
+
+    mu_p = mu_p.to(mu_q.device).unsqueeze(0)
+    logvar_p = logvar_p.to(logvar_q.device).unsqueeze(0)
+    var_q = torch.exp(logvar_q)
+    var_p = torch.exp(logvar_p).clamp_min(1e-6)
+    diff = mu_q - mu_p
+    component_kl = 0.5 * (
+        logvar_p - logvar_q + (var_q + diff.pow(2)) / var_p - 1.0
+    ).sum(dim=-1)
+    return (posterior_probs * component_kl).sum(dim=-1)

--- a/tests/test_minimal.py
+++ b/tests/test_minimal.py
@@ -46,7 +46,7 @@ def test_fit_logs(caplog, epochs):
 
 def test_predict_proba_shape():
     X, y, schema = make_dataset()
-    model = SUAVE(schema=schema)
+    model = SUAVE(schema=schema, n_components=2)
     model.fit(X, y)
     probabilities = model.predict_proba(X)
     assert probabilities.shape == (len(X), 2)
@@ -56,7 +56,7 @@ def test_predict_proba_shape():
 
 def test_encode_returns_latent_means():
     X, y, schema = make_dataset()
-    model = SUAVE(schema=schema, latent_dim=4, batch_size=2)
+    model = SUAVE(schema=schema, latent_dim=4, batch_size=2, n_components=2)
     model.fit(X, y)
     assert model._encoder is not None
     was_training = model._encoder.training
@@ -69,7 +69,7 @@ def test_encode_returns_latent_means():
 
 def test_sample_generates_schema_aligned_dataframe():
     X, y, schema = make_dataset()
-    model = SUAVE(schema=schema, latent_dim=4, batch_size=2)
+    model = SUAVE(schema=schema, latent_dim=4, batch_size=2, n_components=2)
     model.fit(X, y, epochs=1)
     samples = model.sample(3)
     assert isinstance(samples, pd.DataFrame)
@@ -83,7 +83,7 @@ def test_sample_generates_schema_aligned_dataframe():
 
 def test_conditional_sampling_validates_labels():
     X, y, schema = make_dataset()
-    model = SUAVE(schema=schema, latent_dim=4, batch_size=2)
+    model = SUAVE(schema=schema, latent_dim=4, batch_size=2, n_components=2)
     model.fit(X, y, epochs=1)
     requested = np.array([0, 1, 1])
     samples = model.sample(len(requested), conditional=True, y=requested)
@@ -94,7 +94,7 @@ def test_conditional_sampling_validates_labels():
 
 def test_hivae_behaviour_disables_classifier():
     X, _, schema = make_dataset()
-    model = SUAVE(schema=schema, behaviour="hivae")
+    model = SUAVE(schema=schema, behaviour="hivae", n_components=2)
     model.fit(X, epochs=1)
     latent = model.encode(X)
     assert latent.shape[0] == len(X)
@@ -104,7 +104,7 @@ def test_hivae_behaviour_disables_classifier():
 
 def test_hivae_behaviour_persists_after_save(tmp_path: Path):
     X, _, schema = make_dataset()
-    model = SUAVE(schema=schema, behaviour="hivae")
+    model = SUAVE(schema=schema, behaviour="hivae", n_components=2)
     model.fit(X, epochs=1)
     save_path = tmp_path / "model.json"
     model.save(save_path)


### PR DESCRIPTION
## Summary
- add a configurable mixture prior to SUAVE and teach the training loop to optimise categorical and component-wise Gaussian KL terms
- extend the encoder and loss utilities to emit/consume mixture logits and per-component parameters while updating sampling to draw from the hierarchical prior
- exercise the new hierarchy in the minimal and module unit tests, including a helper for mixture latent sampling

## Testing
- pytest -q


------
https://chatgpt.com/codex/tasks/task_e_68cba48908d08320814172c9576cc588