### PR TITLE
Add tests covering SUAVE save/load payload and legacy loader

### DIFF
--- a/tests/test_minimal.py
+++ b/tests/test_minimal.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from pathlib import Path
 import sys
 from unittest.mock import patch
@@ -32,6 +33,62 @@ def make_dataset() -> tuple[pd.DataFrame, pd.Series, Schema]:
         }
     )
     return X, y, schema
+
+
+def _serialise_for_legacy(value):
+    if isinstance(value, torch.Tensor):
+        value = value.detach().cpu()
+        if value.ndim == 0:
+            return value.item()
+        return value.tolist()
+    if isinstance(value, np.ndarray):
+        return value.tolist()
+    if isinstance(value, (np.generic,)):
+        return value.item()
+    if isinstance(value, dict):
+        return {key: _serialise_for_legacy(val) for key, val in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_serialise_for_legacy(item) for item in value]
+    return value
+
+
+def _build_legacy_payload(payload: dict) -> dict:
+    metadata = payload.get("metadata", {})
+    modules = payload.get("modules", {})
+    artefacts = payload.get("artefacts", {})
+
+    legacy = {
+        "schema": metadata.get("schema"),
+        "behaviour": metadata.get("behaviour"),
+        "latent_dim": metadata.get("latent_dim"),
+        "n_components": metadata.get("n_components"),
+        "hidden_dims": metadata.get("hidden_dims"),
+        "dropout": metadata.get("dropout"),
+        "learning_rate": metadata.get("learning_rate"),
+        "batch_size": metadata.get("batch_size"),
+        "kl_warmup_epochs": metadata.get("kl_warmup_epochs"),
+        "val_split": metadata.get("val_split"),
+        "stratify": metadata.get("stratify"),
+        "random_state": metadata.get("random_state"),
+        "tau_start": metadata.get("tau_start"),
+        "tau_min": metadata.get("tau_min"),
+        "tau_decay": metadata.get("tau_decay"),
+        "inference_tau": metadata.get("inference_tau"),
+        "modules": _serialise_for_legacy(modules),
+        "artefacts": _serialise_for_legacy(artefacts),
+    }
+
+    if "prior" not in legacy and "prior" in legacy["modules"]:
+        legacy["prior"] = legacy["modules"]["prior"]
+
+    classes = legacy["artefacts"].get("classes")
+    if classes is not None:
+        legacy["classes"] = classes
+    class_to_index = legacy["artefacts"].get("class_to_index")
+    if class_to_index is not None:
+        legacy["class_to_index"] = class_to_index
+
+    return legacy
 
 
 def test_package_importable():
@@ -119,11 +176,39 @@ def test_save_load_predict_round_trip(tmp_path: Path):
     model.fit(X, y, epochs=1)
     model.calibrate(X, y)
     expected_probabilities = model.predict_proba(X)
+    expected_logits = model._cached_logits.copy()
     expected_latents = model.encode(X)
+    scaler_state = model._temperature_scaler_state.copy() if model._temperature_scaler_state else None
+    tensor_attrs = [
+        "_train_latent_mu",
+        "_train_latent_logvar",
+        "_train_component_logits",
+        "_train_component_mu",
+        "_train_component_logvar",
+        "_train_component_probs",
+    ]
+    tensor_snapshots = {
+        attr: getattr(model, attr).clone().detach() if getattr(model, attr) is not None else None
+        for attr in tensor_attrs
+    }
+    target_indices_snapshot = None
+    if model._train_target_indices is not None:
+        target_indices_snapshot = model._train_target_indices.copy()
     save_path = tmp_path / "model.pt"
     model.save(save_path)
 
     reloaded = SUAVE.load(save_path)
+    assert reloaded.behaviour == "suave"
+    assert reloaded._classifier is not None
+    assert reloaded._is_calibrated is True
+    assert reloaded._temperature_scaler_state is not None
+    if scaler_state is not None:
+        assert reloaded._temperature_scaler_state["fitted"] is scaler_state["fitted"]
+        assert reloaded._temperature_scaler_state["temperature"] == pytest.approx(
+            scaler_state["temperature"]
+        )
+    np.testing.assert_allclose(expected_logits, reloaded._cached_logits)
+    np.testing.assert_allclose(expected_probabilities, reloaded._cached_probabilities)
     reloaded_probabilities = reloaded.predict_proba(X)
     np.testing.assert_allclose(expected_probabilities, reloaded_probabilities)
     np.testing.assert_allclose(expected_latents, reloaded.encode(X))
@@ -131,6 +216,48 @@ def test_save_load_predict_round_trip(tmp_path: Path):
     assert isinstance(samples, pd.DataFrame)
     assert list(samples.columns) == list(schema.feature_names)
     assert len(samples) == 2
