### PR TITLE
Align HI-VAE prior with TensorFlow reference

### DIFF
--- a/suave/model.py
+++ b/suave/model.py
@@ -27,6 +27,7 @@ from .modules.decoder import Decoder
 from .modules.encoder import EncoderMLP
 from .modules.heads import ClassificationHead
 from .modules import losses
+from .modules.prior import PriorMean
 from . import sampling as sampling_utils
 from .types import Schema
 
@@ -148,39 +149,94 @@ class SUAVE:
         self._train_component_mu: Tensor | None = None
         self._train_component_logvar: Tensor | None = None
         self._train_component_probs: Tensor | None = None
+        self._prior_mean_layer: PriorMean | None = None
 
         self._reset_prior_parameters()
 
     def _reset_prior_parameters(self) -> None:
         """Initialise trainable tensors for the mixture prior parameters."""
 
-        self._prior_component_logits = Parameter(
-            torch.zeros(self.n_components, dtype=torch.float32)
-        )
-        self._prior_component_mu = Parameter(
-            torch.zeros(self.n_components, self.latent_dim, dtype=torch.float32)
-        )
-        self._prior_component_logvar = Parameter(
-            torch.zeros(self.n_components, self.latent_dim, dtype=torch.float32)
-        )
+        if self.behaviour == "hivae":
+            self._prior_component_logits = Parameter(
+                torch.zeros(self.n_components, dtype=torch.float32),
+                requires_grad=False,
+            )
+            self._prior_component_mu = None
+            self._prior_component_logvar = Parameter(
+                torch.zeros(self.n_components, self.latent_dim, dtype=torch.float32),
+                requires_grad=False,
+            )
+            self._prior_mean_layer = PriorMean(self.n_components, self.latent_dim)
+        else:
+            self._prior_component_logits = Parameter(
+                torch.zeros(self.n_components, dtype=torch.float32)
+            )
+            self._prior_component_mu = Parameter(
+                torch.zeros(self.n_components, self.latent_dim, dtype=torch.float32)
+            )
+            self._prior_component_logvar = Parameter(
+                torch.zeros(self.n_components, self.latent_dim, dtype=torch.float32)
+            )
+            self._prior_mean_layer = None
 
     def _move_prior_parameters_to_device(self, device: torch.device) -> None:
         """Ensure mixture prior parameters live on ``device`` as trainable tensors."""
 
