### PR TITLE
Expose core submodules via package init

### DIFF
--- a/SUAVE/__init__.py
+++ b/SUAVE/__init__.py
@@ -8,7 +8,14 @@ from suave import *  # noqa: F401,F403
 
 __path__ = list(_suave.__path__)
 
-for _name in ("interactive", "types", "schema_inference"):
+for _name in (
+    "interactive",
+    "types",
+    "schema_inference",
+    "data",
+    "evaluate",
+    "sampling",
+):
     sys.modules[f"SUAVE.{_name}"] = import_module(f"suave.{_name}")
 
 sys.modules["SUAVE.interactive.schema_builder"] = import_module(

--- a/suave/__init__.py
+++ b/suave/__init__.py
@@ -3,11 +3,34 @@
 This module exposes the user-facing classes that are required for the
 minimal runnable skeleton requested in the roadmap.  The real
 implementation will iterate on top of these public entry points.
+
+In addition to the primary estimator and schema helpers, we re-export
+common utility submodules (``data``, ``evaluate``, ``sampling`` and
+``interactive``) so that ``import suave`` mirrors the public namespace
+documented throughout the examples.  Users can therefore rely on
+``suave.data`` or ``suave.evaluate`` without performing an additional
+import of the underlying modules.
 """
+
+from importlib import import_module
 
 from .model import SUAVE
 from .types import Schema
-from .schema_inference import SchemaInferenceMode, SchemaInferenceResult, SchemaInferencer
+from .schema_inference import (
+    SchemaInferenceMode,
+    SchemaInferenceResult,
+    SchemaInferencer,
+)
+
+# Re-export commonly used helper modules so that importing ``suave``
+# exposes the documented namespace without requiring users to jump
+# between subpackages explicitly.
+data = import_module(".data", __name__)
+evaluate = import_module(".evaluate", __name__)
+interactive = import_module(".interactive", __name__)
+sampling = import_module(".sampling", __name__)
+types = import_module(".types", __name__)
+schema_inference = import_module(".schema_inference", __name__)
 
 __all__ = [
     "SUAVE",
@@ -15,4 +38,10 @@ __all__ = [
     "SchemaInferencer",
     "SchemaInferenceMode",
     "SchemaInferenceResult",
+    "data",
+    "evaluate",
+    "interactive",
+    "sampling",
+    "types",
+    "schema_inference",
 ]

--- a/suave/interactive/schema_builder.py
+++ b/suave/interactive/schema_builder.py
@@ -13,7 +13,7 @@ import threading
 import time
 import webbrowser
 from dataclasses import dataclass
-from typing import Dict, Iterable, List, Mapping, MutableMapping, Optional, Tuple
+from typing import Dict, Iterable, List, MutableMapping, Optional
 
 import numpy as np
 import pandas as pd
@@ -553,7 +553,6 @@ loadState();
 """
 
 
-
 def launch_schema_builder(
     df: pd.DataFrame,
     feature_columns: Optional[Iterable[str]] = None,
@@ -652,7 +651,9 @@ class _SchemaBuilder:
             value = getattr(raw_confidence, "value", raw_confidence)
             self._confidence_map[name] = str(value)
         if not self._messages:
-            self._messages = ["Schema inferred automatically; adjust columns as needed."]
+            self._messages = [
+                "Schema inferred automatically; adjust columns as needed."
+            ]
         self._lock = threading.Lock()
         self._stop_event = threading.Event()
         self._cancelled = False
@@ -674,7 +675,9 @@ class _SchemaBuilder:
 
         if self._open_browser:
             url = f"http://{self._host}:{self._port}/"
-            threading.Thread(target=self._launch_browser, args=(url,), daemon=True).start()
+            threading.Thread(
+                target=self._launch_browser, args=(url,), daemon=True
+            ).start()
 
         self._stop_event.wait()
         server.shutdown()
@@ -702,7 +705,9 @@ class _SchemaBuilder:
         def state():
             with self._lock:
                 payload = {
-                    "columns": [self._column_state(name).to_dict() for name in self._schema_dict],
+                    "columns": [
+                        self._column_state(name).to_dict() for name in self._schema_dict
+                    ],
                     "messages": list(self._messages),
                 }
             return jsonify(payload)
@@ -729,16 +734,26 @@ class _SchemaBuilder:
             updated_spec: MutableMapping[str, object] = {"type": new_type}
             if new_type in {"cat", "ordinal"}:
                 if n_classes is None:
-                    return jsonify(
-                        {
-                            "error": (
-                                f"Column '{column}' is '{new_type}' and requires 'n_classes' > 1."
-                            )
-                        }
-                    ), 400
+                    return (
+                        jsonify(
+                            {
+                                "error": (
+                                    f"Column '{column}' is '{new_type}' and requires 'n_classes' > 1."
+                                )
+                            }
+                        ),
+                        400,
+                    )
                 updated_spec["n_classes"] = int(n_classes)
             elif n_classes is not None:
-                return jsonify({"error": "'n_classes' only applies to categorical/ordinal types."}), 400
+                return (
+                    jsonify(
+                        {
+                            "error": "'n_classes' only applies to categorical/ordinal types."
+                        }
+                    ),
+                    400,
+                )
 
             if y_dim is not None:
                 updated_spec["y_dim"] = int(y_dim)


### PR DESCRIPTION
## Summary
- re-export the data, evaluate, interactive, sampling, types, and schema_inference submodules from suave.__init__ so that `import suave` exposes the documented API surface
- extend the uppercase SUAVE compatibility shim to forward to the newly re-exported helper modules
- trim unused typing imports in the interactive schema builder to keep the lint configuration clean

## Testing
- python -m ruff check suave SUAVE tests -q
- python -m pytest -q


------
https://chatgpt.com/codex/tasks/task_e_68d2bbcbcd7c832097b951382b32bbd2