### PR TITLE
Add HI-VAE parity example and decoder alignment tests

### DIFF
--- a/examples/hivae_general_example.py
+++ b/examples/hivae_general_example.py
@@ -1,0 +1,185 @@
+"""Minimal reproduction of the TensorFlow HI-VAE general example using SUAVE.
+
+This script mirrors the structure of ``third_party/hivae_tf/hivae/examples/
+hivae_general_example.py`` but relies exclusively on the native PyTorch
+implementation.  It creates a small mixed-type dataset, trains SUAVE in
+``behaviour="hivae"`` mode and reports reconstruction quality.  When the
+TensorFlow reference implementation is available the script also prints the
+baseline scores for a quick side-by-side comparison.
+"""
+
+from __future__ import annotations
+
+import argparse
+import math
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pandas as pd
+import torch
+
+from suave import data as data_utils
+from suave import sampling as sampling_utils
+from suave.model import SUAVE
+from suave.types import Schema
+
+
+def _make_mock_dataset(n_samples: int, *, random_state: int = 0) -> pd.DataFrame:
+    rng = np.random.default_rng(random_state)
+    data = {
+        "age": rng.normal(loc=60.0, scale=12.0, size=n_samples),
+        "gender": rng.integers(0, 2, size=n_samples),
+        "cholesterol": rng.lognormal(mean=math.log(180.0), sigma=0.15, size=n_samples),
+        "num_admissions": rng.poisson(lam=1.8, size=n_samples),
+    }
+    frame = pd.DataFrame(data)
+    frame["age"] = frame["age"].clip(lower=18.0)
+    frame["cholesterol"] = frame["cholesterol"].clip(lower=90.0)
+    frame.loc[rng.random(size=n_samples) < 0.15, "cholesterol"] = np.nan
+    return frame
+
+
+def _schema() -> Schema:
+    return Schema(
+        {
+            "age": {"type": "real"},
+            "gender": {"type": "cat", "n_classes": 2},
+            "cholesterol": {"type": "pos"},
+            "num_admissions": {"type": "count"},
+        }
+    )
+
+
+def _fit_suave(train: pd.DataFrame, *, epochs: int) -> SUAVE:
+    model = SUAVE(
+        schema=_schema(), behaviour="hivae", latent_dim=8, hidden_dims=(64, 32)
+    )
+    model.fit(train, epochs=epochs, batch_size=min(64, len(train)))
+    return model
+
+
+def _reconstruction_error(original: pd.DataFrame, reconstructed: pd.DataFrame) -> float:
+    numeric_cols = [
+        col for col, spec in _schema().to_dict().items() if spec["type"] != "cat"
+    ]
+    diff = original[numeric_cols] - reconstructed[numeric_cols]
+    return float(np.nanmean(diff.to_numpy(dtype=np.float32) ** 2))
+
+
+def _reconstruct(model: SUAVE, X: pd.DataFrame) -> pd.DataFrame:
+    if not model._is_fitted:
+        raise RuntimeError("Model must be fitted before calling _reconstruct")
+    aligned = X.loc[:, model.schema.feature_names].reset_index(drop=True)
+    mask = data_utils.build_missing_mask(aligned)
+    normalised = model._apply_training_normalization(aligned)
+    mask = (mask | normalised.isna()).reset_index(drop=True)
+    _, data_tensors, mask_tensors = model._prepare_training_tensors(
+        normalised, mask, update_layout=False
+    )
+
+    device = model._select_device()
+    encoder_inputs = model._prepare_inference_inputs(X).to(device)
+    for feature_type in data_tensors:
+        for column in data_tensors[feature_type]:
+            data_tensors[feature_type][column] = data_tensors[feature_type][column].to(
+                device
+            )
+            mask_tensors[feature_type][column] = mask_tensors[feature_type][column].to(
+                device
+            )
+
+    with torch.no_grad():
+        encoder_state = model._encoder.training
+        decoder_state = model._decoder.training
+        model._encoder.eval()
+        model._decoder.eval()
+        mu, _ = model._encoder(encoder_inputs)
+        decoder_out = model._decoder(
+            mu, data_tensors, model._norm_stats_per_col, mask_tensors
+        )
+        if encoder_state:
+            model._encoder.train()
+        if decoder_state:
+            model._decoder.train()
+    return sampling_utils.decoder_outputs_to_frame(
+        decoder_out["per_feature"], model.schema, model._norm_stats_per_col
+    )
+
+
+def _maybe_run_tensorflow_baseline(
+    train: pd.DataFrame, *, epochs: int
+) -> dict[str, Any] | None:
+    try:
+        from third_party.hivae_tf.hivae import hivae as tf_hivae
+    except ImportError:
+        return None
+
+    types_description = [
+        ("age", "pos", 1, None),
+        ("gender", "cat", 2, 2),
+        ("cholesterol", "pos", 1, None),
+        ("num_admissions", "count", 1, None),
+    ]
+    network_dict = {
+        "batch_size": min(64, len(train)),
+        "model_name": "model_HIVAE_inputDropout",
+        "dim_z": 6,
+        "dim_y": 6,
+        "dim_s": 6,
+    }
+
+    temp_dir = Path("./.hivae_tf_cache")
+    temp_dir.mkdir(exist_ok=True)
+    baseline = tf_hivae.hivae(
+        types_description,
+        network_dict,
+        results_path=temp_dir / "results",
+        network_path=temp_dir / "networks",
+        verbosity_level=0,
+    )
+    mask = train.notna().astype(float)
+    baseline.fit(train.fillna(train.mean()), epochs=epochs, true_missing_mask=mask)
+    recon = baseline.predict(train.fillna(train.mean()), true_missing_mask=mask)[1]
+    recon_df = pd.DataFrame(recon, columns=train.columns, index=train.index)
+    mse = _reconstruction_error(train, recon_df)
+    return {"mse": mse, "path": temp_dir}
+
+
+def main(epochs: int) -> None:
+    train = _make_mock_dataset(300)
+    test = _make_mock_dataset(120, random_state=1)
+
+    model = _fit_suave(train, epochs=epochs)
+    samples = model.sample(5)
+    reconstruction = _reconstruct(model, test)
+    suave_mse = _reconstruction_error(test, reconstruction)
+
+    print("SUAVE HI-VAE example")
+    print("====================")
+    print(f"Training samples : {len(train)}")
+    print(f"Test samples     : {len(test)}")
+    print(f"Reconstruction MSE (numeric cols): {suave_mse:.4f}")
+    print("Synthetic preview:\n", samples.head())
+
+    baseline = _maybe_run_tensorflow_baseline(train, epochs=epochs)
+    if baseline is None:
+        print(
+            "\n[optional] Install third_party HI-VAE TensorFlow code to compare baselines."
+        )
+    else:
+        print("\nTensorFlow baseline")
+        print(f"Reconstruction MSE (numeric cols): {baseline['mse']:.4f}")
+        print(f"Artifacts stored under {baseline['path']}")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Run the SUAVE HI-VAE example.")
+    parser.add_argument(
+        "--epochs",
+        type=int,
+        default=20,
+        help="Number of training epochs for both models.",
+    )
+    args = parser.parse_args()
+    main(args.epochs)

