### PR TITLE
Clarify schema builder type descriptions

### DIFF
--- a/suave/modules/decoder.py
+++ b/suave/modules/decoder.py
@@ -98,7 +98,7 @@ class RealHead(LikelihoodHead):
 
 
 class PosHead(LikelihoodHead):
-    """Log-normal reconstruction head for strictly positive features."""
+    """Log-normal reconstruction head for non-negative features processed via ``log1p``."""
 
     def __init__(self, y_dim: int, n_components: int) -> None:
         super().__init__(y_dim, n_components)

--- a/suave/types.py
+++ b/suave/types.py
@@ -50,7 +50,7 @@ class Schema:
         Mapping of column names to dictionaries with at least the ``"type"``
         key. Supported types are:
             - ``"real"`` : continuous values (Gaussian head),
-            - ``"pos"`` : positive real values (log-normal head),
+            - ``"pos"`` : non-negative real values (``log1p`` + log-normal head),
             - ``"count"`` : non-negative integers (Poisson head),
             - ``"cat"`` : categorical (requires ``"n_classes"``),
             - ``"ordinal"`` : ordered discrete (requires ``"n_classes"``).


### PR DESCRIPTION
## Summary
- clarify the interactive schema builder tooltip with domain assumptions, example distributions, and a clearer ordinal-versus-count distinction
- align decoder and schema documentation to describe `pos` features as non-negative values handled via `log1p`

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d2c638e1208320a61985350a3d218a