### PR TITLE
Refresh docstrings to reflect integrated SUAVE context

### DIFF
--- a/suave/model.py
+++ b/suave/model.py
@@ -103,16 +103,16 @@ class SUAVE:
         straight-through Gumbel-Softmax estimator. Default is ``1.0``.
     behaviour:
         Selects the feature set exposed by the estimator. Use ``"supervised"`` to
-        enable the extended classification stack or ``"unsupervised"`` to mirror the
-        lightweight generative-only branch.
+        enable the extended classification stack or ``"unsupervised"`` for the
+        generative-only workflow.
     tau_start:
         Initial temperature for the Gumbel-Softmax component sampler when
-        ``behaviour="unsupervised"``. Default is ``1.0`` to mirror the legacy
-        TensorFlow reference implementation.
+        ``behaviour="unsupervised"``. Default is ``1.0`` which offers a stable
+        starting point for mixture exploration.
     tau_min:
         Minimum temperature reached after annealing when
-        ``behaviour="unsupervised"``. Default is ``1e-3`` which corresponds to the
-        evaluation phase of the original unsupervised experiments.
+        ``behaviour="unsupervised"``. Default is ``1e-3`` so the sampler becomes
+        nearly deterministic by the end of training.
     tau_decay:
         Linear decay applied to the temperature at each epoch when
         ``behaviour="unsupervised"``. Default is ``0.01`` so that the temperature
@@ -2331,8 +2331,8 @@ class SUAVE:
             self._logits_cache_key = None
             self._probability_cache_key = None
             raise RuntimeError(
-                f"{caller} is unavailable when behaviour='unsupervised'; this mode matches "
-                "the baseline unsupervised branch and does not expose classifier outputs."
+                f"{caller} is unavailable when behaviour='unsupervised'; this mode focuses "
+                "on generative modelling and does not expose classifier outputs."
             )
 
     def _compute_logits(

--- a/suave/modules/calibrate.py
+++ b/suave/modules/calibrate.py
@@ -18,9 +18,8 @@ class TemperatureScaler:
 
     The scaler keeps track of the learnt temperature parameter and exposes a
     small ``state_dict`` API so that callers can persist and restore the
-    calibration state.  The implementation mirrors the legacy TensorFlow
-    reference stored under ``third_party/hivae_tf`` while using native PyTorch
-    optimisation utilities.
+    calibration state.  The implementation relies purely on native PyTorch
+    optimisation utilities and is shared across the broader SUAVE package.
     """
 
     temperature: float = 1.0

--- a/suave/modules/decoder.py
+++ b/suave/modules/decoder.py
@@ -54,7 +54,7 @@ def _apply_observed_linear(
 
 
 class RealHead(LikelihoodHead):
-    """Gaussian reconstruction head mirroring the legacy unsupervised design."""
+    """Gaussian reconstruction head for real-valued features in SUAVE."""
 
     def __init__(self, y_dim: int, n_components: int) -> None:
         super().__init__(y_dim, n_components)

--- a/suave/modules/distributions.py
+++ b/suave/modules/distributions.py
@@ -1,8 +1,8 @@
-"""Distribution helpers mirroring the legacy TensorFlow unsupervised implementation.
+"""Distribution helpers shared by the SUAVE decoder components.
 
-The original unsupervised code expresses reconstruction terms for every column type
-in terms of log-likelihoods under the corresponding distribution.  This module
-contains the PyTorch equivalents that are shared by the decoder heads.
+The generative module expresses reconstruction terms for every column type in
+terms of log-likelihoods under the corresponding distribution.  This module
+contains the PyTorch utilities used across the decoder heads.
 """
 
 from __future__ import annotations
@@ -81,7 +81,7 @@ def sample_categorical(logits: Tensor) -> Tensor:
 
 
 def make_normal(mu: Tensor, var: Tensor) -> Normal:
-    """Helper mirroring the TF utility for constructing :class:`Normal` objects."""
+    """Helper constructing :class:`Normal` objects from mean and variance."""
 
     std = torch.sqrt(torch.clamp(var, min=EPS))
     return Normal(mu, std)

--- a/suave/modules/encoder.py
+++ b/suave/modules/encoder.py
@@ -11,11 +11,10 @@ from torch import Tensor, nn
 class EncoderMLP(nn.Module):
     r"""Multi-layer perceptron producing the mean and log-variance of ``z``.
 
-    The architecture mirrors the legacy TensorFlow unsupervised baseline: a stack of dense
+    The architecture follows the default SUAVE encoder: a stack of dense
     layers followed by two linear heads generating the parameters of the
     approximate posterior :math:`q(z \mid x)`.  The log-variance output is
-    clamped for numerical stability, matching the behaviour of the reference
-    implementation.
+    clamped for numerical stability to avoid degenerate values during training.
 
     Parameters
     ----------

--- a/suave/modules/heads.py
+++ b/suave/modules/heads.py
@@ -1,4 +1,4 @@
-"""Classification heads mirroring the legacy TensorFlow unsupervised baseline."""
+"""Classification heads used by the SUAVE classifier stack."""
 
 from __future__ import annotations
 

--- a/suave/modules/losses.py
+++ b/suave/modules/losses.py
@@ -1,4 +1,4 @@
-"""Loss helpers implementing unsupervised-style objectives."""
+"""Loss helpers implementing the variational objectives used in SUAVE."""
 
 from __future__ import annotations
 

--- a/suave/modules/prior.py
+++ b/suave/modules/prior.py
@@ -1,4 +1,4 @@
-"""Prior modules defining unsupervised-specific parameterisations."""
+"""Prior modules defining the mixture-aware parameterisations used in SUAVE."""
 
 from __future__ import annotations
 

--- a/suave/types.py
+++ b/suave/types.py
@@ -13,8 +13,8 @@ class ColumnSpec:
     Parameters
     ----------
     type:
-        Logical feature type. Supported values mirror the unsupervised branch of
-        the model: ``"real"`` (Gaussian), ``"pos"`` (log-normal),
+        Logical feature type. Supported values align with the generative
+        component of SUAVE: ``"real"`` (Gaussian), ``"pos"`` (log-normal),
         ``"count"`` (Poisson), ``"cat"`` (categorical) and ``"ordinal"``
         (cumulative link).
     n_classes:


### PR DESCRIPTION
## Summary
- update docstrings across core SUAVE modules to describe the integrated project rather than the legacy TensorFlow mirror
- refresh behavioural parameter descriptions and runtime messaging to emphasise the generative workflow in unsupervised mode

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68d168c2e6d4832094ffe8422e8cbf69