-        for name in (
-            "_prior_component_logits",
-            "_prior_component_mu",
-            "_prior_component_logvar",
+        def _wrap(tensor: Tensor | Parameter | None) -> Parameter | None:
+            if tensor is None:
+                return None
+            requires_grad = bool(getattr(tensor, "requires_grad", False))
+            data = tensor.detach().to(device=device, dtype=torch.float32)
+            return Parameter(data, requires_grad=requires_grad)
+
+        self._prior_component_logits = _wrap(self._prior_component_logits)
+        self._prior_component_logvar = _wrap(self._prior_component_logvar)
+        if self._prior_component_mu is not None:
+            self._prior_component_mu = _wrap(self._prior_component_mu)
+        if self._prior_mean_layer is not None:
+            self._prior_mean_layer.to(device)
+
+    def _prior_parameters_for_optimizer(self) -> list[Parameter]:
+        """Return the list of trainable prior parameters."""
+
+        if self.behaviour == "hivae":
+            if self._prior_mean_layer is None:
+                raise RuntimeError("Prior mean layer is not initialised")
+            return list(self._prior_mean_layer.parameters())
+        params: list[Parameter] = []
+        for param in (
+            self._prior_component_logits,
+            self._prior_component_mu,
+            self._prior_component_logvar,
         ):
-            tensor = getattr(self, name)
-            if not isinstance(tensor, Parameter):
-                tensor = Parameter(tensor)
-            if tensor.device != device:
-                tensor = Parameter(
-                    tensor.detach().to(device=device, dtype=torch.float32),
-                    requires_grad=True,
-                )
-            setattr(self, name, tensor)
+            if isinstance(param, Parameter):
+                params.append(param)
+        return params
+
+    def _prior_component_logits_tensor(self) -> Tensor:
+        """Return the tensor of prior logits on the active device."""
+
+        if self._prior_component_logits is None:
+            raise RuntimeError("Prior logits are not initialised")
+        return self._prior_component_logits
+
+    def _prior_component_means_tensor(self) -> Tensor:
+        """Return the matrix of prior means for each mixture component."""
+
+        if self.behaviour == "hivae":
+            if self._prior_mean_layer is None:
+                raise RuntimeError("Prior mean layer is not initialised")
+            return self._prior_mean_layer.component_means()
+        if self._prior_component_mu is None:
+            raise RuntimeError("Prior component means are not initialised")
+        return self._prior_component_mu
+
+    def _prior_component_logvar_tensor(self) -> Tensor:
+        """Return the diagonal log-variance of the prior distribution."""
+
+        if self._prior_component_logvar is None:
+            raise RuntimeError("Prior log-variance is not initialised")
+        return self._prior_component_logvar
 
     # ------------------------------------------------------------------
     # Training utilities
@@ -326,13 +382,7 @@ class SUAVE:
             self._classifier = None
         parameters = list(self._encoder.parameters())
         parameters.extend(self._decoder.parameters())
-        parameters.extend(
-            [
-                self._prior_component_logits,
-                self._prior_component_mu,
-                self._prior_component_logvar,
-            ]
-        )
+        parameters.extend(self._prior_parameters_for_optimizer())
         if self._classifier is not None:
             parameters.extend(self._classifier.parameters())
         optimizer = Adam(parameters, lr=self.learning_rate)
@@ -386,13 +436,13 @@ class SUAVE:
                 global_step += 1
                 beta_scale = losses.kl_warmup(global_step, warmup_steps, self.beta)
                 categorical_kl = losses.kl_categorical(
-                    component_logits, self._prior_component_logits
+                    component_logits, self._prior_component_logits_tensor()
                 )
                 gaussian_kl = losses.kl_normal_mixture(
                     component_mu,
                     component_logvar,
-                    self._prior_component_mu,
-                    self._prior_component_logvar,
+                    self._prior_component_means_tensor(),
+                    self._prior_component_logvar_tensor(),
                     posterior_probs,
                 )
                 total_kl = beta_scale * (categorical_kl + gaussian_kl)
@@ -642,9 +692,9 @@ class SUAVE:
         if conditional:
             return self._draw_conditional_latents(n_samples, targets, device)
         latents, _ = sampling_utils.sample_mixture_latents(
-            self._prior_component_logits.detach(),
-            self._prior_component_mu.detach(),
-            self._prior_component_logvar.detach(),
+            self._prior_component_logits_tensor().detach(),
+            self._prior_component_means_tensor().detach(),
+            self._prior_component_logvar_tensor().detach(),
             n_samples,
             device=device,
         )
@@ -1242,16 +1292,24 @@ class SUAVE:
                 "use_weight": use_weight,
                 "class_weight": class_weight,
             }
