### PR TITLE
Fix membership inference threshold sweep

### DIFF
--- a/suave/evaluate.py
+++ b/suave/evaluate.py
@@ -15,3 +15,72 @@ def evaluate_classification(
     if probabilities.shape[0] != len(targets):
         raise ValueError("probabilities and targets must share the first dimension")
     return {"accuracy": float(np.mean(targets == targets))}
+
+
+def simple_membership_inference(
+    member_confidences: np.ndarray, non_member_confidences: np.ndarray
+) -> Dict[str, float]:
+    """Evaluate a threshold-based membership inference baseline.
+
+    The attack assigns the *member* label to samples with confidence scores that are
+    greater than or equal to a threshold. All possible thresholds induced by the
+    provided scores are evaluated, along with an additional pair of thresholds that
+    force "all member" and "all non-member" predictions. The best accuracy achieved
+    over this sweep is returned alongside the majority-class baseline accuracy.
+
+    Args:
+        member_confidences: Confidence scores observed for training samples.
+        non_member_confidences: Confidence scores observed for non-member samples.
+
+    Returns:
+        A dictionary containing the best attack accuracy, the threshold that
+        attains it, and the majority-class accuracy baseline.
+    """
+
+    member_confidences = np.asarray(member_confidences, dtype=float)
+    non_member_confidences = np.asarray(non_member_confidences, dtype=float)
+
+    if member_confidences.ndim != 1 or non_member_confidences.ndim != 1:
+        raise ValueError("membership inference scores must be 1-D arrays")
+
+    total_samples = int(member_confidences.size + non_member_confidences.size)
+    if total_samples == 0:
+        raise ValueError("at least one score is required to run the attack")
+
+    arrays = []
+    labels = []
+    if member_confidences.size:
+        arrays.append(member_confidences)
+        labels.append(np.ones(member_confidences.size, dtype=int))
+    if non_member_confidences.size:
+        arrays.append(non_member_confidences)
+        labels.append(np.zeros(non_member_confidences.size, dtype=int))
+
+    scores = np.concatenate(arrays)
+    membership_labels = np.concatenate(labels)
+
+    # Majority-class baseline (a random guess biased by class imbalance).
+    member_ratio = float(member_confidences.size) / float(total_samples)
+    non_member_ratio = float(non_member_confidences.size) / float(total_samples)
+    majority_accuracy = max(member_ratio, non_member_ratio)
+
+    unique_thresholds = np.unique(scores)
+    # Evaluate two additional thresholds to cover all-member and all-non-member
+    # predictions explicitly.
+    lower_extreme = np.nextafter(scores.min(), -np.inf)
+    upper_extreme = np.nextafter(scores.max(), np.inf)
+    candidate_thresholds = np.unique(
+        np.concatenate((unique_thresholds, np.array([lower_extreme, upper_extreme])))
+    )
+
+    # Vectorised evaluation of all thresholds.
+    predictions = scores[None, :] >= candidate_thresholds[:, None]
+    accuracies = (predictions == membership_labels).mean(axis=1)
+
+    best_index = int(np.argmax(accuracies))
+
+    return {
+        "attack_best_threshold": float(candidate_thresholds[best_index]),
+        "attack_best_accuracy": float(accuracies[best_index]),
+        "attack_majority_class_accuracy": float(majority_accuracy),
+    }

--- a/suave/evaluate.py
+++ b/suave/evaluate.py
@@ -2,85 +2,476 @@
 
 from __future__ import annotations
 
-from typing import Dict
+from typing import Any, Callable, Dict, Tuple
 
 import numpy as np
+from sklearn.metrics import average_precision_score, brier_score_loss, roc_auc_score
+
+
+def _prepare_inputs(
+    probabilities: np.ndarray, targets: np.ndarray
+) -> Tuple[np.ndarray, np.ndarray]:
+    """Validate and format probability/target inputs.
+
+    The helper normalises probability arrays into a two-dimensional matrix and
+    ensures the target labels are integer encoded. It is primarily used by the
+    metric helpers defined in this module.
+
+    Args:
+        probabilities: Raw probability estimates. For binary tasks the array may
+            be one-dimensional containing the positive class probability. For
+            multi-class tasks the array must be shaped ``(n_samples, n_classes)``
+            with columns ordered according to the encoded class index.
+        targets: Integer encoded class labels aligned with ``probabilities``.
+
+    Returns:
+        A tuple containing the probability matrix with shape
+        ``(n_samples, n_classes)`` and the validated target vector.
+
+    Raises:
+        ValueError: If shapes do not align or labels fall outside the probability
+            matrix columns.
+
+    Example:
+        >>> probs, labels = _prepare_inputs(np.array([0.2, 0.8]), np.array([0, 1]))
+        >>> probs.shape
+        (2, 2)
+    """
+
+    prob_array = np.asarray(probabilities, dtype=float)
+    target_array = np.asarray(targets)
+
+    if prob_array.ndim == 1:
+        prob_array = np.stack([1.0 - prob_array, prob_array], axis=1)
+    elif prob_array.ndim == 2 and prob_array.shape[1] == 1:
+        prob_array = np.hstack([1.0 - prob_array, prob_array])
+    elif prob_array.ndim != 2:
+        raise ValueError("probabilities must be one- or two-dimensional")
+
+    if not np.all(np.isfinite(prob_array)):
+        raise ValueError("probabilities must contain only finite values")
+
+    if target_array.ndim != 1:
+        raise ValueError("targets must be a one-dimensional array")
+
+    if not np.issubdtype(target_array.dtype, np.integer):
+        raise ValueError("targets must be integer encoded starting at zero")
+
+    if len(prob_array) != len(target_array):
+        raise ValueError("probabilities and targets must share the first dimension")
+
+    if prob_array.shape[0] == 0:
+        return prob_array, target_array.astype(int, copy=False)
+
+    if np.min(target_array) < 0:
+        raise ValueError("targets must be non-negative integers")
+
+    if np.max(target_array) >= prob_array.shape[1]:
+        raise ValueError("targets reference an invalid class index")
+
+    return prob_array, target_array.astype(int, copy=False)
+
+
+def compute_auroc(probabilities: np.ndarray, targets: np.ndarray) -> float:
+    """Compute the area under the ROC curve (AUROC).
+
+    Args:
+        probabilities: Probability estimates. One-dimensional arrays are
+            interpreted as the positive class probability for binary problems.
+        targets: Integer encoded target labels aligned with ``probabilities``.
+
+    Returns:
+        The AUROC value. ``numpy.nan`` is returned when the metric is undefined,
+        such as when only a single class is present or scikit-learn raises a
+        ``ValueError`` for degenerate inputs.
+
+    Example:
+        >>> probs = np.array([[0.1, 0.9], [0.8, 0.2]])
+        >>> compute_auroc(probs, np.array([1, 0]))
+        1.0
+    """
+
+    prob_array, target_array = _prepare_inputs(probabilities, targets)
+    if prob_array.shape[0] == 0 or np.unique(target_array).size < 2:
+        return float("nan")
+
+    n_classes = prob_array.shape[1]
+    try:
+        if n_classes == 2:
+            return float(roc_auc_score(target_array, prob_array[:, 1]))
+        return float(
+            roc_auc_score(
+                target_array,
+                prob_array,
+                multi_class="ovr",
+                average="macro",
+            )
+        )
+    except ValueError:
+        return float("nan")
+
+
+def compute_auprc(probabilities: np.ndarray, targets: np.ndarray) -> float:
+    """Compute the area under the precision-recall curve (AUPRC).
+
+    Args:
+        probabilities: Probability estimates for each class.
+        targets: Integer encoded target labels aligned with ``probabilities``.
+
+    Returns:
+        The macro-averaged AUPRC across classes. ``numpy.nan`` is returned when
+        the score is undefined for the provided data.
+
+    Example:
+        >>> probs = np.array([[0.05, 0.95], [0.9, 0.1]])
+        >>> compute_auprc(probs, np.array([1, 0]))
+        1.0
+    """
+
+    prob_array, target_array = _prepare_inputs(probabilities, targets)
+    if prob_array.shape[0] == 0:
+        return float("nan")
+
+    n_classes = prob_array.shape[1]
+    if n_classes == 2:
+        if np.unique(target_array).size < 2:
+            return float("nan")
+        try:
+            return float(average_precision_score(target_array, prob_array[:, 1]))
+        except ValueError:
+            return float("nan")
+
+    scores = []
+    for class_index in range(n_classes):
+        binary_target = (target_array == class_index).astype(int)
+        if np.unique(binary_target).size < 2:
+            continue
+        try:
+            scores.append(
+                float(
+                    average_precision_score(binary_target, prob_array[:, class_index])
+                )
+            )
+        except ValueError:
+            continue
+
+    return float(np.mean(scores)) if scores else float("nan")
+
+
+def compute_brier(probabilities: np.ndarray, targets: np.ndarray) -> float:
+    """Compute the Brier score for binary and multi-class classifiers.
+
+    Args:
+        probabilities: Probability estimates for each class.
+        targets: Integer encoded target labels aligned with ``probabilities``.
+
+    Returns:
+        The Brier score. Lower values indicate better calibrated probabilities.
+        ``numpy.nan`` is returned for empty inputs.
+
+    Example:
+        >>> probs = np.array([[0.8, 0.2], [0.3, 0.7]])
+        >>> round(compute_brier(probs, np.array([0, 1])), 3)
+        0.065
+    """
+
+    prob_array, target_array = _prepare_inputs(probabilities, targets)
+    if prob_array.shape[0] == 0:
+        return float("nan")
+
+    n_classes = prob_array.shape[1]
+    if n_classes == 2:
+        return float(brier_score_loss(target_array, prob_array[:, 1]))
+
+    one_hot = np.eye(n_classes)[target_array]
+    return float(np.mean(np.sum((prob_array - one_hot) ** 2, axis=1)))
+
+
+def compute_ece(
+    probabilities: np.ndarray, targets: np.ndarray, n_bins: int = 10
+) -> float:
+    """Compute the expected calibration error (ECE).
+
+    Args:
+        probabilities: Probability estimates for each class.
+        targets: Integer encoded target labels aligned with ``probabilities``.
+        n_bins: Number of equally spaced bins used to evaluate calibration.
+
+    Returns:
+        The ECE value. ``numpy.nan`` is returned for empty inputs.
+
+    Example:
+        >>> probs = np.array([[0.2, 0.8], [0.7, 0.3]])
+        >>> round(compute_ece(probs, np.array([1, 0]), n_bins=5), 2)
+        0.25
+    """
+
+    if n_bins <= 0:
+        raise ValueError("n_bins must be a positive integer")
+
+    prob_array, target_array = _prepare_inputs(probabilities, targets)
+    if prob_array.shape[0] == 0:
+        return float("nan")
+
+    confidences = np.max(prob_array, axis=1)
+    predictions = np.argmax(prob_array, axis=1)
+    bin_edges = np.linspace(0.0, 1.0, n_bins + 1)
+    bin_indices = np.minimum(
+        np.digitize(confidences, bin_edges[1:], right=True), n_bins - 1
+    )
+
+    ece = 0.0
+    total = len(confidences)
+    for bin_index in range(n_bins):
+        mask = bin_indices == bin_index
+        if not np.any(mask):
+            continue
+        bin_confidence = float(np.mean(confidences[mask]))
+        bin_accuracy = float(np.mean(predictions[mask] == target_array[mask]))
+        ece += abs(bin_confidence - bin_accuracy) * (np.sum(mask) / total)
+
+    return float(ece)
 
 
 def evaluate_classification(
     probabilities: np.ndarray, targets: np.ndarray
 ) -> Dict[str, float]:
-    """Return dummy metrics for the minimal implementation."""
+    """Evaluate common classification metrics for SUAVE models.
 
-    if probabilities.shape[0] != len(targets):
-        raise ValueError("probabilities and targets must share the first dimension")
-    return {"accuracy": float(np.mean(targets == targets))}
+    Args:
+        probabilities: Probability estimates shaped ``(n_samples, n_classes)`` or
+            a one-dimensional array containing positive class probabilities for
+            binary classification.
+        targets: Integer encoded ground-truth labels aligned with
+            ``probabilities``. Labels must be zero-indexed to match column
+            positions.
+
+    Returns:
+        A dictionary containing accuracy, AUROC, AUPRC, Brier score, and ECE
+        values. Metrics that are undefined for the provided data return
+        ``numpy.nan``.
+
+    Example:
+        >>> probs = np.array([[0.1, 0.9], [0.8, 0.2]])
+        >>> evaluate_classification(probs, np.array([1, 0]))
+        {'accuracy': 1.0, 'auroc': 1.0, 'auprc': 1.0, 'brier': 0.024999999999999994, 'ece': 0.14999999999999997}
+    """
+
+    prob_array, target_array = _prepare_inputs(probabilities, targets)
+    if prob_array.shape[0] == 0:
+        nan_value = float("nan")
+        return {
+            "accuracy": nan_value,
+            "auroc": nan_value,
+            "auprc": nan_value,
+            "brier": nan_value,
+            "ece": nan_value,
+        }
+
+    predictions = np.argmax(prob_array, axis=1)
+    accuracy = float(np.mean(predictions == target_array))
+
+    return {
+        "accuracy": accuracy,
+        "auroc": compute_auroc(prob_array, target_array),
+        "auprc": compute_auprc(prob_array, target_array),
+        "brier": compute_brier(prob_array, target_array),
+        "ece": compute_ece(prob_array, target_array),
+    }
+
+
+def evaluate_tstr(
+    synthetic: Tuple[np.ndarray, np.ndarray],
+    real: Tuple[np.ndarray, np.ndarray],
+    model_factory: Callable[[], Any],
+) -> Dict[str, float]:
+    """Run a Train-on-Synthetic, Test-on-Real (TSTR) evaluation.
+
+    Args:
+        synthetic: Tuple ``(features, targets)`` used for training. The
+            classifier produced by ``model_factory`` must support ``fit`` and
+            ``predict_proba`` on these arrays.
+        real: Tuple ``(features, targets)`` representing the held-out real data
+            used for evaluation.
+        model_factory: Callable returning an unfitted probabilistic classifier
+            (e.g., ``lambda: LogisticRegression(max_iter=200)``).
+
+    Returns:
+        Classification metrics on the real evaluation split.
+
+    Example:
+        >>> from sklearn.linear_model import LogisticRegression
+        >>> X_syn = np.array([[0.0], [1.0], [2.0], [3.0]])
+        >>> y_syn = np.array([0, 0, 1, 1])
+        >>> X_real = np.array([[0.2], [0.8], [2.2], [2.8]])
+        >>> y_real = np.array([0, 0, 1, 1])
+        >>> evaluate_tstr((X_syn, y_syn), (X_real, y_real),
+        ...                lambda: LogisticRegression(max_iter=200))['accuracy']
+        1.0
+    """
+
+    X_syn, y_syn = synthetic
+    X_real, y_real = real
+
+    model = model_factory()
+    if not hasattr(model, "fit") or not hasattr(model, "predict_proba"):
+        raise ValueError(
+            "model_factory must return an object with fit and predict_proba"
+        )
+
+    model.fit(X_syn, y_syn)
+    probabilities = model.predict_proba(X_real)
+    return evaluate_classification(probabilities, y_real)
+
+
+def evaluate_trtr(
+    real_train: Tuple[np.ndarray, np.ndarray],
+    real_test: Tuple[np.ndarray, np.ndarray],
+    model_factory: Callable[[], Any],
+) -> Dict[str, float]:
+    """Run a Train-on-Real, Test-on-Real (TRTR) evaluation.
+
+    Args:
+        real_train: Tuple ``(features, targets)`` used for training.
+        real_test: Tuple ``(features, targets)`` used for evaluation.
+        model_factory: Callable returning an unfitted classifier supporting
+            ``fit`` and ``predict_proba``.
+
+    Returns:
+        Classification metrics on the held-out real test split.
+
+    Example:
+        >>> from sklearn.linear_model import LogisticRegression
+        >>> X_train = np.array([[0.0], [1.0], [2.0], [3.0]])
+        >>> y_train = np.array([0, 0, 1, 1])
+        >>> X_test = np.array([[0.1], [0.9], [2.1], [2.9]])
+        >>> y_test = np.array([0, 0, 1, 1])
+        >>> evaluate_trtr((X_train, y_train), (X_test, y_test),
+        ...               lambda: LogisticRegression(max_iter=200))['accuracy']
+        1.0
+    """
+
+    X_train, y_train = real_train
+    X_test, y_test = real_test
+
+    model = model_factory()
+    if not hasattr(model, "fit") or not hasattr(model, "predict_proba"):
+        raise ValueError(
+            "model_factory must return an object with fit and predict_proba"
+        )
+
+    model.fit(X_train, y_train)
+    probabilities = model.predict_proba(X_test)
+    return evaluate_classification(probabilities, y_test)
 
 
 def simple_membership_inference(
-    member_confidences: np.ndarray, non_member_confidences: np.ndarray
+    train_probabilities: np.ndarray,
+    train_targets: np.ndarray,
+    test_probabilities: np.ndarray,
+    test_targets: np.ndarray,
 ) -> Dict[str, float]:
-    """Evaluate a threshold-based membership inference baseline.
+    """Run a simple membership-inference attack baseline.
 
-    The attack assigns the *member* label to samples with confidence scores that are
-    greater than or equal to a threshold. All possible thresholds induced by the
-    provided scores are evaluated, along with an additional pair of thresholds that
-    force "all member" and "all non-member" predictions. The best accuracy achieved
-    over this sweep is returned alongside the majority-class baseline accuracy.
+    The attack scores each example by the predicted probability of its true
+    class and evaluates a sweep over decision thresholds to separate members
+    (training examples) from non-members (held-out examples). All thresholds
+    induced by the observed scores are considered alongside extreme thresholds
+    that force "all member" and "all non-member" predictions to ensure the
+    majority-class baseline is explicitly evaluated.
 
     Args:
-        member_confidences: Confidence scores observed for training samples.
-        non_member_confidences: Confidence scores observed for non-member samples.
+        train_probabilities: Probabilities predicted on the training data.
+        train_targets: Integer encoded training labels.
+        test_probabilities: Probabilities predicted on held-out data.
+        test_targets: Integer encoded held-out labels.
 
     Returns:
-        A dictionary containing the best attack accuracy, the threshold that
-        attains it, and the majority-class accuracy baseline.
+        A dictionary containing ``attack_auc``, ``attack_best_threshold``,
+        ``attack_best_accuracy``, and ``attack_majority_class_accuracy``. The
+        scores are ``numpy.nan`` when the attack is undefined (e.g., only a
+        single membership class is present).
+
+    Example:
+        >>> train_probs = np.array([[0.1, 0.9], [0.2, 0.8]])
+        >>> train_targets = np.array([1, 1])
+        >>> test_probs = np.array([[0.7, 0.3], [0.6, 0.4]])
+        >>> test_targets = np.array([0, 0])
+        >>> simple_membership_inference(train_probs, train_targets,
+        ...                              test_probs, test_targets)['attack_auc']
+        1.0
     """
 
-    member_confidences = np.asarray(member_confidences, dtype=float)
-    non_member_confidences = np.asarray(non_member_confidences, dtype=float)
+    train_probs, train_labels = _prepare_inputs(train_probabilities, train_targets)
+    test_probs, test_labels = _prepare_inputs(test_probabilities, test_targets)
 
-    if member_confidences.ndim != 1 or non_member_confidences.ndim != 1:
-        raise ValueError("membership inference scores must be 1-D arrays")
+    if train_probs.shape[1] != test_probs.shape[1]:
+        raise ValueError(
+            "train and test probabilities must have the same number of classes"
+        )
 
-    total_samples = int(member_confidences.size + non_member_confidences.size)
-    if total_samples == 0:
-        raise ValueError("at least one score is required to run the attack")
+    if train_probs.shape[0] == 0 or test_probs.shape[0] == 0:
+        nan_value = float("nan")
+        return {
+            "attack_auc": nan_value,
+            "attack_best_threshold": nan_value,
+            "attack_best_accuracy": nan_value,
+            "attack_majority_class_accuracy": nan_value,
+        }
 
-    arrays = []
-    labels = []
-    if member_confidences.size:
-        arrays.append(member_confidences)
-        labels.append(np.ones(member_confidences.size, dtype=int))
-    if non_member_confidences.size:
-        arrays.append(non_member_confidences)
-        labels.append(np.zeros(non_member_confidences.size, dtype=int))
+    def _true_class_confidence(
+        prob_matrix: np.ndarray, labels: np.ndarray
+    ) -> np.ndarray:
+        if prob_matrix.shape[1] == 2:
+            confidences = np.where(labels == 1, prob_matrix[:, 1], prob_matrix[:, 0])
+        else:
+            confidences = prob_matrix[np.arange(len(labels)), labels]
+        return confidences.astype(float, copy=False)
 
-    scores = np.concatenate(arrays)
-    membership_labels = np.concatenate(labels)
+    member_scores = _true_class_confidence(train_probs, train_labels)
+    non_member_scores = _true_class_confidence(test_probs, test_labels)
 
-    # Majority-class baseline (a random guess biased by class imbalance).
-    member_ratio = float(member_confidences.size) / float(total_samples)
-    non_member_ratio = float(non_member_confidences.size) / float(total_samples)
-    majority_accuracy = max(member_ratio, non_member_ratio)
+    scores = np.concatenate([member_scores, non_member_scores])
+    membership_labels = np.concatenate(
+        [
+            np.ones_like(member_scores, dtype=int),
+            np.zeros_like(non_member_scores, dtype=int),
+        ]
+    )
+
+    total_samples = float(scores.size)
+    member_ratio = float(member_scores.size) / total_samples
+    non_member_ratio = float(non_member_scores.size) / total_samples
+    majority_accuracy = float(max(member_ratio, non_member_ratio))
+
+    if np.unique(membership_labels).size < 2:
+        nan_value = float("nan")
+        return {
+            "attack_auc": nan_value,
+            "attack_best_threshold": nan_value,
+            "attack_best_accuracy": nan_value,
+            "attack_majority_class_accuracy": majority_accuracy,
+        }
+
+    try:
+        attack_auc = float(roc_auc_score(membership_labels, scores))
+    except ValueError:
+        attack_auc = float("nan")
 
     unique_thresholds = np.unique(scores)
-    # Evaluate two additional thresholds to cover all-member and all-non-member
-    # predictions explicitly.
     lower_extreme = np.nextafter(scores.min(), -np.inf)
     upper_extreme = np.nextafter(scores.max(), np.inf)
     candidate_thresholds = np.unique(
         np.concatenate((unique_thresholds, np.array([lower_extreme, upper_extreme])))
     )
 
-    # Vectorised evaluation of all thresholds.
     predictions = scores[None, :] >= candidate_thresholds[:, None]
     accuracies = (predictions == membership_labels).mean(axis=1)
-
     best_index = int(np.argmax(accuracies))
 
     return {
+        "attack_auc": attack_auc,
         "attack_best_threshold": float(candidate_thresholds[best_index]),
         "attack_best_accuracy": float(accuracies[best_index]),
-        "attack_majority_class_accuracy": float(majority_accuracy),
+        "attack_majority_class_accuracy": majority_accuracy,
     }

--- a/tests/test_evaluate_metrics.py
+++ b/tests/test_evaluate_metrics.py
@@ -1,22 +1,184 @@
-"""Tests for evaluation metrics utilities."""
+"""Unit tests for evaluation helpers."""
+
+from __future__ import annotations
+
+import math
 
 import numpy as np
 import pytest
 
-from suave.evaluate import simple_membership_inference
+pytest.importorskip(
+    "sklearn", reason="scikit-learn is required for evaluation metrics tests"
+)
+
+from sklearn.linear_model import LogisticRegression
+from sklearn.metrics import average_precision_score, roc_auc_score
+
+from suave.evaluate import (
+    compute_auprc,
+    compute_auroc,
+    compute_brier,
+    compute_ece,
+    evaluate_classification,
+    evaluate_trtr,
+    evaluate_tstr,
+    simple_membership_inference,
+)
+
+
+def test_evaluate_classification_binary_perfect_predictions() -> None:
+    probabilities = np.array([[0.01, 0.99], [0.98, 0.02]])
+    targets = np.array([1, 0])
+
+    metrics = evaluate_classification(probabilities, targets)
+
+    assert metrics["accuracy"] == pytest.approx(1.0)
+    assert metrics["auroc"] == pytest.approx(1.0)
+    assert metrics["auprc"] == pytest.approx(1.0)
+    assert metrics["brier"] == pytest.approx(0.00025)
+
+    confidences = np.max(probabilities, axis=1)
+    predictions = np.argmax(probabilities, axis=1)
+    bin_edges = np.linspace(0.0, 1.0, 11)
+    bin_indices = np.minimum(np.digitize(confidences, bin_edges[1:], right=True), 9)
+    expected_ece = 0.0
+    for bin_index in range(10):
+        mask = bin_indices == bin_index
+        if not np.any(mask):
+            continue
+        expected_ece += abs(
+            np.mean(confidences[mask]) - np.mean(predictions[mask] == targets[mask])
+        ) * (np.sum(mask) / len(confidences))
+
+    assert metrics["ece"] == pytest.approx(expected_ece)
+
+
+def test_metrics_handle_single_class() -> None:
+    probabilities = np.array([[0.8, 0.2], [0.7, 0.3]])
+    targets = np.array([0, 0])
+
+    metrics = evaluate_classification(probabilities, targets)
+
+    assert metrics["accuracy"] == pytest.approx(1.0)
+    assert math.isnan(metrics["auroc"])
+    assert math.isnan(metrics["auprc"])
+    assert metrics["brier"] == pytest.approx((0.2**2 + 0.3**2) / 2)
+    assert metrics["ece"] >= 0.0
+
+
+def test_metric_helpers_match_sklearn_multi_class() -> None:
+    probabilities = np.array(
+        [
+            [0.7, 0.2, 0.1],
+            [0.1, 0.8, 0.1],
+            [0.2, 0.3, 0.5],
+            [0.2, 0.2, 0.6],
+        ]
+    )
+    targets = np.array([0, 1, 2, 2])
+
+    auroc = compute_auroc(probabilities, targets)
+    auprc = compute_auprc(probabilities, targets)
+    brier = compute_brier(probabilities, targets)
+
+    expected_auroc = roc_auc_score(
+        targets, probabilities, multi_class="ovr", average="macro"
+    )
+    expected_auprc = np.mean(
+        [
+            average_precision_score((targets == idx).astype(int), probabilities[:, idx])
+            for idx in range(probabilities.shape[1])
+        ]
+    )
+    one_hot = np.eye(probabilities.shape[1])[targets]
+    expected_brier = np.mean(np.sum((probabilities - one_hot) ** 2, axis=1))
+
+    assert auroc == pytest.approx(expected_auroc)
+    assert auprc == pytest.approx(expected_auprc)
+    assert brier == pytest.approx(expected_brier)
+
+
+def test_compute_ece_known_value() -> None:
+    probabilities = np.array([[0.9, 0.1], [0.6, 0.4], [0.2, 0.8], [0.05, 0.95]])
+    targets = np.array([0, 0, 1, 1])
+
+    ece = compute_ece(probabilities, targets, n_bins=2)
+
+    # Manually compute ECE for two bins [0, 0.5), [0.5, 1.0].
+    confidences = np.max(probabilities, axis=1)
+    bin_indices = (confidences >= 0.5).astype(int)
+
+    expected = 0.0
+    for bin_index in range(2):
+        mask = bin_indices == bin_index
+        if not np.any(mask):
+            continue
+        bin_confidence = np.mean(confidences[mask])
+        bin_accuracy = np.mean(np.argmax(probabilities[mask], axis=1) == targets[mask])
+        expected += abs(bin_confidence - bin_accuracy) * (
+            np.sum(mask) / len(confidences)
+        )
+
+    assert ece == pytest.approx(expected)
+
+
+def test_evaluate_accepts_one_dimensional_probabilities() -> None:
+    probabilities = np.array([0.9, 0.2, 0.7, 0.1])
+    targets = np.array([1, 0, 1, 0])
+
+    metrics = evaluate_classification(probabilities, targets)
+
+    assert metrics["accuracy"] == pytest.approx(1.0)
+    assert metrics["brier"] == pytest.approx(np.mean((probabilities - targets) ** 2))
+
+
+def test_tstr_and_trtr_workflow() -> None:
+    X_syn = np.array([[0.0], [0.1], [1.0], [1.1]])
+    y_syn = np.array([0, 0, 1, 1])
+    X_real_train = np.array([[0.05], [0.15], [0.95], [1.05]])
+    y_real_train = np.array([0, 0, 1, 1])
+    X_real_test = np.array([[0.02], [0.12], [0.98], [1.08]])
+    y_real_test = np.array([0, 0, 1, 1])
+
+    def factory() -> LogisticRegression:
+        return LogisticRegression(max_iter=500, solver="lbfgs")
+
+    tstr_metrics = evaluate_tstr((X_syn, y_syn), (X_real_test, y_real_test), factory)
+    trtr_metrics = evaluate_trtr(
+        (X_real_train, y_real_train), (X_real_test, y_real_test), factory
+    )
+
+    assert tstr_metrics["accuracy"] >= 0.75
+    assert trtr_metrics["accuracy"] >= 0.75
+
+
+def test_simple_membership_inference_baseline() -> None:
+    train_probabilities = np.array([[0.05, 0.95], [0.15, 0.85], [0.02, 0.98]])
+    train_targets = np.array([1, 1, 1])
+    test_probabilities = np.array([[0.7, 0.3], [0.8, 0.2], [0.65, 0.35]])
+    test_targets = np.array([0, 0, 0])
+
+    results = simple_membership_inference(
+        train_probabilities, train_targets, test_probabilities, test_targets
+    )
+
+    assert results["attack_auc"] == pytest.approx(1.0)
+    assert results["attack_best_accuracy"] == pytest.approx(1.0)
+    assert results["attack_best_threshold"] == pytest.approx(0.85)
+    assert results["attack_majority_class_accuracy"] == pytest.approx(0.5)
 
 
 def test_simple_membership_inference_identical_scores_majority_accuracy() -> None:
-    """When confidences tie, the best attack should match the majority class."""
+    train_probabilities = np.full((2, 2), 0.5)
+    train_targets = np.ones(2, dtype=int)
+    test_probabilities = np.full((8, 2), 0.5)
+    test_targets = np.zeros(8, dtype=int)
 
-    member_scores = np.full(2, 0.5)
-    non_member_scores = np.full(8, 0.5)
-
-    metrics = simple_membership_inference(member_scores, non_member_scores)
-
-    majority_ratio = non_member_scores.size / (
-        member_scores.size + non_member_scores.size
+    metrics = simple_membership_inference(
+        train_probabilities, train_targets, test_probabilities, test_targets
     )
+
+    majority_ratio = test_targets.size / (train_targets.size + test_targets.size)
     assert metrics["attack_best_accuracy"] == pytest.approx(majority_ratio)
     assert metrics["attack_majority_class_accuracy"] == pytest.approx(majority_ratio)
-    assert metrics["attack_best_threshold"] > float(non_member_scores.max())
+    assert metrics["attack_best_threshold"] > float(test_probabilities[:, 0].max())

--- a/tests/test_evaluate_metrics.py
+++ b/tests/test_evaluate_metrics.py
@@ -1,0 +1,22 @@
+"""Tests for evaluation metrics utilities."""
+
+import numpy as np
+import pytest
+
+from suave.evaluate import simple_membership_inference
+
+
+def test_simple_membership_inference_identical_scores_majority_accuracy() -> None:
+    """When confidences tie, the best attack should match the majority class."""
+
+    member_scores = np.full(2, 0.5)
+    non_member_scores = np.full(8, 0.5)
+
+    metrics = simple_membership_inference(member_scores, non_member_scores)
+
+    majority_ratio = non_member_scores.size / (
+        member_scores.size + non_member_scores.size
+    )
+    assert metrics["attack_best_accuracy"] == pytest.approx(majority_ratio)
+    assert metrics["attack_majority_class_accuracy"] == pytest.approx(majority_ratio)
+    assert metrics["attack_best_threshold"] > float(non_member_scores.max())


### PR DESCRIPTION
## Summary
- extend the membership inference threshold sweep to include all-member and all-non-member predictions
- expose the best threshold, accuracy, and majority baseline from the helper
- add a regression test ensuring identical confidences fall back to the majority class

## Testing
- pytest -q
- PYTHONPATH=. pytest tests/test_evaluate_metrics.py -q
- ruff check suave/evaluate.py tests/test_evaluate_metrics.py
- black suave/evaluate.py tests/test_evaluate_metrics.py

------
https://chatgpt.com/codex/tasks/task_e_68cbde15ec348320ba4254118ed4c381