+    if target_indices_snapshot is not None:
+        np.testing.assert_array_equal(
+            target_indices_snapshot, reloaded._train_target_indices
+        )
+    for attr, snapshot in tensor_snapshots.items():
+        loaded_value = getattr(reloaded, attr)
+        if snapshot is None:
+            assert loaded_value is None
+        else:
+            assert loaded_value is not None
+            assert torch.allclose(loaded_value, snapshot)
+
+
+def test_save_payload_contains_classifier_temperature_and_prior(tmp_path: Path):
+    X, y, schema = make_dataset()
+    model = SUAVE(schema=schema, latent_dim=4, batch_size=2, n_components=2)
+    model.fit(X, y, epochs=1)
+    model.calibrate(X, y)
+    expected_logits = model._cached_logits.copy()
+    expected_probabilities = model._cached_probabilities.copy()
+    save_path = tmp_path / "payload.pt"
+    model.save(save_path)
+
+    payload = torch.load(save_path, map_location="cpu")
+    metadata = payload["metadata"]
+    assert metadata["behaviour"] == "suave"
+    modules = payload["modules"]
+    classifier_payload = modules["classifier"]
+    assert classifier_payload is not None
+    assert classifier_payload["state_dict"]
+    assert "linear.weight" in classifier_payload["state_dict"]
+    assert modules["temperature_scaler"]["fitted"] is True
+    prior_state = modules["prior"]
+    for key in ("logits", "logvar", "mu"):
+        assert key in prior_state
+        assert isinstance(prior_state[key], torch.Tensor)
+    artefacts = payload["artefacts"]
+    assert artefacts["is_calibrated"] is True
+    np.testing.assert_allclose(artefacts["cached_logits"], expected_logits)
+    np.testing.assert_allclose(
+        artefacts["cached_probabilities"], expected_probabilities
+    )
 
 
 def test_hivae_behaviour_disables_classifier():
@@ -161,6 +288,8 @@ def test_hivae_behaviour_persists_after_save(tmp_path: Path):
     loaded = SUAVE.load(save_path)
     assert loaded.behaviour == "hivae"
     assert loaded._inference_tau == pytest.approx(trained_tau)
+    assert loaded._classifier is None
+    assert loaded._cached_logits is None
     with pytest.raises(RuntimeError):
         loaded.predict_proba(X)
 
@@ -286,3 +415,48 @@ def test_hivae_impute_assignment_modes_route_expected_weights():
         torch.ones(assignments_sample.size(0)),
         atol=1e-6,
     )
+
+
+def test_legacy_loader_respects_behaviour_modes(tmp_path: Path):
+    X, y, schema = make_dataset()
+
+    suave_model = SUAVE(schema=schema, latent_dim=4, batch_size=2, n_components=2)
+    suave_model.fit(X, y, epochs=1)
+    suave_model.calibrate(X, y)
+    expected_suave_probs = suave_model.predict_proba(X)
+    expected_suave_logits = suave_model._cached_logits.copy()
+    expected_suave_latents = suave_model.encode(X)
+    modern_suave_path = tmp_path / "modern_suave.pt"
+    suave_model.save(modern_suave_path)
+    suave_payload = torch.load(modern_suave_path, map_location="cpu")
+    legacy_suave = _build_legacy_payload(suave_payload)
+    legacy_suave_path = tmp_path / "legacy_suave.json"
+    legacy_suave_path.write_text(json.dumps(legacy_suave))
+    loaded_suave = SUAVE.load(legacy_suave_path)
+    assert loaded_suave.behaviour == "suave"
+    assert loaded_suave._classifier is not None
+    np.testing.assert_allclose(expected_suave_logits, loaded_suave._cached_logits)
+    np.testing.assert_allclose(
+        expected_suave_probs, loaded_suave._cached_probabilities
+    )
+    np.testing.assert_allclose(expected_suave_latents, loaded_suave.encode(X))
+    np.testing.assert_allclose(expected_suave_probs, loaded_suave.predict_proba(X))
+
+    hivae_model = SUAVE(
+        schema=schema, behaviour="hivae", latent_dim=4, batch_size=2, n_components=2
+    )
+    hivae_model.fit(X, epochs=1)
+    expected_hivae_latents = hivae_model.encode(X)
+    modern_hivae_path = tmp_path / "modern_hivae.pt"
+    hivae_model.save(modern_hivae_path)
+    hivae_payload = torch.load(modern_hivae_path, map_location="cpu")
+    legacy_hivae = _build_legacy_payload(hivae_payload)
+    legacy_hivae_path = tmp_path / "legacy_hivae.json"
+    legacy_hivae_path.write_text(json.dumps(legacy_hivae))
+    loaded_hivae = SUAVE.load(legacy_hivae_path)
+    assert loaded_hivae.behaviour == "hivae"
+    assert loaded_hivae._classifier is None
+    assert loaded_hivae._cached_logits is None
+    np.testing.assert_allclose(expected_hivae_latents, loaded_hivae.encode(X))
+    with pytest.raises(RuntimeError):
+        loaded_hivae.predict_proba(X)


### PR DESCRIPTION
## Summary
- add helpers to serialise saved payloads into the legacy JSON format for regression coverage
- extend save/load round-trip tests to assert classifier caches, calibration state, and prior parameters persist
- exercise legacy loader paths for suave and hivae behaviours to confirm classifiers are restored or ignored appropriately

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d0336fc4448320bdb024878c35ca64