+        prior_state: dict[str, Any] = {
+            "logits": self._prior_component_logits_tensor().detach().cpu(),
+            "logvar": self._prior_component_logvar_tensor().detach().cpu(),
+        }
+        if self.behaviour == "hivae":
+            if self._prior_mean_layer is None:
+                raise RuntimeError("Prior mean layer is not initialised")
+            prior_state["mean_state_dict"] = self._state_dict_to_cpu(
+                self._prior_mean_layer
+            )
+        else:
+            prior_state["mu"] = self._prior_component_means_tensor().detach().cpu()
         modules = {
             "encoder": self._state_dict_to_cpu(self._encoder),
             "decoder": self._state_dict_to_cpu(self._decoder),
             "classifier": classifier_state,
             "temperature_scaler": self._temperature_scaler.state_dict(),
-            "prior": {
-                "logits": self._prior_component_logits.detach().cpu(),
-                "mu": self._prior_component_mu.detach().cpu(),
-                "logvar": self._prior_component_logvar.detach().cpu(),
-            },
+            "prior": prior_state,
         }
         artefacts: dict[str, Any] = {
             "classes": self._classes,
@@ -1432,22 +1490,60 @@ class SUAVE:
         model._is_calibrated = bool(temperature_state.get("fitted", False))
 
         model._move_prior_parameters_to_device(device)
-        for attr, key in (
-            ("_prior_component_logits", "logits"),
-            ("_prior_component_mu", "mu"),
-            ("_prior_component_logvar", "logvar"),
-        ):
-            value = prior_state.get(key)
-            if value is None:
-                continue
-            tensor = torch.as_tensor(value, dtype=torch.float32, device=device)
-            param = getattr(model, attr)
-            if tensor.shape != param.data.shape:
+        logits_value = prior_state.get("logits")
+        if logits_value is not None:
+            logits_tensor = torch.as_tensor(
+                logits_value, dtype=torch.float32, device=device
+            )
+            param = model._prior_component_logits_tensor()
+            if logits_tensor.shape != param.shape:
                 raise ValueError(
-                    f"Saved prior tensor '{key}' has shape {tensor.shape} which does not match the model configuration {param.data.shape}"
+                    "Saved prior logits do not match the model configuration"
                 )
             with torch.no_grad():
-                param.copy_(tensor)
+                param.copy_(logits_tensor)
+        logvar_value = prior_state.get("logvar")
+        if logvar_value is not None:
+            logvar_tensor = torch.as_tensor(
+                logvar_value, dtype=torch.float32, device=device
+            )
+            param_logvar = model._prior_component_logvar_tensor()
+            if logvar_tensor.shape != param_logvar.shape:
+                raise ValueError(
+                    "Saved prior log-variance does not match the model configuration"
+                )
+            with torch.no_grad():
+                param_logvar.copy_(logvar_tensor)
+        if model.behaviour == "hivae":
+            if model._prior_mean_layer is None:
+                raise RuntimeError("Prior mean layer is not initialised")
+            mean_state = prior_state.get("mean_state_dict")
+            if mean_state is not None:
+                state = (
+                    mean_state
+                    if isinstance(mean_state, OrderedDict)
+                    else OrderedDict(mean_state)
+                )
+                model._prior_mean_layer.load_state_dict(state)
+            else:
+                mu_value = prior_state.get("mu")
+                if mu_value is not None:
+                    means_tensor = torch.as_tensor(
+                        mu_value, dtype=torch.float32, device=device
+                    )
+                    model._prior_mean_layer.load_component_means(means_tensor)
+        else:
+            mu_value = prior_state.get("mu")
+            if mu_value is not None and model._prior_component_mu is not None:
+                mu_tensor = torch.as_tensor(
+                    mu_value, dtype=torch.float32, device=device
+                )
+                if mu_tensor.shape != model._prior_component_mu.shape:
+                    raise ValueError(
+                        "Saved prior means do not match the model configuration"
+                    )
+                with torch.no_grad():
+                    model._prior_component_mu.copy_(mu_tensor)
 
         model._is_fitted = True
         return model
@@ -1491,28 +1587,35 @@ class SUAVE:
             logvar_state = prior_state.get("logvar")
             if logits_state is not None:
                 logits_tensor = torch.tensor(logits_state, dtype=torch.float32)
-                if logits_tensor.shape != model._prior_component_logits.shape:
+                logits_param = model._prior_component_logits_tensor()
+                if logits_tensor.shape != logits_param.shape:
                     raise ValueError(
                         "Saved prior logits do not match the model configuration"
                     )
                 with torch.no_grad():
-                    model._prior_component_logits.copy_(logits_tensor)
-            if mu_state is not None:
-                mu_tensor = torch.tensor(mu_state, dtype=torch.float32)
-                if mu_tensor.shape != model._prior_component_mu.shape:
-                    raise ValueError(
-                        "Saved prior means do not match the model configuration"
-                    )
-                with torch.no_grad():
-                    model._prior_component_mu.copy_(mu_tensor)
+                    logits_param.copy_(logits_tensor)
             if logvar_state is not None:
                 logvar_tensor = torch.tensor(logvar_state, dtype=torch.float32)
-                if logvar_tensor.shape != model._prior_component_logvar.shape:
+                logvar_param = model._prior_component_logvar_tensor()
+                if logvar_tensor.shape != logvar_param.shape:
                     raise ValueError(
                         "Saved prior log-variances do not match the model configuration"
                     )
                 with torch.no_grad():
-                    model._prior_component_logvar.copy_(logvar_tensor)
+                    logvar_param.copy_(logvar_tensor)
+            if mu_state is not None:
+                mu_tensor = torch.tensor(mu_state, dtype=torch.float32)
+                if model.behaviour == "hivae":
+                    if model._prior_mean_layer is None:
+                        raise RuntimeError("Prior mean layer is not initialised")
+                    model._prior_mean_layer.load_component_means(mu_tensor)
+                elif model._prior_component_mu is not None:
+                    if mu_tensor.shape != model._prior_component_mu.shape:
+                        raise ValueError(
+                            "Saved prior means do not match the model configuration"
+                        )
+                    with torch.no_grad():
+                        model._prior_component_mu.copy_(mu_tensor)
         return model
 
     @staticmethod

--- a/suave/modules/prior.py
+++ b/suave/modules/prior.py
@@ -1,0 +1,51 @@
+"""Prior modules defining HI-VAE specific parameterisations."""
+
+from __future__ import annotations
+
+import torch
+from torch import Tensor, nn
+
+
+class PriorMean(nn.Module):
+    """Linear layer producing component-wise Gaussian means from assignments."""
+
+    def __init__(self, n_components: int, latent_dim: int) -> None:
+        super().__init__()
+        if n_components <= 0:
+            raise ValueError("n_components must be positive")
+        if latent_dim <= 0:
+            raise ValueError("latent_dim must be positive")
+        self.n_components = int(n_components)
+        self.latent_dim = int(latent_dim)
+        self.linear = nn.Linear(self.n_components, self.latent_dim)
+        nn.init.zeros_(self.linear.weight)
+        nn.init.zeros_(self.linear.bias)
+
+    def forward(self, assignments: Tensor) -> Tensor:
+        """Return the Gaussian means associated with ``assignments``."""
+
+        if assignments.size(-1) != self.n_components:
+            raise ValueError("assignments must have dimension matching n_components")
+        return self.linear(assignments)
+
+    def component_means(self) -> Tensor:
+        r"""Return the mean of :math:`p(z \mid s)` for each mixture component."""
+
+        eye = torch.eye(
+            self.n_components,
+            dtype=self.linear.weight.dtype,
+            device=self.linear.weight.device,
+        )
+        return self.forward(eye)
+
+    def load_component_means(self, means: Tensor) -> None:
+        """Initialise the linear layer so that components map to ``means``."""
+
+        if means.shape != (self.n_components, self.latent_dim):
+            raise ValueError("means must have shape (n_components, latent_dim)")
+        means = means.to(
+            dtype=self.linear.weight.dtype, device=self.linear.weight.device
+        )
+        with torch.no_grad():
+            self.linear.bias.zero_()
+            self.linear.weight.copy_(means.t())

--- a/tests/test_third_party_alignment.py
+++ b/tests/test_third_party_alignment.py
@@ -7,7 +7,9 @@ import math
 import numpy as np
 import torch
 
+from suave.modules import losses
 from suave.modules.decoder import CatHead, CountHead, OrdinalHead, PosHead, RealHead
+from suave.modules.prior import PriorMean
 
 
 def _softplus(x: np.ndarray) -> np.ndarray:
@@ -112,10 +114,13 @@ def _ordinal_probabilities(
     sigmoid = 1.0 / (1.0 + np.exp(-logits))
     probs = np.concatenate(
         [sigmoid, np.ones_like(sigmoid[..., :1])], axis=-1
-    ) - np.concatenate([
-        np.zeros_like(sigmoid[..., :1]),
-        sigmoid,
-    ], axis=-1)
+    ) - np.concatenate(
+        [
+            np.zeros_like(sigmoid[..., :1]),
+            sigmoid,
+        ],
+        axis=-1,
+    )
     probs = np.clip(probs, a_min=eps, a_max=1.0)
     return probs, thresholds
 
@@ -180,6 +185,53 @@ def test_real_head_matches_third_party_formulation() -> None:
         atol=1e-5,
         rtol=1e-4,
     )
