### PR TITLE
Add configurable hidden layers to classification head

### DIFF
--- a/tests/test_minimal.py
+++ b/tests/test_minimal.py
@@ -177,6 +177,28 @@ def test_predict_proba_refreshes_cache_for_new_frames():
     assert refreshed.shape == (len(X), 2)
 
 
+def test_multilayer_classification_head_runs_end_to_end():
+    X, y, schema = make_dataset()
+    hidden_dims = (16, 8)
+    model = SUAVE(
+        schema=schema,
+        n_components=2,
+        head_hidden_dims=hidden_dims,
+        dropout=0.2,
+        batch_size=2,
+    )
+    model.fit(X, y, epochs=1)
+
+    assert model._classifier is not None
+    assert model._classifier.linear.in_features == hidden_dims[-1]
+
+    probabilities = model.predict_proba(X)
+    predictions = model.predict(X)
+
+    assert probabilities.shape == (len(X), 2)
+    assert predictions.shape == (len(X),)
+
+
 def test_encode_returns_latent_means():
     X, y, schema = make_dataset()
     model = SUAVE(schema=schema, latent_dim=4, batch_size=2, n_components=2)


### PR DESCRIPTION
## Summary
- allow ClassificationHead to build optional hidden MLP stacks with configurable sizes
- expose `head_hidden_dims` on `SUAVE` to wire the new head architecture through training, saving, and loading
- add a regression test covering training and inference with a multi-layer classification head

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d2cf0de72c8320840f52923708fbc3