### PR TITLE
Guard classifier APIs in HI-VAE mode

### DIFF
--- a/suave/model.py
+++ b/suave/model.py
@@ -1303,7 +1303,10 @@ class SUAVE:
         self._ensure_classifier_available("predict_proba")
         if not self._is_fitted or self._classes is None:
             raise RuntimeError("Model must be fitted before calling predict_proba")
-        logits = self._compute_logits(X)
+        _ = self._compute_logits(X)
+        if self._cached_logits is None:
+            raise RuntimeError("Logits cache was not populated")
+        logits = self._cached_logits
         if self._is_calibrated:
             logits = self._temperature_scaler.transform(logits)
         probabilities = self._logits_to_probabilities(logits)

--- a/tests/test_minimal.py
+++ b/tests/test_minimal.py
@@ -134,13 +134,21 @@ def test_save_load_predict_round_trip(tmp_path: Path):
 
 
 def test_hivae_behaviour_disables_classifier():
-    X, _, schema = make_dataset()
+    X, y, schema = make_dataset()
     model = SUAVE(schema=schema, behaviour="hivae", n_components=2)
     model.fit(X, epochs=1)
     latent = model.encode(X)
     assert latent.shape[0] == len(X)
     with pytest.raises(RuntimeError):
+        model._ensure_classifier_available("test")
+    with pytest.raises(RuntimeError):
+        model._compute_logits(X)
+    with pytest.raises(RuntimeError):
         model.predict_proba(X)
+    with pytest.raises(RuntimeError):
+        model.predict(X)
+    with pytest.raises(RuntimeError):
+        model.calibrate(X, y)
 
 
 def test_hivae_behaviour_persists_after_save(tmp_path: Path):


### PR DESCRIPTION
## Summary
- ensure HI-VAE behaviour raises when classifier-specific helpers are accessed
- route `predict_proba` through the cached logits before applying optional temperature scaling
- extend the HI-VAE behaviour test to cover all classifier entry points

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d00ef305ac8320ab6e034a76796147