### PR TITLE
Improve numeric contiguity check

### DIFF
--- a/suave/schema_inference.py
+++ b/suave/schema_inference.py
@@ -193,10 +193,10 @@ class SchemaInferencer:
         if integer_like:
             int_values = np.round(numeric).astype(int)
             sorted_unique = np.sort(np.unique(int_values))
-            contiguous = bool(
-                sorted_unique.size > 0
-                and np.array_equal(sorted_unique, np.arange(sorted_unique[0], sorted_unique[-1] + 1))
-            )
+            if sorted_unique.size <= 1:
+                contiguous = bool(sorted_unique.size)
+            else:
+                contiguous = bool(np.all(np.diff(sorted_unique) == 1))
             limited_range = (
                 sorted_unique.size > 0
                 and (sorted_unique[-1] - sorted_unique[0]) <= ORDINAL_RANGE_THRESHOLD

--- a/tests/test_schema_inference.py
+++ b/tests/test_schema_inference.py
@@ -58,3 +58,14 @@ def test_interactive_mode_gracefully_falls_back(monkeypatch) -> None:
 
     assert "flagged" in result.review_columns
     assert any("Interactive review not available" in message for message in result.messages)
+
+
+def test_integer_inference_handles_wide_range() -> None:
+    wide_range = [0, 10_000_000, 20_000_000]
+    df = pd.DataFrame({"wide_range_ints": wide_range})
+
+    inferencer = SchemaInferencer()
+    result = inferencer.infer(df, mode=SchemaInferenceMode.SILENT)
+    schema_dict = result.schema.to_dict()
+
+    assert schema_dict["wide_range_ints"]["type"] == "count"


### PR DESCRIPTION
## Summary
- update the integer contiguity detection in schema inference to use successive differences
- add a regression test covering wide-range integer columns to ensure inference remains stable

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d1a475c79c832091577847e5a3d921