+
+
+def test_categorical_kl_matches_tensorflow_formula() -> None:
+    rng = np.random.default_rng(11)
+    batch = 6
+    n_components = 4
+
+    logits = torch.from_numpy(rng.normal(size=(batch, n_components)).astype(np.float32))
+    prior_logits = torch.zeros(n_components)
+    kl = losses.kl_categorical(logits, prior_logits)
+
+    probs = torch.softmax(logits, dim=-1).numpy()
+    safe_probs = np.clip(probs, a_min=1e-6, a_max=None)
+    expected = np.log(float(n_components)) + np.sum(probs * np.log(safe_probs), axis=-1)
+    torch.testing.assert_close(
+        kl, torch.from_numpy(expected.astype(np.float32)), atol=1e-5, rtol=1e-5
+    )
+
+
+def test_gaussian_kl_matches_tensorflow_formula() -> None:
+    rng = np.random.default_rng(17)
+    batch, n_components, latent_dim = 5, 3, 4
+
+    logits = torch.from_numpy(rng.normal(size=(batch, n_components)).astype(np.float32))
+    posterior_probs = torch.softmax(logits, dim=-1)
+    mu_q = torch.from_numpy(
+        rng.normal(size=(batch, n_components, latent_dim)).astype(np.float32)
+    )
+    logvar_q = torch.from_numpy(
+        rng.normal(size=(batch, n_components, latent_dim)).astype(np.float32)
+    )
+
+    prior = PriorMean(n_components, latent_dim)
+    means = torch.from_numpy(
+        rng.normal(scale=0.05, size=(n_components, latent_dim)).astype(np.float32)
+    )
+    prior.load_component_means(means)
+    mu_p = prior.component_means()
+    logvar_p = torch.zeros_like(mu_p)
+
+    kl = losses.kl_normal_mixture(mu_q, logvar_q, mu_p, logvar_p, posterior_probs)
+
+    var_q = torch.exp(logvar_q)
+    diff = mu_q - mu_p.unsqueeze(0)
+    component_kl = 0.5 * (var_q + diff.pow(2) - logvar_q - 1.0).sum(dim=-1)
+    expected = (posterior_probs * component_kl).sum(dim=-1)
+    torch.testing.assert_close(kl, expected, atol=1e-5, rtol=1e-5)
 
 
 def test_categorical_head_matches_third_party_formulation() -> None:
@@ -280,9 +332,7 @@ def test_count_head_matches_third_party_formulation() -> None:
     )
 
     missing_mask = 1.0 - mask
-    expected_missing = _poisson_log_likelihood(
-        x_log, missing_mask, rate_raw, offset
-    )
+    expected_missing = _poisson_log_likelihood(x_log, missing_mask, rate_raw, offset)
     torch.testing.assert_close(
         output["log_px_missing"],
         torch.from_numpy(expected_missing),


### PR DESCRIPTION
## Summary
- introduce a PriorMean linear module and freeze logits/log-variance when behaviour="hivae" to match the TensorFlow HI-VAE prior
- wire the new prior through optimisation, sampling, and serialisation so unit-variance mixtures are used and mean parameters stay consistent when saving/loading
- add KL divergence alignment tests ensuring the categorical and Gaussian terms reproduce the reference TensorFlow formulas

## Testing
- pytest -q
- ruff check suave tests

------
https://chatgpt.com/codex/tasks/task_e_68cc0e10336c8320a9e3bc4dde41fd09