--- a/tests/test_third_party_alignment.py
+++ b/tests/test_third_party_alignment.py
@@ -1,0 +1,132 @@
+"""Tests comparing SUAVE's HI-VAE heads against the published TensorFlow formulas."""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import torch
+
+from suave.modules.decoder import CatHead, RealHead
+
+
+def _softplus(x: np.ndarray) -> np.ndarray:
+    """Numerically stable softplus matching TensorFlow's implementation."""
+
+    return np.log1p(np.exp(-np.abs(x))) + np.maximum(x, 0.0)
+
+
+def _gaussian_log_likelihood(
+    x_raw: np.ndarray,
+    mask: np.ndarray,
+    mean_raw: np.ndarray,
+    var_raw: np.ndarray,
+    mean_scale: float,
+    std_scale: float,
+) -> np.ndarray:
+    """Reproduce the TensorFlow HI-VAE Gaussian reconstruction formula."""
+
+    eps = 1e-6
+    var = _softplus(var_raw) + eps
+    mean = mean_raw * std_scale + mean_scale
+    var_scaled = var * (std_scale**2)
+    log_det = np.log(2.0 * math.pi * var_scaled)
+    squared = (x_raw - mean) ** 2 / np.clip(var_scaled, a_min=eps, a_max=None)
+    log_px = -0.5 * (log_det + squared)
+    log_px = log_px * mask
+    return log_px.sum(axis=-1)
+
+
+def _categorical_log_likelihood(
+    one_hot: np.ndarray,
+    logits: np.ndarray,
+    mask: np.ndarray | None,
+) -> np.ndarray:
+    """Reproduce the TensorFlow HI-VAE categorical reconstruction formula."""
+
+    max_logits = np.max(logits, axis=-1, keepdims=True)
+    log_probs = (
+        logits
+        - max_logits
+        - np.log(np.sum(np.exp(logits - max_logits), axis=-1, keepdims=True))
+    )
+    log_px = (one_hot * log_probs).sum(axis=-1)
+    if mask is not None:
+        log_px = log_px * mask.squeeze(-1)
+    return log_px
+
+
+def test_real_head_matches_third_party_formulation() -> None:
+    rng = np.random.default_rng(42)
+    batch = 6
+
+    mean_scale = float(rng.normal(loc=1.0, scale=0.2))
+    std_scale = float(rng.uniform(0.5, 1.5))
+
+    x_raw = rng.normal(loc=mean_scale, scale=std_scale, size=(batch, 1)).astype(
+        np.float32
+    )
+    mask = (rng.random(size=(batch, 1)) > 0.2).astype(np.float32)
+    mean_raw = rng.normal(size=(batch, 1)).astype(np.float32)
+    var_raw = rng.normal(size=(batch, 1)).astype(np.float32)
+
+    x_norm = (x_raw - mean_scale) / std_scale
+    params = np.concatenate([mean_raw, var_raw], axis=-1)
+
+    head = RealHead()
+    output = head(
+        torch.from_numpy(x_norm),
+        torch.from_numpy(params),
+        {"mean": mean_scale, "std": std_scale},
+        torch.from_numpy(mask),
+    )
+
+    expected = _gaussian_log_likelihood(
+        x_raw, mask, mean_raw, var_raw, mean_scale, std_scale
+    )
+    torch.testing.assert_close(
+        output["log_px"], torch.from_numpy(expected), atol=1e-5, rtol=1e-4
+    )
+
+    missing_mask = 1.0 - mask
+    expected_missing = _gaussian_log_likelihood(
+        x_raw, missing_mask, mean_raw, var_raw, mean_scale, std_scale
+    )
+    torch.testing.assert_close(
+        output["log_px_missing"],
+        torch.from_numpy(expected_missing),
+        atol=1e-5,
+        rtol=1e-4,
+    )
+
+
+def test_categorical_head_matches_third_party_formulation() -> None:
+    rng = np.random.default_rng(7)
+    batch = 5
+    n_classes = 4
+
+    logits = rng.normal(size=(batch, n_classes)).astype(np.float32)
+    indices = rng.integers(low=0, high=n_classes, size=batch)
+    one_hot = np.eye(n_classes, dtype=np.float32)[indices]
+    mask = (rng.random(size=(batch, 1)) > 0.3).astype(np.float32)
+
+    head = CatHead(n_classes=n_classes)
+    output = head(
+        torch.from_numpy(one_hot),
+        torch.from_numpy(logits),
+        None,
+        torch.from_numpy(mask),
+    )
+
+    expected = _categorical_log_likelihood(one_hot, logits, mask)
+    torch.testing.assert_close(
+        output["log_px"], torch.from_numpy(expected), atol=1e-5, rtol=1e-4
+    )
+
+    expected_missing = _categorical_log_likelihood(one_hot, logits, 1.0 - mask)
+    torch.testing.assert_close(
+        output["log_px_missing"],
+        torch.from_numpy(expected_missing),
+        atol=1e-5,
+        rtol=1e-4,
+    )


### PR DESCRIPTION
## Summary
- add a SUAVE-based port of the TensorFlow HI-VAE general example with optional baseline comparison
- add parity tests that compare the SUAVE decoder heads against the TensorFlow log-likelihood formulas

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68cba64ae08c8320863e908d65cb8197