### PR TITLE
Improve README clarity and API overview

### DIFF
--- a/README-CN.md
+++ b/README-CN.md
@@ -2,13 +2,26 @@
 
 SUAVE 是一款以 Schema 为核心的变分自编码器，面向混合类型表格数据，同时支持生成式建模与有监督预测。项目直接受到 HI-VAE 及其后续层次潜变量研究的启发，并在此基础上强化了显式 Schema、分阶段训练以及概率校准等现代化工作流。
 
-## 设计理念
+## 核心特性
 
-- **Schema 驱动的输入。** 用户需通过 :class:`~suave.types.Schema` 明确声明每一列特征，使模型在训练前即可获知数据类型与类别数量。【F:suave/types.py†L22-L115】
-- **分阶段优化。** 训练流程遵循“预热 → 分类头 → 联合微调”的阶段式调度，并配合 KL 退火以复刻 HI-VAE 风格目标的稳定收敛特性。【F:suave/model.py†L889-L1010】
-- **透明的自动化。** 可选的 ``auto_parameters`` 启发式会依据数据统计量自适应批大小与训练时长，同时所有超参仍可在方法签名中被显式覆盖。【F:suave/model.py†L73-L128】【F:suave/model.py†L1039-L1091】
-- **缺失值感知的生成解码。** 标准化工具与解码器头会在实数、分类、正数、计数与序数特征上持续传递逐列掩码，从而一致地处理缺失数据。【F:suave/data.py†L15-L143】【F:suave/model.py†L1123-L1244】
-- **内置校准与评估。** 模型提供温度缩放、Brier 得分、ECE 等评估指标，帮助在下游场景中生成可靠概率。【F:suave/model.py†L2603-L2682】【F:suave/evaluate.py†L1-L200】
+- **Schema 驱动的输入。** 用户需通过 `Schema` 明确声明每一列特征，使模型在训练前即可获知数据类型与类别数量。
+- **分阶段优化。** 训练流程遵循“预热 → 分类头 → 联合微调”的调度，并配合 KL 退火以获得稳定的收敛表现。
+- **透明的自动化。** 可选的 `auto_parameters` 启发式会依据数据统计量自适应批大小、学习率与训练时长，同时所有超参仍可被显式覆盖。
+- **缺失值感知的生成解码。** 标准化工具与解码器头会在实数、分类、正数、计数与序数特征上持续传递掩码，从而一致地处理缺失数据。
+- **内置校准与评估。** 模型提供温度缩放、Brier 得分、ECE 等评估指标，帮助在下游场景中生成可靠概率。
+
+## API 全景
+
+| 方法 | 作用 |
+| ---- | ---- |
+| `fit(X, y=None, **schedule)` | 采用分阶段优化训练生成模型与（可选的）分类头，并自动划分内部验证集。 |
+| `predict(X)` | 在经过校准后返回最可能的类别标签。 |
+| `predict_proba(X)` | 输出已校准的类别概率，并通过缓存机制避免重复的编码计算。 |
+| `calibrate(X, y)` | 在保留集 logits 上学习温度缩放参数，并在后续预测中复用。 |
+| `encode(X, return_components=False)` | 将数据映射至潜空间，可选地返回混合分量分配与对应统计量。 |
+| `sample(n, conditional=False, y=None)` | 生成合成样本，可按类别标签进行条件采样。 |
+| `impute(X, only_missing=True)` | 重建缺失或被掩码的单元格并与原始数据合并。 |
+| `save(path)` / `SUAVE.load(path)` | 保存与恢复模型权重、Schema 元数据和校准状态，以便部署。 |
 
 ## 安装
 
@@ -47,6 +60,8 @@ labels = model.predict(train_X.tail(5))
 完整示例可参考 [`examples/sepsis_minimal.py`](examples/sepsis_minimal.py)。
 
 ## API 概览
+
+以下示例覆盖最常用的工作流程。除特别说明外，接口均可接受 pandas DataFrame 或 NumPy 数组。
 
 ### Schema 定义
 
@@ -95,7 +110,7 @@ preds = model.predict(test_X)
 
 模型会基于输入指纹缓存 logits，从而避免重复的编码计算。
 
-### 概率校准
+### 概率校准与评估
 
 ```python
 model.calibrate(val_X, val_y)
@@ -103,6 +118,17 @@ calibrated = model.predict_proba(test_X)
 ```
 
 温度缩放在保留集 logits 上训练，并在后续预测中自动复用。
+
+```python
+from suave.evaluate import compute_auroc, compute_auprc, compute_brier, compute_ece
+
+auroc = compute_auroc(proba, val_y.to_numpy())
+auprc = compute_auprc(proba, val_y.to_numpy())
+brier = compute_brier(proba, val_y.to_numpy())
+ece = compute_ece(proba, val_y.to_numpy(), n_bins=15)
+```
+
+各指标函数会自动校验概率矩阵的形状，在输入退化时返回 `numpy.nan`。
 
 ### 潜变量编码
 
@@ -144,19 +170,6 @@ restored.predict_proba(test_X)
 ```
 
 保存的模型文件包含 schema 信息、参数权重与校准状态，可直接复现部署推理。
-
-### 评估工具
-
-```python
-from suave.evaluate import compute_auroc, compute_auprc, compute_brier, compute_ece
-
-auroc = compute_auroc(proba, val_y.to_numpy())
-auprc = compute_auprc(proba, val_y.to_numpy())
-brier = compute_brier(proba, val_y.to_numpy())
-ece = compute_ece(proba, val_y.to_numpy(), n_bins=15)
-```
-
-各指标函数会自动校验概率矩阵的形状，在输入退化时返回 ``numpy.nan``。
 
 ## 规划
 


### PR DESCRIPTION
## Summary
- rewrite the English and Chinese READMEs to improve flow and readability
- add a concise table describing the main SUAVE API methods and their purpose
- reorganize calibration content to cover evaluation helpers alongside calibration details

## Testing
- not run (documentation only)

------
https://chatgpt.com/codex/tasks/task_e_68d1776e0e848320a457363acf00ce51