### PR TITLE
Add notebook comparing SUAVE and HI-VAE on MIMIC sample

### DIFF
--- a/examples/mimic_hivae_suave_comparison.ipynb
+++ b/examples/mimic_hivae_suave_comparison.ipynb
@@ -1,0 +1,428 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "9bd903bf",
+   "metadata": {},
+   "source": [
+    "# Comparing SUAVE (behaviour=\"hivae\") with the reference HI-VAE\n",
+    "\n",
+    "This notebook trains both implementations on the `mimic-example-1000.tsv` sample and compares their reconstructions/imputations to ensure the behaviours match."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "045b3054",
+   "metadata": {},
+   "source": [
+    "> **TensorFlow dependency**: the reference implementation in `third_party/hivae_tf` expects TensorFlow 2.x (see the bundled README). The experiments below were validated with TensorFlow 2.11 and `tensorflow-probability` 0.19."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e7cb7011",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Uncomment the following line if TensorFlow 2.11 and tensorflow-probability 0.19\n",
+    "# are not available in your environment.\n",
+    "# !pip install tensorflow==2.11.0 tensorflow-probability==0.19.0\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f627dd9c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import sys\n",
+    "import random\n",
+    "from pathlib import Path\n",
+    "\n",
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "import torch\n",
+    "import tensorflow as tf\n",
+    "\n",
+    "REPO_ROOT = Path('..').resolve()\n",
+    "sys.path.insert(0, str(REPO_ROOT))\n",
+    "sys.path.insert(0, str(REPO_ROOT / 'third_party' / 'hivae_tf'))\n",
+    "\n",
+    "from suave import SUAVE, Schema\n",
+    "from hivae import hivae as Hivae\n",
+    "\n",
+    "os.environ.setdefault('PYTHONHASHSEED', '42')\n",
+    "random.seed(42)\n",
+    "np.random.seed(42)\n",
+    "torch.manual_seed(42)\n",
+    "tf.random.set_seed(42)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c41577aa",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "DATA_PATH = Path('data/mimic-example-1000/mimic-example-1000.tsv')\n",
+    "if not DATA_PATH.exists():\n",
+    "    raise FileNotFoundError(f'Dataset not found: {DATA_PATH}')\n",
+    "\n",
+    "raw_df = pd.read_csv(DATA_PATH, sep='\t')\n",
+    "print(f'Shape: {raw_df.shape[0]} rows x {raw_df.shape[1]} columns')\n",
+    "raw_df.head()\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6b5794e9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "summary = pd.DataFrame({\n",
+    "    'dtype': raw_df.dtypes.astype(str),\n",
+    "    'n_unique': raw_df.nunique(dropna=True),\n",
+    "    'n_missing': raw_df.isna().sum(),\n",
+    "})\n",
+    "summary['missing_pct'] = summary['n_missing'] / len(raw_df) * 100.0\n",
+    "summary.sort_values('missing_pct', ascending=False)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "52d9c6c4",
+   "metadata": {},
+   "source": [
+    "The helper below proposes a schema by inspecting dtypes and value ranges. Review the output and adjust any column specifications manually if needed."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9c9dafe0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas.api.types as pdt\n",
+    "\n",
+    "\n",
+    "def infer_column_spec(series: pd.Series) -> dict[str, object]:\n",
+    "    dtype = series.dtype\n",
+    "    non_na = series.dropna()\n",
+    "    if pdt.is_bool_dtype(dtype):\n",
+    "        return {'type': 'cat', 'n_classes': 2}\n",
+    "    if pdt.is_integer_dtype(dtype):\n",
+    "        unique_values = non_na.unique()\n",
+    "        unique_count = len(unique_values)\n",
+    "        if unique_count <= 2 and set(map(int, unique_values)) <= {0, 1}:\n",
+    "            return {'type': 'cat', 'n_classes': max(unique_count, 2)}\n",
+    "        return {'type': 'real'}\n",
+    "    if pdt.is_float_dtype(dtype):\n",
+    "        return {'type': 'real'}\n",
+    "    if pdt.is_numeric_dtype(dtype):\n",
+    "        return {'type': 'real'}\n",
+    "    if non_na.empty:\n",
+    "        return {'type': 'real'}\n",
+    "    return {'type': 'cat', 'n_classes': max(int(non_na.nunique()), 2)}\n",
+    "\n",
+    "schema_dict = {column: infer_column_spec(raw_df[column]) for column in raw_df.columns}\n",
+    "\n",
+    "schema_preview = pd.DataFrame(schema_dict).T\n",
+    "schema_preview\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2600f635",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "schema = Schema(schema_dict)\n",
+    "print(f'Total features: {len(list(schema.feature_names))}')\n",
+    "\n",
+    "def schema_to_hivae_types(schema: Schema) -> list[tuple[str, str, int | None, int | None]]:\n",
+    "    types: list[tuple[str, str, int | None, int | None]] = []\n",
+    "    for column in schema.feature_names:\n",
+    "        spec = schema[column]\n",
+    "        if spec.type == 'cat':\n",
+    "            types.append((column, 'cat', spec.n_classes, spec.n_classes))\n",
+    "        elif spec.type == 'ordinal':\n",
+    "            types.append((column, 'ordinal', spec.n_classes, spec.n_classes))\n",
+    "        elif spec.type == 'real':\n",
+    "            types.append((column, 'real', 1, None))\n",
+    "        elif spec.type == 'pos':\n",
+    "            types.append((column, 'pos', 1, None))\n",
+    "        elif spec.type == 'count':\n",
+    "            types.append((column, 'count', 1, None))\n",
+    "        else:\n",
+    "            raise ValueError(f'Unsupported feature type: {spec.type}')\n",
+    "    return types\n",
+    "\n",
+    "types_list = schema_to_hivae_types(schema)\n",
+    "print(f'HI-VAE type descriptors: {len(types_list)} columns')\n",
+    "types_list[:5]\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3ee02b6f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "train_df = raw_df.sample(frac=0.8, random_state=42)\n",
+    "test_df = raw_df.drop(train_df.index)\n",
+    "train_df = train_df.reset_index(drop=True)\n",
+    "test_df = test_df.reset_index(drop=True)\n",
+    "\n",
+    "train_missing_mask = train_df.notna().astype(int)\n",
+    "test_missing_mask = test_df.notna().astype(int)\n",
+    "\n",
+    "train_df.head()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8a3a5dcf",
+   "metadata": {},
+   "source": [
+    "## Train the reference HI-VAE implementation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3efdfad2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "artifact_root = Path('artifacts') / 'mimic_hivae'\n",
+    "artifact_root.mkdir(parents=True, exist_ok=True)\n",
+    "\n",
+    "network_config = {\n",
+    "    'model_name': 'model_HIVAE_inputDropout',\n",
+    "    'dim_z': 32,\n",
+    "    'dim_y': 32,\n",
+    "    'dim_s': 32,\n",
+    "    'batch_size': 64,\n",
+    "}\n",
+    "\n",
+    "hivae_model = Hivae(\n",
+    "    types_list,\n",
+    "    network_config,\n",
+    "    results_path=str(artifact_root / 'results'),\n",
+    "    network_path=str(artifact_root / 'networks'),\n",
+    "    verbosity_level=1,\n",
+    ")\n",
+    "\n",
+    "hivae_model.fit(train_df, epochs=50, true_missing_mask=train_missing_mask)\n",
+    "(\n",
+    "    hivae_test_data,\n",
+    "    hivae_reconstructed,\n",
+    "    hivae_decoded,\n",
+    "    hivae_latent_z,\n",
+    "    hivae_latent_s,\n",
+    ") = hivae_model.predict(test_df, true_missing_mask=test_missing_mask)\n",
+    "\n",
+    "hivae_decoded_df = pd.DataFrame(hivae_decoded, columns=test_df.columns)\n",
+    "hivae_decoded_df.head()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "979a2517",
+   "metadata": {},
+   "source": [
+    "## Train SUAVE with `behaviour=\"hivae\"`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e165b7f6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "suave_model = SUAVE(\n",
+    "    schema=schema,\n",
+    "    behaviour='hivae',\n",
+    "    latent_dim=32,\n",
+    "    hidden_dims=(256, 128),\n",
+    "    dropout=0.1,\n",
+    "    learning_rate=1e-3,\n",
+    "    batch_size=64,\n",
+    "    kl_warmup_epochs=5,\n",
+    "    random_state=42,\n",
+    ")\n",
+    "\n",
+    "suave_model.fit(train_df, epochs=50, batch_size=64)\n",
+    "suave_reconstruction = suave_model.impute(test_df, only_missing=False)\n",
+    "suave_reconstruction.head()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8e3a906b",
+   "metadata": {},
+   "source": [
+    "## Align reconstructions for comparison"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5677abda",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def convert_to_numeric(\n",
+    "    suave_frame: pd.DataFrame,\n",
+    "    hivae_frame: pd.DataFrame,\n",
+    "    schema: Schema,\n",
+    ") -> tuple[pd.DataFrame, pd.DataFrame]:\n",
+    "    suave_numeric: dict[str, pd.Series] = {}\n",
+    "    hivae_numeric: dict[str, pd.Series] = {}\n",
+    "    for column in schema.feature_names:\n",
+    "        spec = schema[column]\n",
+    "        suave_series = suave_frame[column]\n",
+    "        hivae_series = hivae_frame[column]\n",
+    "        if spec.type in {'cat', 'ordinal'}:\n",
+    "            suave_codes = pd.Categorical(suave_series).codes\n",
+    "            suave_numeric[column] = pd.Series(suave_codes, index=suave_series.index)\n",
+    "            hivae_numeric[column] = pd.to_numeric(hivae_series, errors='coerce')\n",
+    "        else:\n",
+    "            suave_numeric[column] = pd.to_numeric(suave_series, errors='coerce')\n",
+    "            hivae_numeric[column] = pd.to_numeric(hivae_series, errors='coerce')\n",
+    "    suave_df = pd.DataFrame(suave_numeric)\n",
+    "    hivae_df = pd.DataFrame(hivae_numeric)\n",
+    "    return suave_df, hivae_df\n",
+    "\n",
+    "suave_numeric, hivae_numeric = convert_to_numeric(suave_reconstruction, hivae_decoded_df, schema)\n",
+    "suave_numeric.head()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e2e4a3e2",
+   "metadata": {},
+   "source": [
+    "## Quantitative comparison"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "779d326e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "numeric_metrics: list[dict[str, object]] = []\n",
+    "for column in schema.feature_names:\n",
+    "    spec = schema[column]\n",
+    "    if spec.type in {'cat', 'ordinal'}:\n",
+    "        continue\n",
+    "    suave_vals = suave_numeric[column]\n",
+    "    hivae_vals = hivae_numeric[column]\n",
+    "    diff = suave_vals - hivae_vals\n",
+    "    missing_mask = test_missing_mask[column] == 0\n",
+    "    mae_all = float(np.nanmean(np.abs(diff)))\n",
+    "    rmse_all = float(np.sqrt(np.nanmean(diff**2)))\n",
+    "    max_abs_all = float(np.nanmax(np.abs(diff))) if not np.isnan(diff).all() else np.nan\n",
+    "    if missing_mask.any():\n",
+    "        diff_missing = diff[missing_mask]\n",
+    "        mae_missing = float(np.nanmean(np.abs(diff_missing)))\n",
+    "        rmse_missing = float(np.sqrt(np.nanmean(diff_missing**2)))\n",
+    "    else:\n",
+    "        mae_missing = np.nan\n",
+    "        rmse_missing = np.nan\n",
+    "    numeric_metrics.append({\n",
+    "        'column': column,\n",
+    "        'type': spec.type,\n",
+    "        'mae_all': mae_all,\n",
+    "        'rmse_all': rmse_all,\n",
+    "        'max_abs_all': max_abs_all,\n",
+    "        'mae_missing': mae_missing,\n",
+    "        'rmse_missing': rmse_missing,\n",
+    "        'n_missing': int(missing_mask.sum()),\n",
+    "    })\n",
+    "\n",
+    "numeric_metrics_df = pd.DataFrame(numeric_metrics).sort_values('mae_all', ascending=False)\n",
+    "numeric_metrics_df.head()\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d16da6a8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "categorical_metrics: list[dict[str, object]] = []\n",
+    "for column in schema.feature_names:\n",
+    "    spec = schema[column]\n",
+    "    if spec.type not in {'cat', 'ordinal'}:\n",
+    "        continue\n",
+    "    suave_codes = pd.Categorical(suave_reconstruction[column]).codes\n",
+    "    hivae_codes = pd.to_numeric(hivae_decoded_df[column], errors='coerce')\n",
+    "    valid_mask = (~pd.isna(suave_codes)) & (~pd.isna(hivae_codes))\n",
+    "    total_valid = int(valid_mask.sum())\n",
+    "    overall_match = float((suave_codes[valid_mask] == hivae_codes[valid_mask]).mean()) if total_valid else np.nan\n",
+    "    missing_mask = (test_missing_mask[column] == 0)\n",
+    "    valid_missing = valid_mask & missing_mask\n",
+    "    valid_missing_total = int(valid_missing.sum())\n",
+    "    missing_match = float((suave_codes[valid_missing] == hivae_codes[valid_missing]).mean()) if valid_missing_total else np.nan\n",
+    "    categorical_metrics.append({\n",
+    "        'column': column,\n",
+    "        'type': spec.type,\n",
+    "        'match_rate_all': overall_match,\n",
+    "        'match_rate_missing': missing_match,\n",
+    "        'n_valid': total_valid,\n",
+    "        'n_missing': int(missing_mask.sum()),\n",
+    "        'n_valid_missing': valid_missing_total,\n",
+    "    })\n",
+    "\n",
+    "categorical_metrics_df = pd.DataFrame(categorical_metrics).sort_values('match_rate_all', ascending=True)\n",
+    "categorical_metrics_df.head()\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "288bcac8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "overall_numeric = {\n",
+    "    'mean_mae_all': float(np.nanmean(numeric_metrics_df['mae_all'])) if not numeric_metrics_df.empty else np.nan,\n",
+    "    'mean_rmse_all': float(np.nanmean(numeric_metrics_df['rmse_all'])) if not numeric_metrics_df.empty else np.nan,\n",
+    "    'mean_mae_missing': float(np.nanmean(numeric_metrics_df['mae_missing'])) if not numeric_metrics_df.empty else np.nan,\n",
+    "    'mean_rmse_missing': float(np.nanmean(numeric_metrics_df['rmse_missing'])) if not numeric_metrics_df.empty else np.nan,\n",
+    "}\n",
+    "\n",
+    "overall_categorical = {\n",
+    "    'mean_match_all': float(np.nanmean(categorical_metrics_df['match_rate_all'])) if not categorical_metrics_df.empty else np.nan,\n",
+    "    'mean_match_missing': float(np.nanmean(categorical_metrics_df['match_rate_missing'])) if not categorical_metrics_df.empty else np.nan,\n",
+    "}\n",
+    "\n",
+    "overall_numeric, overall_categorical\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0f0fdea6",
+   "metadata": {},
+   "source": [
+    "The summary above highlights how closely SUAVE (configured with `behaviour=\"hivae\"`) tracks the original HI-VAE implementation on the same train/test split. Inspect the per-column metrics to spot any variables where the reconstructions diverge meaningfully."
+   ]
+  }
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- add a Jupyter notebook under `examples/` that loads the `mimic-example-1000.tsv` sample, inspects missingness, and infers a schema shared by both models.
- train the bundled HI-VAE reference and SUAVE (behaviour="hivae") on matched splits, then collate reconstruction metrics to compare their outputs.

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cc00bbfe0083208365fecbcd9ab550