### PR TITLE
Improve classifier caching and head regularisation

### DIFF
--- a/tests/test_calibration.py
+++ b/tests/test_calibration.py
@@ -55,11 +55,16 @@ class DummySUAVE(SUAVE):
     def set_logits(self, frame: pd.DataFrame, logits: np.ndarray) -> None:
         self._logit_lookup[id(frame)] = logits
 
-    def _compute_logits(self, X: pd.DataFrame) -> np.ndarray:  # type: ignore[override]
+    def _compute_logits(
+        self, X: pd.DataFrame, *, cache_key: str | None = None
+    ) -> np.ndarray:  # type: ignore[override]
         logits = self._logit_lookup.get(id(X))
         if logits is None:
             raise KeyError("Logits for the provided frame are not registered")
         self._cached_logits = logits
+        self._cached_probabilities = None
+        self._logits_cache_key = cache_key
+        self._probability_cache_key = None
         return logits
 
 


### PR DESCRIPTION
## Summary
- add configurable dropout regularisation to the latent classification head
- make classifier inference cache-aware with data fingerprints and propagate cache metadata through save/load
- extend unit tests to exercise the new caching behaviour and ensure HI-VAE mode clears stale classifier caches

## Testing
- `pytest -q`
- `ruff check suave/modules/heads.py suave/model.py tests/test_minimal.py tests/test_calibration.py`
- `black --check suave/modules/heads.py suave/model.py tests/test_minimal.py tests/test_calibration.py`


------
https://chatgpt.com/codex/tasks/task_e_68d033223d0083208f9f500d7721b710