### PR TITLE
Improve Optuna search coverage and evaluation reporting

### DIFF
--- a/examples/mimic_mortality_supervised.py
+++ b/examples/mimic_mortality_supervised.py
@@ -1,0 +1,914 @@
+"""Supervised mortality modelling and analysis for the sepsis datasets."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import sys
+import time
+from typing import Dict, Iterable, List, Mapping, MutableMapping, Optional, Tuple
+
+import numpy as np
+import pandas as pd
+from matplotlib import pyplot as plt
+from sklearn.calibration import calibration_curve
+from sklearn.decomposition import PCA
+from sklearn.impute import SimpleImputer
+from sklearn.linear_model import LogisticRegression
+from sklearn.metrics import (
+    accuracy_score,
+    brier_score_loss,
+    confusion_matrix,
+    mutual_info_score,
+    roc_auc_score,
+)
+from sklearn.model_selection import train_test_split
+from sklearn.pipeline import Pipeline
+from sklearn.preprocessing import StandardScaler
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from suave import (
+    SUAVE,
+    Schema,
+    SchemaInferenceMode,
+    SchemaInferencer,
+)
+from suave.evaluate import evaluate_tstr, evaluate_trtr, simple_membership_inference
+
+
+try:
+    import optuna
+except ImportError as exc:  # pragma: no cover - optuna provided via requirements
+    raise RuntimeError(
+        "Optuna is required for the mortality analysis. Install it via 'pip install optuna'."
+    ) from exc
+
+
+RANDOM_STATE = 42
+TARGET_COLUMNS = ("in_hospital_mortality", "28d_mortality")
+CATEGORICAL_FEATURES = ("sex", "CRRT", "Respiratory_Support")
+CALIBRATION_SIZE = 0.2
+VALIDATION_SIZE = 0.2
+OUTPUT_DIR_NAME = "analysis_outputs"
+HIDDEN_DIMENSION_OPTIONS: Dict[str, Tuple[int, int]] = {
+    "compact": (96, 48),
+    "small": (128, 64),
+    "medium": (256, 128),
+    "wide": (384, 192),
+    "deep": (512, 256),
+    "very_deep": (640, 320),
+}
+
+
+def load_dataset(path: Path) -> pd.DataFrame:
+    """Load a TSV file into a :class:`pandas.DataFrame`."""
+
+    return pd.read_csv(path, sep="\t")
+
+
+def define_schema(df: pd.DataFrame, feature_columns: Iterable[str]) -> Schema:
+    """Create a :class:`Schema` describing ``df``'s feature columns."""
+
+    inferencer = SchemaInferencer(categorical_overrides=CATEGORICAL_FEATURES)
+    result = inferencer.infer(
+        df,
+        feature_columns,
+        mode=SchemaInferenceMode.INFO,
+    )
+    for message in result.messages:
+        print(f"[schema] {message}")
+    return result.schema
+
+
+def prepare_features(df: pd.DataFrame, feature_columns: Iterable[str]) -> pd.DataFrame:
+    """Return features aligned to ``feature_columns``."""
+
+    return df.loc[:, list(feature_columns)].copy()
+
+
+def split_train_validation_calibration(
+    features: pd.DataFrame,
+    targets: pd.Series,
+    *,
+    calibration_size: float,
+    validation_size: float,
+    random_state: int,
+) -> Tuple[
+    pd.DataFrame,
+    pd.DataFrame,
+    pd.DataFrame,
+    pd.Series,
+    pd.Series,
+    pd.Series,
+]:
+    """Split data into train, validation, and calibration subsets."""
+
+    X_model, X_calibration, y_model, y_calibration = train_test_split(
+        features,
+        targets,
+        test_size=calibration_size,
+        stratify=targets,
+        random_state=random_state,
+    )
+    X_train, X_validation, y_train, y_validation = train_test_split(
+        X_model,
+        y_model,
+        test_size=validation_size,
+        stratify=y_model,
+        random_state=random_state,
+    )
+    return (
+        X_train.reset_index(drop=True),
+        X_validation.reset_index(drop=True),
+        X_calibration.reset_index(drop=True),
+        y_train.reset_index(drop=True),
+        y_validation.reset_index(drop=True),
+        y_calibration.reset_index(drop=True),
+    )
+
+
+def schema_markdown_table(schema: Schema) -> str:
+    """Return a Markdown table summarising ``schema``."""
+
+    header = "| Column | Type | n_classes | y_dim |\n| --- | --- | --- | --- |"
+    rows = [header]
+    schema_dict: MutableMapping[str, MutableMapping[str, object]] = schema.to_dict()
+    for name, spec in schema_dict.items():
+        n_classes = spec.get("n_classes", "")
+        y_dim = spec.get("y_dim", "")
+        rows.append(f"| {name} | {spec['type']} | {n_classes} | {y_dim} |")
+    return "\n".join(rows)
+
+
+def format_float(value: Optional[float]) -> str:
+    """Format floating point numbers for Markdown tables."""
+
+    if value is None:
+        return "nan"
+    if isinstance(value, float) and not np.isfinite(value):
+        return "nan"
+    return f"{float(value):.3f}"
+
+
+def compute_binary_metrics(
+    probabilities: np.ndarray, targets: pd.Series | np.ndarray
+) -> Dict[str, float]:
+    """Compute AUROC, accuracy, specificity, sensitivity, and Brier score."""
+
+    prob_matrix = np.asarray(probabilities)
+    if prob_matrix.ndim == 1:
+        positive_probs = prob_matrix
+    else:
+        positive_probs = prob_matrix[:, -1]
+    labels = np.asarray(targets)
+    predictions = (positive_probs >= 0.5).astype(int)
+
+    metrics: Dict[str, float] = {}
+
+    try:
+        metrics["AUC"] = float(roc_auc_score(labels, positive_probs))
+    except ValueError:
+        metrics["AUC"] = float("nan")
+
+    metrics["ACC"] = float(accuracy_score(labels, predictions))
+    tn, fp, fn, tp = confusion_matrix(labels, predictions, labels=[0, 1]).ravel()
+    metrics["SPE"] = float(tn / (tn + fp)) if (tn + fp) > 0 else float("nan")
+    metrics["SEN"] = float(tp / (tp + fn)) if (tp + fn) > 0 else float("nan")
+    metrics["Brier"] = float(brier_score_loss(labels, positive_probs))
+    return metrics
+
+
+def run_optuna_search(
+    X_train: pd.DataFrame,
+    y_train: pd.Series,
+    X_validation: pd.DataFrame,
+    y_validation: pd.Series,
+    schema: Schema,
+    *,
+    random_state: int,
+    n_trials: Optional[int],
+    timeout: Optional[int],
+    study_name: Optional[str] = None,
+    storage: Optional[str] = None,
+) -> tuple["optuna.study.Study", Dict[str, object]]:
+    """Perform Optuna hyperparameter optimisation for :class:`SUAVE`."""
+
+    if n_trials is not None and n_trials <= 0:
+        n_trials = None
+    if timeout is not None and timeout <= 0:
+        timeout = None
+
+    def objective(trial: "optuna.trial.Trial") -> float:
+        latent_dim = trial.suggest_categorical(
+            "latent_dim", [8, 16, 24, 32, 48, 64, 96, 128]
+        )
+        hidden_key = trial.suggest_categorical(
+            "hidden_dims", list(HIDDEN_DIMENSION_OPTIONS.keys())
+        )
+        dropout = trial.suggest_float("dropout", 0.0, 0.6)
+        learning_rate = trial.suggest_float("learning_rate", 1e-4, 5e-2, log=True)
+        batch_size = trial.suggest_categorical("batch_size", [64, 128, 256, 512, 1024])
+        beta = trial.suggest_float("beta", 0.25, 4.0)
+        warmup_epochs = trial.suggest_int("warmup_epochs", 1, 8)
+        head_epochs = trial.suggest_int("head_epochs", 1, 6)
+        finetune_epochs = trial.suggest_int("finetune_epochs", 1, 6)
+
+        model = SUAVE(
+            schema=schema,
+            latent_dim=latent_dim,
+            hidden_dims=HIDDEN_DIMENSION_OPTIONS[hidden_key],
+            dropout=dropout,
+            learning_rate=learning_rate,
+            batch_size=batch_size,
+            beta=beta,
+            random_state=random_state,
+            auto_parameters=False,
+        )
+
+        start_time = time.perf_counter()
+        model.fit(
+            X_train,
+            y_train,
+            warmup_epochs=warmup_epochs,
+            head_epochs=head_epochs,
+            finetune_epochs=finetune_epochs,
+        )
+        fit_seconds = time.perf_counter() - start_time
+        validation_probs = model.predict_proba(X_validation)
+        validation_metrics = compute_binary_metrics(validation_probs, y_validation)
+        trial.set_user_attr("validation_metrics", validation_metrics)
+        trial.set_user_attr("fit_seconds", fit_seconds)
+
+        auc = validation_metrics.get("AUC", float("nan"))
+        if not np.isfinite(auc):
+            raise optuna.exceptions.TrialPruned("Non-finite validation AUC")
+        return auc
+
+    study = optuna.create_study(
+        direction="maximize",
+        study_name=study_name,
+        storage=storage,
+        load_if_exists=bool(storage and study_name),
+    )
+    study.optimize(objective, n_trials=n_trials, timeout=timeout)
+
+    if study.best_trial is None:
+        raise RuntimeError("Optuna search did not produce a best trial")
+    best_attributes: Dict[str, object] = {
+        "trial_number": study.best_trial.number,
+        "value": study.best_value,
+        "params": dict(study.best_trial.params),
+        "validation_metrics": study.best_trial.user_attrs.get("validation_metrics", {}),
+        "fit_seconds": study.best_trial.user_attrs.get("fit_seconds"),
+    }
+    return study, best_attributes
+
+
+def plot_calibration_curves(
+    probability_map: Mapping[str, np.ndarray],
+    label_map: Mapping[str, np.ndarray],
+    *,
+    target_name: str,
+    output_path: Path,
+    n_bins: int = 10,
+) -> None:
+    """Generate calibration curves with Brier scores annotated in the legend."""
+
+    fig, ax = plt.subplots(figsize=(6, 5))
+    ax.plot(
+        [0, 1], [0, 1], linestyle="--", color="tab:gray", label="Perfect calibration"
+    )
+
+    for dataset_name, probs in probability_map.items():
+        labels = label_map[dataset_name]
+        if probs.ndim == 2:
+            pos_probs = probs[:, -1]
+        else:
+            pos_probs = probs
+        try:
+            frac_pos, mean_pred = calibration_curve(labels, pos_probs, n_bins=n_bins)
+        except ValueError:
+            continue
+        brier = brier_score_loss(labels, pos_probs)
+        ax.plot(
+            mean_pred, frac_pos, marker="o", label=f"{dataset_name} (Brier={brier:.3f})"
+        )
+
+    ax.set_xlabel("Predicted probability")
+    ax.set_ylabel("Observed frequency")
+    ax.set_title(f"Calibration: {target_name}")
+    ax.legend()
+    fig.tight_layout()
+    fig.savefig(output_path, dpi=300)
+    plt.close(fig)
+
+
+def plot_latent_space(
+    model: SUAVE,
+    feature_map: Mapping[str, pd.DataFrame],
+    label_map: Mapping[str, pd.Series | np.ndarray],
+    *,
+    target_name: str,
+    output_path: Path,
+) -> None:
+    """Project latent representations with PCA and create scatter plots."""
+
+    latent_blocks: List[np.ndarray] = []
+    dataset_keys: List[str] = []
+    for name, features in feature_map.items():
+        if features.empty:
+            continue
+        latents = model.encode(features)
+        if latents.size == 0:
+            continue
+        latent_blocks.append(latents)
+        dataset_keys.append(name)
+
+    if not latent_blocks:
+        return
+
+    concatenated = np.vstack(latent_blocks)
+    pca = PCA(n_components=2)
+    projected = pca.fit_transform(concatenated)
+
+    offsets = np.cumsum([0] + [block.shape[0] for block in latent_blocks])
+    fig, axes = plt.subplots(
+        1,
+        len(latent_blocks),
+        figsize=(6 * len(latent_blocks), 5),
+        sharex=True,
+        sharey=True,
+    )
+    if len(latent_blocks) == 1:
+        axes = [axes]
+
+    for idx, (ax, name) in enumerate(zip(axes, dataset_keys)):
+        start, end = offsets[idx], offsets[idx + 1]
+        subset = projected[start:end]
+        labels = np.asarray(label_map[name])
+        scatter = ax.scatter(
+            subset[:, 0],
+            subset[:, 1],
+            c=labels,
+            cmap="coolwarm",
+            alpha=0.7,
+            edgecolor="none",
+        )
+        ax.set_title(f"{name}")
+        ax.set_xlabel("PC1")
+        ax.set_ylabel("PC2")
+        legend = ax.legend(*scatter.legend_elements(), title="Label")
+        ax.add_artist(legend)
+
+    fig.suptitle(f"Latent space projection: {target_name}")
+    fig.tight_layout(rect=(0, 0, 1, 0.96))
+    fig.savefig(output_path, dpi=300)
+    plt.close(fig)
+
+
+def kolmogorov_smirnov_statistic(real: np.ndarray, synthetic: np.ndarray) -> float:
+    """Compute the Kolmogorov-Smirnov statistic between two samples."""
+
+    real = np.asarray(real, dtype=float)
+    synthetic = np.asarray(synthetic, dtype=float)
+    real = real[np.isfinite(real)]
+    synthetic = synthetic[np.isfinite(synthetic)]
+    if real.size == 0 or synthetic.size == 0:
+        return float("nan")
+    real_sorted = np.sort(real)
+    synthetic_sorted = np.sort(synthetic)
+    combined = np.concatenate([real_sorted, synthetic_sorted])
+    cdf_real = np.searchsorted(real_sorted, combined, side="right") / real_sorted.size
+    cdf_synth = (
+        np.searchsorted(synthetic_sorted, combined, side="right")
+        / synthetic_sorted.size
+    )
+    return float(np.max(np.abs(cdf_real - cdf_synth)))
+
+
+def rbf_mmd(
+    real: np.ndarray,
+    synthetic: np.ndarray,
+    *,
+    max_samples: int = 1000,
+    random_state: int = 42,
+) -> float:
+    """Compute the maximum mean discrepancy with an RBF kernel."""
+
+    real = np.asarray(real, dtype=float)
+    synthetic = np.asarray(synthetic, dtype=float)
+    real = real[np.isfinite(real)]
+    synthetic = synthetic[np.isfinite(synthetic)]
+    if real.size == 0 or synthetic.size == 0:
+        return float("nan")
+
+    rng = np.random.default_rng(random_state)
+    if real.size > max_samples:
+        real = rng.choice(real, size=max_samples, replace=False)
+    if synthetic.size > max_samples:
+        synthetic = rng.choice(synthetic, size=max_samples, replace=False)
+
+    real = real[:, None]
+    synthetic = synthetic[:, None]
+    data = np.concatenate([real, synthetic], axis=0)
+    squared_distances = (data - data.T) ** 2
+    median_sq = float(np.median(squared_distances))
+    bandwidth = np.sqrt(0.5 * median_sq) if median_sq > 1e-12 else 1.0
+
+    def kernel(a: np.ndarray, b: np.ndarray) -> np.ndarray:
+        distances = (a - b.T) ** 2
+        return np.exp(-distances / (2.0 * bandwidth**2))
+
+    k_xx = kernel(real, real)
+    k_yy = kernel(synthetic, synthetic)
+    k_xy = kernel(real, synthetic)
+    mmd = k_xx.mean() + k_yy.mean() - 2.0 * k_xy.mean()
+    return float(max(mmd, 0.0))
+
+
+def mutual_information_feature(
+    real: np.ndarray, synthetic: np.ndarray, n_bins: int = 10
+) -> float:
+    """Estimate mutual information between dataset indicator and feature bins."""
+
+    real = np.asarray(real, dtype=float)
+    synthetic = np.asarray(synthetic, dtype=float)
+    real = real[np.isfinite(real)]
+    synthetic = synthetic[np.isfinite(synthetic)]
+    if real.size == 0 or synthetic.size == 0:
+        return float("nan")
+
+    combined = np.concatenate([real, synthetic])
+    quantiles = np.quantile(combined, np.linspace(0.0, 1.0, n_bins + 1))
+    bin_edges = np.unique(quantiles)
+    if bin_edges.size <= 1:
+        return 0.0
+    interior = bin_edges[1:-1]
+    real_binned = np.digitize(real, interior, right=False)
+    synthetic_binned = np.digitize(synthetic, interior, right=False)
+
+    if np.unique(real_binned).size <= 1 and np.unique(synthetic_binned).size <= 1:
+        return 0.0
+
+    dataset_indicator = np.concatenate(
+        [
+            np.zeros(real_binned.size, dtype=int),
+            np.ones(synthetic_binned.size, dtype=int),
+        ]
+    )
+    feature_bins = np.concatenate([real_binned, synthetic_binned])
+    if np.unique(feature_bins).size <= 1:
+        return 0.0
+    return float(mutual_info_score(dataset_indicator, feature_bins))
+
+
+def to_numeric_frame(df: pd.DataFrame) -> pd.DataFrame:
+    """Coerce all columns in ``df`` to numeric values."""
+
+    numeric = df.copy()
+    for column in numeric.columns:
+        numeric[column] = pd.to_numeric(numeric[column], errors="coerce")
+    return numeric
+
+
+def make_logistic_pipeline() -> Pipeline:
+    """Factory for the baseline classifier used in TSTR/TRTR."""
+
+    return Pipeline(
+        [
+            ("imputer", SimpleImputer(strategy="median")),
+            ("scaler", StandardScaler()),
+            ("classifier", LogisticRegression(max_iter=200)),
+        ]
+    )
+
+
+def parse_arguments() -> argparse.Namespace:
+    """Return parsed command line arguments for the analysis script."""
+
+    parser = argparse.ArgumentParser(
+        description="Run the SUAVE mortality modelling analysis with Optuna tuning.",
+    )
+    parser.add_argument(
+        "--optuna-trials",
+        type=int,
+        default=30,
+        help="Maximum number of Optuna trials per target (default: 30).",
+    )
+    parser.add_argument(
+        "--optuna-timeout",
+        type=int,
+        default=7200,
+        help="Maximum tuning time in seconds per target (default: 7200, i.e. 2 hours).",
+    )
+    parser.add_argument(
+        "--optuna-study-prefix",
+        type=str,
+        default=None,
+        help="Optional prefix for Optuna study names when using persistent storage.",
+    )
+    parser.add_argument(
+        "--optuna-storage",
+        type=str,
+        default=None,
+        help="Optional Optuna storage URL for persistent studies.",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    """Run the full supervised mortality analysis pipeline."""
+
+    args = parse_arguments()
+    data_dir = Path(__file__).parent / "data" / "sepsis_mortality_dataset"
+    output_dir = data_dir / OUTPUT_DIR_NAME
+    output_dir.mkdir(exist_ok=True)
+
+    train_df = load_dataset(data_dir / "mimic-mortality-train.tsv")
+    test_df = load_dataset(data_dir / "mimic-mortality-test.tsv")
+    external_df = load_dataset(data_dir / "eicu-mortality-external_val.tsv")
+
+    feature_columns = [
+        column for column in train_df.columns if column not in TARGET_COLUMNS
+    ]
+    schema = define_schema(train_df, feature_columns)
+    schema_table = schema_markdown_table(schema)
+
+    metrics_records: List[Dict[str, object]] = []
+    calibration_paths: Dict[str, Path] = {}
+    latent_paths: Dict[str, Path] = {}
+    membership_records: List[Dict[str, object]] = []
+    optuna_reports: Dict[str, Dict[str, object]] = {}
+
+    models: Dict[str, SUAVE] = {}
+    tstr_results: Optional[pd.DataFrame] = None
+    tstr_path: Optional[Path] = None
+    distribution_df: Optional[pd.DataFrame] = None
+    distribution_path: Optional[Path] = None
+
+    for target in TARGET_COLUMNS:
+        if target not in train_df.columns:
+            continue
+        print(f"Training model for {target}…")
+        X_full = prepare_features(train_df, feature_columns)
+        y_full = train_df[target]
+
+        (
+            X_train_model,
+            X_validation,
+            X_calibration,
+            y_train_model,
+            y_validation,
+            y_calibration,
+        ) = split_train_validation_calibration(
+            X_full,
+            y_full,
+            calibration_size=CALIBRATION_SIZE,
+            validation_size=VALIDATION_SIZE,
+            random_state=RANDOM_STATE,
+        )
+
+        study_name = (
+            f"{args.optuna_study_prefix}_{target}" if args.optuna_study_prefix else None
+        )
+        study, best_info = run_optuna_search(
+            X_train_model,
+            y_train_model,
+            X_validation,
+            y_validation,
+            schema,
+            random_state=RANDOM_STATE,
+            n_trials=args.optuna_trials,
+            timeout=args.optuna_timeout,
+            study_name=study_name,
+            storage=args.optuna_storage,
+        )
+
+        best_params = dict(best_info.get("params", {}))
+        hidden_key = str(best_params.get("hidden_dims", "medium"))
+        hidden_dims = HIDDEN_DIMENSION_OPTIONS.get(
+            hidden_key, HIDDEN_DIMENSION_OPTIONS["medium"]
+        )
+        model = SUAVE(
+            schema=schema,
+            latent_dim=int(best_params.get("latent_dim", 16)),
+            hidden_dims=hidden_dims,
+            dropout=float(best_params.get("dropout", 0.1)),
+            learning_rate=float(best_params.get("learning_rate", 1e-3)),
+            batch_size=int(best_params.get("batch_size", 256)),
+            beta=float(best_params.get("beta", 1.5)),
+            random_state=RANDOM_STATE,
+            auto_parameters=False,
+        )
+        model.fit(
+            X_train_model,
+            y_train_model,
+            warmup_epochs=int(best_params.get("warmup_epochs", 3)),
+            head_epochs=int(best_params.get("head_epochs", 2)),
+            finetune_epochs=int(best_params.get("finetune_epochs", 2)),
+        )
+        model.calibrate(X_calibration, y_calibration)
+        models[target] = model
+
+        evaluation_datasets: Dict[str, Tuple[pd.DataFrame, pd.Series]] = {
+            "Train": (X_train_model, y_train_model),
+            "Validation": (X_validation, y_validation),
+            "MIMIC test": (prepare_features(test_df, feature_columns), test_df[target]),
+        }
+        if target in external_df.columns:
+            evaluation_datasets["eICU external"] = (
+                prepare_features(external_df, feature_columns),
+                external_df[target],
+            )
+
+        probability_map: Dict[str, np.ndarray] = {}
+        label_map: Dict[str, np.ndarray] = {}
+        dataset_metric_map: Dict[str, Dict[str, float]] = {}
+        for dataset_name, (features, labels) in evaluation_datasets.items():
+            probs = model.predict_proba(features)
+            probability_map[dataset_name] = probs
+            label_map[dataset_name] = np.asarray(labels)
+            metrics = compute_binary_metrics(probs, labels)
+            dataset_metric_map[dataset_name] = metrics
+            metric_row = {
+                "target": target,
+                "dataset": dataset_name,
+                **metrics,
+            }
+            metrics_records.append(metric_row)
+
+        calibration_path = output_dir / f"calibration_{target}.png"
+        plot_calibration_curves(
+            probability_map, label_map, target_name=target, output_path=calibration_path
+        )
+        calibration_paths[target] = calibration_path
+
+        latent_features = {
+            name: features for name, (features, _) in evaluation_datasets.items()
+        }
+        latent_labels = {
+            name: labels for name, (_, labels) in evaluation_datasets.items()
+        }
+        latent_path = output_dir / f"latent_{target}.png"
+        plot_latent_space(
+            model,
+            latent_features,
+            latent_labels,
+            target_name=target,
+            output_path=latent_path,
+        )
+        latent_paths[target] = latent_path
+
+        train_probabilities = probability_map["Train"]
+        test_probabilities = probability_map["MIMIC test"]
+        membership = simple_membership_inference(
+            train_probabilities,
+            np.asarray(y_train_model),
+            test_probabilities,
+            np.asarray(evaluation_datasets["MIMIC test"][1]),
+        )
+        membership_records.append(
+            {
+                "target": target,
+                "auc": membership.get("attack_auc", float("nan")),
+                "best_threshold": membership.get(
+                    "attack_best_threshold", float("nan")
+                ),
+                "best_accuracy": membership.get("attack_best_accuracy", float("nan")),
+                "majority_accuracy": membership.get(
+                    "attack_majority_class_accuracy", float("nan")
+                ),
+            }
+        )
+
+        trial_rows: List[Dict[str, object]] = []
+        for trial in study.trials:
+            record: Dict[str, object] = {
+                "trial_number": trial.number,
+                "value": trial.value,
+            }
+            record.update(trial.params)
+            val_metrics = trial.user_attrs.get("validation_metrics")
+            if isinstance(val_metrics, Mapping):
+                for metric_name, metric_value in val_metrics.items():
+                    record[f"validation_{metric_name.lower()}"] = metric_value
+            fit_seconds = trial.user_attrs.get("fit_seconds")
+            if fit_seconds is not None:
+                record["fit_seconds"] = fit_seconds
+            trial_rows.append(record)
+        trials_df = pd.DataFrame(trial_rows)
+        trials_path = output_dir / f"optuna_trials_{target}.csv"
+        if not trials_df.empty:
+            trials_df.to_csv(trials_path, index=False)
+        else:
+            trials_path.write_text("trial_number,value\n")
+
+        optuna_reports[target] = {
+            "best": best_info,
+            "best_params": best_params,
+            "metrics": dataset_metric_map,
+            "trials_csv": trials_path,
+        }
+
+    metrics_df = pd.DataFrame(metrics_records)
+    metrics_path = output_dir / "evaluation_metrics.csv"
+    metrics_df.to_csv(metrics_path, index=False)
+
+    membership_df = pd.DataFrame(membership_records)
+    membership_path = output_dir / "membership_inference.csv"
+    membership_df.to_csv(membership_path, index=False)
+
+    in_hospital_model = models.get("in_hospital_mortality")
+    if in_hospital_model is not None:
+        print("Generating synthetic data for TSTR/TRTR comparisons…")
+        X_train_full = prepare_features(train_df, feature_columns)
+        y_train_full = train_df["in_hospital_mortality"]
+        numeric_train = to_numeric_frame(X_train_full)
+
+        rng = np.random.default_rng(RANDOM_STATE)
+        synthetic_labels = rng.choice(
+            y_train_full, size=len(y_train_full), replace=True
+        )
+        synthetic_features = in_hospital_model.sample(
+            len(synthetic_labels), conditional=True, y=synthetic_labels
+        )
+        numeric_synthetic = to_numeric_frame(synthetic_features[feature_columns])
+
+        numeric_test = to_numeric_frame(prepare_features(test_df, feature_columns))
+        y_test = test_df["in_hospital_mortality"]
+
+        tstr_metrics = evaluate_tstr(
+            (numeric_synthetic.to_numpy(), np.asarray(synthetic_labels)),
+            (numeric_test.to_numpy(), y_test.to_numpy()),
+            make_logistic_pipeline,
+        )
+        trtr_metrics = evaluate_trtr(
+            (numeric_train.to_numpy(), y_train_full.to_numpy()),
+            (numeric_test.to_numpy(), y_test.to_numpy()),
+            make_logistic_pipeline,
+        )
+        tstr_results = pd.DataFrame(
+            [
+                {"setting": "TSTR", **tstr_metrics},
+                {"setting": "TRTR", **trtr_metrics},
+            ]
+        )
+        tstr_path = output_dir / "tstr_trtr_comparison.csv"
+        tstr_results.to_csv(tstr_path, index=False)
+
+        distribution_rows: List[Dict[str, object]] = []
+        for column in feature_columns:
+            real_values = numeric_train[column].to_numpy()
+            synthetic_values = numeric_synthetic[column].to_numpy()
+            distribution_rows.append(
+                {
+                    "feature": column,
+                    "ks": kolmogorov_smirnov_statistic(real_values, synthetic_values),
+                    "mmd": rbf_mmd(real_values, synthetic_values),
+                    "mutual_information": mutual_information_feature(
+                        real_values, synthetic_values
+                    ),
+                }
+            )
+        distribution_df = pd.DataFrame(distribution_rows)
+        distribution_path = output_dir / "distribution_shift_metrics.csv"
+        distribution_df.to_csv(distribution_path, index=False)
+
+    summary_lines: List[str] = [
+        "# Mortality modelling report",
+        "",
+        "## Schema",
+        schema_table,
+        "",
+        "## Model selection and performance",
+    ]
+
+    if not optuna_reports:
+        summary_lines.append("No models were trained.")
+
+    for target, report in optuna_reports.items():
+        best = report["best"]
+        best_params = report["best_params"]
+        metrics_map: Mapping[str, Dict[str, float]] = report["metrics"]
+        summary_lines.append(f"### {target}")
+        best_value = best.get("value")
+        value_text = (
+            f"{best_value:.4f}" if isinstance(best_value, (int, float)) else "n/a"
+        )
+        summary_lines.append(
+            f"Best Optuna trial #{best.get('trial_number')} with validation AUC {value_text}"
+        )
+        summary_lines.append("Best parameters:")
+        summary_lines.append("```json")
+        summary_lines.append(json.dumps(best_params, indent=2, ensure_ascii=False))
+        summary_lines.append("```")
+        summary_lines.append("| Dataset | AUC | ACC | SPE | SEN | Brier |")
+        summary_lines.append("| --- | --- | --- | --- | --- | --- |")
+        for dataset_name, metrics in metrics_map.items():
+            summary_lines.append(
+                "| {dataset} | {auc} | {acc} | {spe} | {sen} | {brier} |".format(
+                    dataset=dataset_name,
+                    auc=format_float(metrics.get("AUC")),
+                    acc=format_float(metrics.get("ACC")),
+                    spe=format_float(metrics.get("SPE")),
+                    sen=format_float(metrics.get("SEN")),
+                    brier=format_float(metrics.get("Brier")),
+                )
+            )
+        summary_lines.append(
+            f"Optuna trials logged at: {report['trials_csv'].relative_to(output_dir)}"
+        )
+        summary_lines.append(
+            f"Calibration plot: {calibration_paths[target].relative_to(output_dir)}"
+        )
+        summary_lines.append(
+            f"Latent projection: {latent_paths[target].relative_to(output_dir)}"
+        )
+        summary_lines.append("")
+
+    if tstr_results is not None:
+        summary_lines.append("## TSTR vs TRTR")
+        summary_lines.append("| Setting | Accuracy | AUROC | AUPRC | Brier | ECE |")
+        summary_lines.append("| --- | --- | --- | --- | --- | --- |")
+        for row in tstr_results.itertuples(index=False):
+            summary_lines.append(
+                "| {setting} | {acc} | {auc} | {auprc} | {brier} | {ece} |".format(
+                    setting=row.setting,
+                    acc=format_float(row.accuracy),
+                    auc=format_float(getattr(row, "auroc", np.nan)),
+                    auprc=format_float(row.auprc),
+                    brier=format_float(row.brier),
+                    ece=format_float(row.ece),
+                )
+            )
+        summary_lines.append("")
+
+    if distribution_df is not None and distribution_path is not None:
+        summary_lines.append("## Distribution shift and privacy")
+        distribution_top = distribution_df.sort_values("ks", ascending=False).head(10)
+        summary_lines.append("Top 10 features by KS statistic:")
+        summary_lines.append("| Feature | KS | MMD | Mutual information |")
+        summary_lines.append("| --- | --- | --- | --- |")
+        for _, row in distribution_top.iterrows():
+            summary_lines.append(
+                "| {feature} | {ks:.3f} | {mmd:.3f} | {mi:.3f} |".format(
+                    feature=row["feature"],
+                    ks=row.get("ks", np.nan),
+                    mmd=row.get("mmd", np.nan),
+                    mi=row.get("mutual_information", np.nan),
+                )
+            )
+        summary_lines.append(
+            f"Full distribution metrics: {distribution_path.relative_to(output_dir)}"
+        )
+    else:
+        summary_lines.append("## Distribution shift and privacy")
+
+    if not membership_df.empty:
+        summary_lines.append("Membership inference results:")
+        summary_lines.append(
+            "| Target | AUC | Best accuracy | Threshold | Majority baseline |"
+        )
+        summary_lines.append("| --- | --- | --- | --- | --- |")
+        for row in membership_df.itertuples(index=False):
+            summary_lines.append(
+                "| {target} | {auc} | {accuracy} | {threshold} | {majority} |".format(
+                    target=row.target,
+                    auc=format_float(row.auc),
+                    accuracy=format_float(row.best_accuracy),
+                    threshold=format_float(row.best_threshold),
+                    majority=format_float(row.majority_accuracy),
+                )
+            )
+        summary_lines.append(
+            f"Membership metrics saved to: {membership_path.relative_to(output_dir)}"
+        )
+    else:
+        summary_lines.append("No membership inference metrics were recorded.")
+
+    summary_path = output_dir / "summary.md"
+    summary_path.write_text("\n".join(summary_lines), encoding="utf-8")
+
+    print("Analysis complete.")
+    print(f"Metric table saved to {metrics_path}")
+    for target, path in calibration_paths.items():
+        print(f"Calibration plot for {target}: {path}")
+    for target, path in latent_paths.items():
+        print(f"Latent space plot for {target}: {path}")
+    print(f"Membership inference results saved to {membership_path}")
+    if (
+        in_hospital_model is not None
+        and tstr_path is not None
+        and distribution_path is not None
+    ):
+        print(f"TSTR/TRTR comparison saved to {tstr_path}")
+        print(f"Distribution metrics saved to {distribution_path}")
+    print(f"Summary written to {summary_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ torch>=2.2,<2.3
 matplotlib>=3.7
 tqdm>=4.65
 scikit-learn>=1.3
+optuna>=3.4

--- a/suave/__init__.py
+++ b/suave/__init__.py
@@ -7,5 +7,12 @@ implementation will iterate on top of these public entry points.
 
 from .model import SUAVE
 from .types import Schema
+from .schema_inference import SchemaInferenceMode, SchemaInferenceResult, SchemaInferencer
 
-__all__ = ["SUAVE", "Schema"]
+__all__ = [
+    "SUAVE",
+    "Schema",
+    "SchemaInferencer",
+    "SchemaInferenceMode",
+    "SchemaInferenceResult",
+]

--- a/suave/schema_inference.py
+++ b/suave/schema_inference.py
@@ -1,0 +1,385 @@
+"""Schema inference utilities with multiple review modes."""
+
+from __future__ import annotations
+
+import os
+import sys
+from dataclasses import dataclass
+from enum import Enum
+from typing import Dict, Iterable, List, Mapping, MutableMapping, Optional, Tuple
+
+import numpy as np
+import pandas as pd
+from pandas.api.types import is_bool_dtype, is_numeric_dtype
+
+try:  # pragma: no cover - optional interactive dependency
+    import matplotlib
+    from matplotlib import pyplot as plt
+except Exception:  # pragma: no cover - fallback when matplotlib is unavailable
+    matplotlib = None
+    plt = None
+
+from .types import Schema
+
+
+NUMERIC_CATEGORICAL_THRESHOLD = 0.05
+MAX_CATEGORICAL_UNIQUE = 20
+STD_REAL_FALLBACK = 0.1
+RANGE_REAL_FALLBACK = 1.0
+SMALL_STD_THRESHOLD = 1e-6
+SMALL_RANGE_THRESHOLD = 1e-6
+BINARY_VALUES = {0, 1}
+ORDINAL_RANGE_THRESHOLD = 10
+POSITIVE_SKEW_THRESHOLD = 1.0
+POSITIVE_MAX_MEAN_RATIO = 5.0
+REVIEW_RATIO_MARGIN = 0.02
+REVIEW_SKEW_MARGIN = 0.25
+REVIEW_UNIQUE_MARGIN = 2
+MIN_NUMERIC_COVERAGE = 0.95
+
+
+class SchemaInferenceMode(str, Enum):
+    """Enumeration of the available schema inference modes."""
+
+    SILENT = "silent"
+    INFO = "info"
+    INTERACTIVE = "interactive"
+
+
+@dataclass
+class SchemaInferenceResult:
+    """Container with the output of :class:`SchemaInferencer.infer`."""
+
+    schema: Schema
+    mode: SchemaInferenceMode
+    review_columns: List[str]
+    column_notes: Mapping[str, str]
+    messages: List[str]
+
+
+class SchemaInferencer:
+    """Infer a :class:`Schema` from a dataframe using descriptive statistics.
+
+    Parameters
+    ----------
+    categorical_overrides:
+        Columns that must always be considered categorical regardless of their
+        observed statistics.
+    """
+
+    def __init__(self, *, categorical_overrides: Optional[Iterable[str]] = None):
+        self._categorical_overrides = set(categorical_overrides or [])
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def infer(
+        self,
+        df: pd.DataFrame,
+        feature_columns: Optional[Iterable[str]] = None,
+        *,
+        mode: SchemaInferenceMode = SchemaInferenceMode.SILENT,
+    ) -> SchemaInferenceResult:
+        """Infer a :class:`Schema` from ``df`` under the requested ``mode``.
+
+        The silent mode returns the automatically inferred schema.  Info mode
+        includes human-readable messages for columns that are close to the
+        heuristic thresholds.  Interactive mode optionally launches a review UI
+        when the environment supports it, allowing users to confirm or adjust
+        the inferred types.
+        """
+
+        columns = list(feature_columns) if feature_columns is not None else list(df.columns)
+
+        schema_dict: Dict[str, MutableMapping[str, object]] = {}
+        review_notes: Dict[str, str] = {}
+
+        for column in columns:
+            spec, notes = self._infer_column_schema(column, df[column])
+            schema_dict[column] = dict(spec)
+            if notes:
+                review_notes[column] = notes
+
+        messages: List[str] = []
+        if mode in {SchemaInferenceMode.INFO, SchemaInferenceMode.INTERACTIVE} and review_notes:
+            for name, note in review_notes.items():
+                messages.append(f"Column '{name}' flagged for review: {note}")
+
+        if mode is SchemaInferenceMode.INTERACTIVE and review_notes:
+            if self._can_launch_gui():
+                updated = self._interactive_review(df, schema_dict, review_notes)
+                if updated:
+                    messages.append(
+                        "Interactive review applied to: " + ", ".join(sorted(updated))
+                    )
+            else:
+                messages.append(
+                    "Interactive review not available in the current environment; "
+                    "returning the automatically inferred schema."
+                )
+
+        result_schema = Schema(schema_dict)
+        return SchemaInferenceResult(
+            schema=result_schema,
+            mode=mode,
+            review_columns=list(review_notes.keys()),
+            column_notes=review_notes,
+            messages=messages,
+        )
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _infer_column_schema(
+        self, column: str, series: pd.Series
+    ) -> Tuple[Mapping[str, object], str]:
+        if column in self._categorical_overrides:
+            nunique = int(series.dropna().nunique())
+            spec = self._categorical_spec(nunique)
+            return spec, "Categorical override applied."
+
+        if is_bool_dtype(series):
+            nunique = int(series.dropna().nunique())
+            return self._categorical_spec(nunique), "Boolean column coerced to categorical."
+
+        non_null = series.dropna()
+        if non_null.empty:
+            return {"type": "real"}, "Column empty after removing missing values."
+
+        if is_numeric_dtype(series):
+            return self._infer_numeric_schema(non_null)
+
+        convertible = pd.to_numeric(non_null, errors="coerce")
+        coverage = float(convertible.notna().sum()) / float(len(non_null)) if len(non_null) else 0.0
+        if coverage >= MIN_NUMERIC_COVERAGE:
+            spec, notes = self._infer_numeric_schema(convertible.dropna())
+            extra_note = (
+                "Converted from non-numeric values with high numeric coverage."
+            )
+            full_note = f"{extra_note} {notes}".strip()
+            return spec, full_note
+
+        nunique = int(non_null.nunique())
+        note = (
+            "Treating as categorical; only "
+            f"{coverage:.0%} of values can be safely parsed as numeric."
+        )
+        return self._categorical_spec(nunique), note
+
+    def _infer_numeric_schema(self, series: pd.Series) -> Tuple[Mapping[str, object], str]:
+        numeric = pd.to_numeric(series, errors="coerce").dropna()
+        if numeric.empty:
+            return {"type": "real"}, "No numeric values available after coercion."
+
+        nunique = int(numeric.nunique())
+        non_missing = numeric.size
+        unique_ratio = nunique / non_missing if non_missing else 0.0
+        std = float(numeric.std(ddof=0))
+        value_range = float(numeric.max() - numeric.min())
+        unique_values = set(np.unique(numeric))
+        min_value = float(numeric.min())
+        max_value = float(numeric.max())
+        mean_value = float(numeric.mean()) if non_missing else 0.0
+        ratio = (max_value / max(mean_value, 1e-6)) if mean_value > 0 else float("inf")
+        skewness = float(numeric.skew()) if nunique > 2 else 0.0
+        if np.isnan(skewness):
+            skewness = 0.0
+
+        review_reasons: List[str] = []
+
+        integer_like = bool(
+            np.all(np.isfinite(numeric)) and np.allclose(numeric, np.round(numeric))
+        )
+        if integer_like:
+            int_values = np.round(numeric).astype(int)
+            sorted_unique = np.sort(np.unique(int_values))
+            contiguous = bool(
+                sorted_unique.size > 0
+                and np.array_equal(sorted_unique, np.arange(sorted_unique[0], sorted_unique[-1] + 1))
+            )
+            limited_range = (
+                sorted_unique.size > 0
+                and (sorted_unique[-1] - sorted_unique[0]) <= ORDINAL_RANGE_THRESHOLD
+            )
+            non_negative = min_value >= 0
+            starts_low = sorted_unique.size > 0 and sorted_unique[0] <= 1
+
+            if nunique <= 2 and unique_values.issubset(BINARY_VALUES):
+                if abs(unique_ratio - NUMERIC_CATEGORICAL_THRESHOLD) <= REVIEW_RATIO_MARGIN:
+                    review_reasons.append("Binary ratio near categorical threshold.")
+                return self._categorical_spec(nunique), " ".join(review_reasons).strip()
+
+            if (
+                non_negative
+                and contiguous
+                and limited_range
+                and nunique <= MAX_CATEGORICAL_UNIQUE
+                and unique_ratio <= NUMERIC_CATEGORICAL_THRESHOLD
+            ):
+                if abs(unique_ratio - NUMERIC_CATEGORICAL_THRESHOLD) <= REVIEW_RATIO_MARGIN:
+                    review_reasons.append("Ordinal ladder near categorical ratio boundary.")
+                if nunique >= MAX_CATEGORICAL_UNIQUE - REVIEW_UNIQUE_MARGIN:
+                    review_reasons.append("Ordinal ladder near size threshold.")
+                return self._ordinal_spec(nunique), " ".join(review_reasons).strip()
+
+            if (
+                non_negative
+                and starts_low
+                and (
+                    unique_ratio > NUMERIC_CATEGORICAL_THRESHOLD
+                    or nunique > MAX_CATEGORICAL_UNIQUE
+                )
+            ):
+                if unique_ratio <= NUMERIC_CATEGORICAL_THRESHOLD + REVIEW_RATIO_MARGIN:
+                    review_reasons.append("Count ladder close to categorical ratio boundary.")
+                return {"type": "count"}, " ".join(review_reasons).strip()
+
+            if nunique <= MAX_CATEGORICAL_UNIQUE and unique_ratio <= NUMERIC_CATEGORICAL_THRESHOLD:
+                if (
+                    abs(unique_ratio - NUMERIC_CATEGORICAL_THRESHOLD) <= REVIEW_RATIO_MARGIN
+                    or nunique >= MAX_CATEGORICAL_UNIQUE - REVIEW_UNIQUE_MARGIN
+                ):
+                    review_reasons.append("Discrete integer near categorical thresholds.")
+                return self._categorical_spec(nunique), " ".join(review_reasons).strip()
+
+            if std <= SMALL_STD_THRESHOLD or value_range <= SMALL_RANGE_THRESHOLD:
+                review_reasons.append("Dispersion too small; treating as categorical.")
+                return self._categorical_spec(nunique), " ".join(review_reasons).strip()
+
+            if non_negative and (
+                skewness >= POSITIVE_SKEW_THRESHOLD or ratio >= POSITIVE_MAX_MEAN_RATIO
+            ):
+                if skewness <= POSITIVE_SKEW_THRESHOLD + REVIEW_SKEW_MARGIN:
+                    review_reasons.append("Positive skew close to threshold.")
+                return {"type": "pos"}, " ".join(review_reasons).strip()
+
+            if unique_ratio <= NUMERIC_CATEGORICAL_THRESHOLD + REVIEW_RATIO_MARGIN:
+                review_reasons.append("Integer feature near categorical threshold.")
+
+            return {"type": "real"}, " ".join(review_reasons).strip()
+
+        if nunique <= 2 and unique_values.issubset(BINARY_VALUES):
+            if abs(unique_ratio - NUMERIC_CATEGORICAL_THRESHOLD) <= REVIEW_RATIO_MARGIN:
+                review_reasons.append("Binary ratio near categorical threshold.")
+            return self._categorical_spec(nunique), " ".join(review_reasons).strip()
+
+        if nunique <= MAX_CATEGORICAL_UNIQUE and unique_ratio <= NUMERIC_CATEGORICAL_THRESHOLD:
+            if std > STD_REAL_FALLBACK or value_range > RANGE_REAL_FALLBACK:
+                review_reasons.append("Dispersion suggests continuous behaviour despite low cardinality.")
+                return {"type": "real"}, " ".join(review_reasons).strip()
+            if (
+                abs(unique_ratio - NUMERIC_CATEGORICAL_THRESHOLD) <= REVIEW_RATIO_MARGIN
+                or nunique >= MAX_CATEGORICAL_UNIQUE - REVIEW_UNIQUE_MARGIN
+            ):
+                review_reasons.append("Floating feature near categorical thresholds.")
+            return self._categorical_spec(nunique), " ".join(review_reasons).strip()
+
+        if std <= SMALL_STD_THRESHOLD or value_range <= SMALL_RANGE_THRESHOLD:
+            review_reasons.append("Dispersion too small; defaulting to categorical.")
+            return self._categorical_spec(nunique), " ".join(review_reasons).strip()
+
+        positive_support = min_value > 0 or (min_value == 0 and max_value > 0)
+        if positive_support and (
+            skewness >= POSITIVE_SKEW_THRESHOLD or ratio >= POSITIVE_MAX_MEAN_RATIO
+        ):
+            if skewness <= POSITIVE_SKEW_THRESHOLD + REVIEW_SKEW_MARGIN:
+                review_reasons.append("Positive skew close to threshold.")
+            return {"type": "pos"}, " ".join(review_reasons).strip()
+
+        if abs(unique_ratio - NUMERIC_CATEGORICAL_THRESHOLD) <= REVIEW_RATIO_MARGIN:
+            review_reasons.append("Continuous feature near categorical ratio boundary.")
+
+        return {"type": "real"}, " ".join(review_reasons).strip()
+
+    # ------------------------------------------------------------------
+    # Interactive helpers
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _can_launch_gui() -> bool:
+        if plt is None or matplotlib is None:
+            return False
+        backend = matplotlib.get_backend().lower()
+        interactive_backends = {
+            "qt5agg",
+            "qt4agg",
+            "tkagg",
+            "macosx",
+            "gtk3agg",
+            "wxagg",
+        }
+        has_display = bool(os.environ.get("DISPLAY") or sys.platform in {"win32", "darwin"})
+        return backend in interactive_backends and has_display
+
+    def _interactive_review(
+        self,
+        df: pd.DataFrame,
+        schema_dict: Dict[str, MutableMapping[str, object]],
+        review_notes: Mapping[str, str],
+    ) -> List[str]:
+        if plt is None:
+            return []
+
+        updated: List[str] = []
+        for column in review_notes:
+            series = df[column].dropna()
+            if series.empty:
+                continue
+
+            fig, ax = plt.subplots()
+            self._plot_distribution(ax, series)
+            ax.set_title(f"{column}: inferred {schema_dict[column]['type']}")
+            fig.tight_layout()
+            plt.show(block=True)
+            plt.close(fig)
+
+            while True:
+                prompt = (
+                    f"Column '{column}' inferred as {schema_dict[column]['type']}. "
+                    "Enter a new type [real/pos/count/cat/ordinal] or press Enter to accept: "
+                )
+                user_input = input(prompt).strip().lower()
+                if not user_input:
+                    break
+                if user_input in {"real", "pos", "count", "cat", "ordinal"}:
+                    schema_dict[column] = self._spec_from_type(user_input, series)
+                    updated.append(column)
+                    break
+                print("Unrecognised type. Please enter one of: real, pos, count, cat, ordinal.")
+
+        return updated
+
+    @staticmethod
+    def _plot_distribution(ax, series: pd.Series) -> None:
+        if is_numeric_dtype(series):
+            ax.hist(series, bins=min(30, max(5, int(np.sqrt(series.size)))), color="tab:blue", alpha=0.75)
+            ax.set_xlabel("Value")
+            ax.set_ylabel("Frequency")
+        else:
+            counts = series.astype(str).value_counts().sort_index()
+            positions = np.arange(len(counts.index))
+            ax.bar(positions, counts.values, color="tab:blue", alpha=0.75)
+            ax.set_xticks(positions)
+            ax.set_xticklabels(counts.index, rotation=45, ha="right")
+            ax.set_ylabel("Count")
+
+    @staticmethod
+    def _spec_from_type(column_type: str, series: pd.Series) -> Mapping[str, object]:
+        if column_type in {"cat", "ordinal"}:
+            nunique = int(series.dropna().nunique())
+            return {"type": column_type, "n_classes": max(nunique, 2)}
+        return {"type": column_type}
+
+    @staticmethod
+    def _categorical_spec(nunique: int) -> Mapping[str, object]:
+        return {"type": "cat", "n_classes": max(int(nunique), 2)}
+
+    @staticmethod
+    def _ordinal_spec(nunique: int) -> Mapping[str, object]:
+        return {"type": "ordinal", "n_classes": max(int(nunique), 2)}
+
+
+__all__ = [
+    "SchemaInferencer",
+    "SchemaInferenceMode",
+    "SchemaInferenceResult",
+]

--- a/tests/test_schema_inference.py
+++ b/tests/test_schema_inference.py
@@ -1,0 +1,60 @@
+"""Tests for the schema inference helper."""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+from suave.schema_inference import SchemaInferenceMode, SchemaInferencer
+
+
+def test_infer_silent_mode_returns_schema_only() -> None:
+    df = pd.DataFrame(
+        {
+            "age": np.linspace(10, 80, num=50),
+            "sex": ["M", "F"] * 25,
+            "count_feature": [0, 1, 2, 3, 4] * 10,
+        }
+    )
+    inferencer = SchemaInferencer(categorical_overrides={"sex"})
+    result = inferencer.infer(df, mode=SchemaInferenceMode.SILENT)
+    schema_dict = result.schema.to_dict()
+
+    assert schema_dict["age"]["type"] == "real"
+    assert schema_dict["sex"]["type"] == "cat"
+    assert schema_dict["count_feature"]["type"] == "count"
+    assert result.mode is SchemaInferenceMode.SILENT
+    assert result.messages == []
+
+
+def test_info_mode_highlights_columns_near_threshold() -> None:
+    repeated_pattern = [0, 1, 2] * 20  # unique ratio close to categorical threshold
+    df = pd.DataFrame(
+        {
+            "possibly_categorical": repeated_pattern,
+            "continuous": np.linspace(0.0, 1.0, num=len(repeated_pattern)),
+        }
+    )
+    inferencer = SchemaInferencer()
+    result = inferencer.infer(df, mode=SchemaInferenceMode.INFO)
+
+    assert "possibly_categorical" in result.review_columns
+    assert any("possibly_categorical" in message for message in result.messages)
+
+
+def test_interactive_mode_gracefully_falls_back(monkeypatch) -> None:
+    df = pd.DataFrame(
+        {
+            "flagged": [0, 1] + [0] * 38,
+        }
+    )
+    inferencer = SchemaInferencer()
+    monkeypatch.setattr(
+        SchemaInferencer,
+        "_can_launch_gui",
+        staticmethod(lambda: False),
+    )
+    result = inferencer.infer(df, mode=SchemaInferenceMode.INTERACTIVE)
+
+    assert "flagged" in result.review_columns
+    assert any("Interactive review not available" in message for message in result.messages)


### PR DESCRIPTION
## Summary
- widen the Optuna search space for the mortality example with additional latent/hidden configurations, broader batch sizes, and tuned regularisation ranges while keeping epoch counts practical
- fix the generated report so TSTR/TRTR AUROC values and membership inference summaries populate correctly using the evaluated metrics

## Testing
- python examples/mimic_mortality_supervised.py --optuna-trials 12 --optuna-timeout 3600
- pytest -q


------
https://chatgpt.com/codex/tasks/task_e_68d18264362c8320b64b3eac4089f021