### PR TITLE
Refine mortality supervised example for single-label workflow

### DIFF
--- a/examples/mimic_mortality_supervised.py
+++ b/examples/mimic_mortality_supervised.py
@@ -10,7 +10,9 @@ import json
 from pathlib import Path
 import time
 from typing import Dict, List, Mapping, Optional, Tuple
-from IPython.display import Markdown, display
+
+from IPython.display import display
+from tabulate import tabulate
 
 import numpy as np
 import pandas as pd
@@ -18,6 +20,7 @@ from matplotlib import pyplot as plt
 from sklearn.calibration import calibration_curve
 from sklearn.decomposition import PCA
 from sklearn.impute import SimpleImputer
+from sklearn.ensemble import RandomForestClassifier
 from sklearn.linear_model import LogisticRegression
 from sklearn.metrics import (
     accuracy_score,
@@ -25,8 +28,11 @@ from sklearn.metrics import (
     confusion_matrix,
     roc_auc_score,
 )
+from sklearn.neighbors import KNeighborsClassifier
 from sklearn.pipeline import Pipeline
 from sklearn.preprocessing import StandardScaler
+from sklearn.svm import SVC
+from sklearn.tree import DecisionTreeClassifier
 
 EXAMPLES_DIR = Path().resolve()
 if not EXAMPLES_DIR.exists():
@@ -42,13 +48,11 @@ from mimic_mortality_utils import (
     Schema,
     define_schema,
     
-    format_float,
     kolmogorov_smirnov_statistic,
     load_dataset,
     mutual_information_feature,
     prepare_features,
     rbf_mmd,
-    schema_markdown_table,
     split_train_validation_calibration,
     to_numeric_frame,
 )
@@ -64,41 +68,127 @@ except ImportError as exc:  # pragma: no cover - optuna provided via requirement
     ) from exc
 
 
+def is_interactive_session() -> bool:
+    """Return ``True`` when running inside an interactive IPython session."""
+
+    try:
+        from IPython import get_ipython
+    except ImportError:
+        return False
+    return get_ipython() is not None
+
+
+def render_dataframe(
+    df: pd.DataFrame,
+    *,
+    title: Optional[str] = None,
+    floatfmt: Optional[str] = ".3f",
+) -> None:
+    """Display ``df`` using ``display`` when interactive, otherwise print via tabulate."""
+
+    if title:
+        print(title)
+    if df.empty:
+        print("(empty table)")
+        return
+    if is_interactive_session():
+        display(df)
+    else:
+        tabulate_kwargs = {"headers": "keys", "tablefmt": "github", "showindex": False}
+        if floatfmt is not None:
+            tabulate_kwargs["floatfmt"] = floatfmt
+        print(tabulate(df, **tabulate_kwargs))
+
+
+def dataframe_to_markdown(df: pd.DataFrame, *, floatfmt: Optional[str] = ".3f") -> str:
+    """Return a GitHub-flavoured Markdown table representing ``df``."""
+
+    if df.empty:
+        return "_No data available._"
+    tabulate_kwargs = {"headers": "keys", "tablefmt": "github", "showindex": False}
+    if floatfmt is not None:
+        tabulate_kwargs["floatfmt"] = floatfmt
+    return tabulate(df, **tabulate_kwargs)
+
+
+def schema_to_dataframe(schema: Schema) -> pd.DataFrame:
+    """Convert a :class:`Schema` into a tidy :class:`pandas.DataFrame`."""
+
+    schema_records: List[Dict[str, object]] = []
+    for column, spec in schema.to_dict().items():
+        schema_records.append(
+            {
+                "Column": column,
+                "Type": spec.get("type", ""),
+                "n_classes": spec.get("n_classes", ""),
+                "y_dim": spec.get("y_dim", ""),
+            }
+        )
+    return pd.DataFrame(schema_records)
+
+
+#%% [markdown]
+# ## Analysis configuration
+#
+# Define the label to model and tuning/runtime parameters. Setting the label up
+# front avoids looping over every possible prediction task so that the analysis
+# remains focused on a single clinical question.
+
 # %%
 
-# Configuration
+# Select the target label to model. Choose from the columns listed in
+# ``TARGET_COLUMNS`` loaded from ``mimic_mortality_utils``.
+TARGET_LABEL = "in_hospital_mortality"
+
+# Configuration for Optuna search and output artifacts.
 analysis_config = {
     "optuna_trials": 60,
-    "optuna_timeout": 3600*48,
+    "optuna_timeout": 3600 * 48,
     "optuna_study_prefix": "supervised",
     "optuna_storage": None,
     "output_dir_name": "analysis_outputs_supervised",
 }
 
+#%% [markdown]
+# ## Data loading and schema definition
+#
+# Load train/test/external splits, construct the schema, and validate the
+# requested target label. Schema corrections are added here so that the
+# downstream modelling code receives explicit type information.
 
 # %%
 
 DATA_DIR = (EXAMPLES_DIR / "data" / "sepsis_mortality_dataset").resolve()
 OUTPUT_DIR = EXAMPLES_DIR / analysis_config["output_dir_name"]
 OUTPUT_DIR.mkdir(exist_ok=True)
-analysis_config['optuna_storage'] = f'sqlite:///{OUTPUT_DIR}/{analysis_config["optuna_study_prefix"]}_optuna.db'
+analysis_config["optuna_storage"] = (
+    f"sqlite:///{OUTPUT_DIR}/{analysis_config['optuna_study_prefix']}_optuna.db"
+)
 
 train_df = load_dataset(DATA_DIR / "mimic-mortality-train.tsv")
 test_df = load_dataset(DATA_DIR / "mimic-mortality-test.tsv")
 external_df = load_dataset(DATA_DIR / "eicu-mortality-external_val.tsv")
 
+if TARGET_LABEL not in TARGET_COLUMNS:
+    raise ValueError(
+        f"Target label '{TARGET_LABEL}' is not one of the configured targets: {TARGET_COLUMNS}"
+    )
+
 FEATURE_COLUMNS = [column for column in train_df.columns if column not in TARGET_COLUMNS]
 schema = define_schema(train_df, FEATURE_COLUMNS, mode="interactive")
 
-# manual schema correction
-schema.update({'BMI':{'type': 'real'},
-               'Respiratory_Support':{'type': 'ordinal', 'n_classes': 5},
-               'LYM%':{'type': 'real'}
-               })
+# Manual schema corrections ensure columns with ambiguous types are treated
+# appropriately during modelling.
+schema.update(
+    {
+        "BMI": {"type": "real"},
+        "Respiratory_Support": {"type": "ordinal", "n_classes": 5},
+        "LYM%": {"type": "real"},
+    }
+)
 
-
-schema_table = schema_markdown_table(schema)
-display(Markdown(schema_table))
+schema_df = schema_to_dataframe(schema).sort_values("Column").reset_index(drop=True)
+render_dataframe(schema_df, title="Schema overview", floatfmt=None)
 
 
 # %%
@@ -118,8 +208,6 @@ HEAD_HIDDEN_DIMENSION_OPTIONS: Dict[str, Tuple[int, int]] = {
     "wide": (96, 48, 16),
     "extra_wide": (64, 128, 64, 16),
 }
-
-
 def make_logistic_pipeline() -> Pipeline:
     """Factory for the baseline classifier used in TSTR/TRTR."""
 
@@ -352,209 +440,337 @@ def plot_latent_space(
     plt.close(fig)
 
 
-# %%
-metrics_records: List[Dict[str, object]] = []
-membership_records: List[Dict[str, object]] = []
-optuna_reports: Dict[str, Dict[str, object]] = {}
-calibration_paths: Dict[str, Path] = {}
-latent_paths: Dict[str, Path] = {}
+#%% [markdown]
+# ## Prepare modelling datasets
+#
+# Create train/validation/calibration splits for the selected label. The split
+# mirrors the original notebook so that Optuna tuning and calibration operate on
+# disjoint subsets.
 
-models: Dict[str, SUAVE] = {}
+# %%
+
+X_full = prepare_features(train_df, FEATURE_COLUMNS)
+y_full = train_df[TARGET_LABEL]
+
+(
+    X_train_model,
+    X_validation,
+    X_calibration,
+    y_train_model,
+    y_validation,
+    y_calibration,
+) = split_train_validation_calibration(
+    X_full,
+    y_full,
+    calibration_size=CALIBRATION_SIZE,
+    validation_size=VALIDATION_SIZE,
+    random_state=RANDOM_STATE,
+)
+
+# Prepare holdout datasets once to reuse across later cells.
+X_test = prepare_features(test_df, FEATURE_COLUMNS)
+y_test = test_df[TARGET_LABEL]
+
+external_features: Optional[pd.DataFrame]
+external_labels: Optional[pd.Series]
+if TARGET_LABEL in external_df.columns:
+    external_features = prepare_features(external_df, FEATURE_COLUMNS)
+    external_labels = external_df[TARGET_LABEL]
+else:
+    external_features = None
+    external_labels = None
+
+
+#%% [markdown]
+# ## Classical model benchmarks
+#
+# Fit a suite of scikit-learn classifiers as quick baselines before training
+# SUAVE. These provide a reference point for MIMIC test performance and, when
+# available, eICU external validation.
+
+# %%
+
+baseline_models = {
+    "Logistic regression": Pipeline(
+        [
+            ("imputer", SimpleImputer(strategy="median")),
+            ("scaler", StandardScaler()),
+            (
+                "classifier",
+                LogisticRegression(max_iter=500, random_state=RANDOM_STATE),
+            ),
+        ]
+    ),
+    "KNN": Pipeline(
+        [
+            ("imputer", SimpleImputer(strategy="median")),
+            ("scaler", StandardScaler()),
+            ("classifier", KNeighborsClassifier(n_neighbors=25)),
+        ]
+    ),
+    "Decision tree": Pipeline(
+        [
+            ("imputer", SimpleImputer(strategy="median")),
+            ("classifier", DecisionTreeClassifier(random_state=RANDOM_STATE)),
+        ]
+    ),
+    "Random forest": Pipeline(
+        [
+            ("imputer", SimpleImputer(strategy="median")),
+            (
+                "classifier",
+                RandomForestClassifier(n_estimators=200, random_state=RANDOM_STATE),
+            ),
+        ]
+    ),
+    "SVM (RBF)": Pipeline(
+        [
+            ("imputer", SimpleImputer(strategy="median")),
+            ("scaler", StandardScaler()),
+            ("classifier", SVC(kernel="rbf", probability=True)),
+        ]
+    ),
+}
+
+baseline_evaluation_sets: Dict[str, Tuple[pd.DataFrame, pd.Series]] = {
+    "MIMIC test": (X_test, y_test)
+}
+if external_features is not None and external_labels is not None:
+    baseline_evaluation_sets["eICU external"] = (external_features, external_labels)
+
+baseline_rows: List[Dict[str, object]] = []
+metric_columns = ["AUC", "ACC", "SPE", "SEN", "Brier"]
+
+for model_name, estimator in baseline_models.items():
+    fitted_estimator = estimator.fit(X_train_model, y_train_model)
+    for dataset_name, (features, labels) in baseline_evaluation_sets.items():
+        probabilities = fitted_estimator.predict_proba(features)
+        metrics = compute_binary_metrics(probabilities, labels)
+        row = {
+            "Model": model_name,
+            "Dataset": dataset_name,
+            "Notes": "",
+        }
+        row.update({column: metrics.get(column, float("nan")) for column in metric_columns})
+        baseline_rows.append(row)
+
+    if "eICU external" not in baseline_evaluation_sets:
+        baseline_rows.append(
+            {
+                "Model": model_name,
+                "Dataset": "eICU external",
+                "Notes": "Target not available in eICU split.",
+                **{column: float("nan") for column in metric_columns},
+            }
+        )
+
+baseline_df = pd.DataFrame(baseline_rows)
+baseline_order = ["Model", "Dataset", *metric_columns, "Notes"]
+baseline_df = baseline_df.loc[:, baseline_order]
+baseline_path = OUTPUT_DIR / f"baseline_models_{TARGET_LABEL}.csv"
+baseline_df.to_csv(baseline_path, index=False)
+render_dataframe(
+    baseline_df,
+    title=f"Classical baseline performance for {TARGET_LABEL}",
+    floatfmt=".3f",
+)
+
+
+#%% [markdown]
+# ## Hyperparameter search with Optuna
+#
+# Optimise SUAVE hyperparameters on the training/validation split. The trial
+# history is persisted to CSV for later inspection.
+
+# %%
+
+study_name = (
+    f"{analysis_config['optuna_study_prefix']}_{TARGET_LABEL}"
+    if analysis_config["optuna_study_prefix"]
+    else None
+)
+study, optuna_best_info = run_optuna_search(
+    X_train_model,
+    y_train_model,
+    X_validation,
+    y_validation,
+    schema,
+    random_state=RANDOM_STATE,
+    n_trials=analysis_config["optuna_trials"],
+    timeout=analysis_config["optuna_timeout"],
+    study_name=study_name,
+    storage=analysis_config["optuna_storage"],
+)
+
+optuna_best_params = dict(optuna_best_info.get("params", {}))
+
+trial_rows: List[Dict[str, object]] = []
+for trial in study.trials:
+    record: Dict[str, object] = {
+        "trial_number": trial.number,
+        "value": trial.value,
+    }
+    record.update(trial.params)
+    val_metrics = trial.user_attrs.get("validation_metrics")
+    if isinstance(val_metrics, Mapping):
+        for metric_name, metric_value in val_metrics.items():
+            record[f"validation_{metric_name.lower()}"] = metric_value
+    fit_seconds = trial.user_attrs.get("fit_seconds")
+    if fit_seconds is not None:
+        record["fit_seconds"] = fit_seconds
+    trial_rows.append(record)
+
+optuna_trials_df = pd.DataFrame(trial_rows)
+optuna_trials_path = OUTPUT_DIR / f"optuna_trials_{TARGET_LABEL}.csv"
+if not optuna_trials_df.empty:
+    optuna_trials_df.to_csv(optuna_trials_path, index=False)
+else:
+    optuna_trials_path.write_text("trial_number,value")
+
+
+#%% [markdown]
+# ## Model training
+#
+# Instantiate SUAVE with the best Optuna configuration and fit/calibrate on the
+# appropriate subsets.
+
+# %%
+
+hidden_key = str(optuna_best_params.get("hidden_dims", "medium"))
+head_hidden_key = str(optuna_best_params.get("head_hidden_dims", "medium"))
+hidden_dims = HIDDEN_DIMENSION_OPTIONS.get(hidden_key, HIDDEN_DIMENSION_OPTIONS["medium"])
+head_hidden_dims = HEAD_HIDDEN_DIMENSION_OPTIONS.get(
+    head_hidden_key, HEAD_HIDDEN_DIMENSION_OPTIONS["medium"]
+)
+
+model = SUAVE(
+    schema=schema,
+    latent_dim=int(optuna_best_params.get("latent_dim", 16)),
+    hidden_dims=hidden_dims,
+    head_hidden_dims=head_hidden_dims,
+    dropout=float(optuna_best_params.get("dropout", 0.1)),
+    learning_rate=float(optuna_best_params.get("learning_rate", 1e-3)),
+    batch_size=int(optuna_best_params.get("batch_size", 256)),
+    beta=float(optuna_best_params.get("beta", 1.5)),
+    random_state=RANDOM_STATE,
+    behaviour="supervised",
+)
+
+model.fit(
+    X_train_model,
+    y_train_model,
+    warmup_epochs=int(optuna_best_params.get("warmup_epochs", 3)),
+    head_epochs=int(optuna_best_params.get("head_epochs", 2)),
+    finetune_epochs=int(optuna_best_params.get("finetune_epochs", 2)),
+    joint_decoder_lr_scale=float(optuna_best_params.get("joint_decoder_lr_scale", 0.1)),
+)
+model.calibrate(X_calibration, y_calibration)
+
+
+#%% [markdown]
+# ## Prognosis prediction and evaluation
+#
+# Evaluate the trained model on train/validation/test/eICU cohorts, generate
+# calibration curves, and run a membership inference baseline.
+
+# %%
+
+evaluation_datasets: Dict[str, Tuple[pd.DataFrame, pd.Series]] = {
+    "Train": (X_train_model, y_train_model),
+    "Validation": (X_validation, y_validation),
+    "MIMIC test": (X_test, y_test),
+}
+if external_features is not None and external_labels is not None:
+    evaluation_datasets["eICU external"] = (external_features, external_labels)
+
+probability_map: Dict[str, np.ndarray] = {}
+label_map: Dict[str, np.ndarray] = {}
+metrics_rows: List[Dict[str, object]] = []
+
+for dataset_name, (features, labels) in evaluation_datasets.items():
+    probs = model.predict_proba(features)
+    probability_map[dataset_name] = probs
+    label_map[dataset_name] = np.asarray(labels)
+    metrics = compute_binary_metrics(probs, labels)
+    metrics_rows.append({"target": TARGET_LABEL, "dataset": dataset_name, **metrics})
+
+metrics_df = pd.DataFrame(metrics_rows)
+ordered_metric_columns = [
+    "target",
+    "dataset",
+    "AUC",
+    "ACC",
+    "SPE",
+    "SEN",
+    "Brier",
+]
+existing_columns = [column for column in ordered_metric_columns if column in metrics_df.columns]
+if existing_columns:
+    metrics_df = metrics_df.loc[:, existing_columns]
+metrics_path = OUTPUT_DIR / "evaluation_metrics.csv"
+metrics_df.to_csv(metrics_path, index=False)
+render_dataframe(
+    metrics_df,
+    title=f"Evaluation metrics for {TARGET_LABEL}",
+    floatfmt=".3f",
+)
+
+calibration_path = OUTPUT_DIR / f"calibration_{TARGET_LABEL}.png"
+plot_calibration_curves(
+    probability_map, label_map, target_name=TARGET_LABEL, output_path=calibration_path
+)
+
+train_probabilities = probability_map["Train"]
+test_probabilities = probability_map["MIMIC test"]
+membership_metrics = simple_membership_inference(
+    train_probabilities,
+    np.asarray(y_train_model),
+    test_probabilities,
+    np.asarray(y_test),
+)
+membership_df = pd.DataFrame([{"target": TARGET_LABEL, **membership_metrics}])
+membership_path = OUTPUT_DIR / "membership_inference.csv"
+membership_df.to_csv(membership_path, index=False)
+render_dataframe(
+    membership_df,
+    title="Membership inference baseline",
+    floatfmt=".3f",
+)
+
+
+#%% [markdown]
+# ## TSTR/TRTR comparison
+#
+# Compare models trained on synthetic versus real data. The analysis is only
+# relevant when the current task models in-hospital mortality, matching the
+# publication results.
+
+# %%
 
 tstr_results: Optional[pd.DataFrame] = None
 tstr_path: Optional[Path] = None
 distribution_df: Optional[pd.DataFrame] = None
 distribution_path: Optional[Path] = None
+distribution_top: Optional[pd.DataFrame] = None
 
-for target in TARGET_COLUMNS:
-    if target not in train_df.columns:
-        continue
-    print(f"Training supervised model for {target}…")
-    X_full = prepare_features(train_df, FEATURE_COLUMNS)
-    y_full = train_df[target]
-
-    (
-        X_train_model,
-        X_validation,
-        X_calibration,
-        y_train_model,
-        y_validation,
-        y_calibration,
-    ) = split_train_validation_calibration(
-        X_full,
-        y_full,
-        calibration_size=CALIBRATION_SIZE,
-        validation_size=VALIDATION_SIZE,
-        random_state=RANDOM_STATE,
+if TARGET_LABEL != "in_hospital_mortality":
+    print(
+        "Skipping TSTR/TRTR comparison because it is defined for the in-hospital "
+        "mortality task."
     )
-
-    study_name = (
-        f"{analysis_config['optuna_study_prefix']}_{target}"
-        if analysis_config["optuna_study_prefix"]
-        else None
-    )
-    study, best_info = run_optuna_search(
-        X_train_model,
-        y_train_model,
-        X_validation,
-        y_validation,
-        schema,
-        random_state=RANDOM_STATE,
-        n_trials=analysis_config["optuna_trials"],
-        timeout=analysis_config["optuna_timeout"],
-        study_name=study_name,
-        storage=analysis_config["optuna_storage"],
-    )
-
-    best_params = dict(best_info.get("params", {}))
-    hidden_key = str(best_params.get("hidden_dims", "medium"))
-    head_hidden_key = str(best_params.get("head_hidden_dims", "medium"))
-    hidden_dims = HIDDEN_DIMENSION_OPTIONS.get(
-        hidden_key, HIDDEN_DIMENSION_OPTIONS["medium"]
-    )
-    head_hidden_dims = HEAD_HIDDEN_DIMENSION_OPTIONS.get(
-        head_hidden_key, HEAD_HIDDEN_DIMENSION_OPTIONS["medium"]
-    )
-    model = SUAVE(
-        schema=schema,
-        latent_dim=int(best_params.get("latent_dim", 16)),
-        hidden_dims=hidden_dims,
-        head_hidden_dims=head_hidden_dims,
-        dropout=float(best_params.get("dropout", 0.1)),
-        learning_rate=float(best_params.get("learning_rate", 1e-3)),
-        batch_size=int(best_params.get("batch_size", 256)),
-        beta=float(best_params.get("beta", 1.5)),
-        random_state=RANDOM_STATE,
-        behaviour="supervised",
-    )
-    model.fit(
-        X_train_model,
-        y_train_model,
-        warmup_epochs=int(best_params.get("warmup_epochs", 3)),
-        head_epochs=int(best_params.get("head_epochs", 2)),
-        finetune_epochs=int(best_params.get("finetune_epochs", 2)),
-        joint_decoder_lr_scale=float(best_params.get("joint_decoder_lr_scale", 0.1)),
-    )
-    model.calibrate(X_calibration, y_calibration)
-    models[target] = model
-
-    evaluation_datasets: Dict[str, Tuple[pd.DataFrame, pd.Series]] = {
-        "Train": (X_train_model, y_train_model),
-        "Validation": (X_validation, y_validation),
-        "MIMIC test": (prepare_features(test_df, FEATURE_COLUMNS), test_df[target]),
-    }
-    if target in external_df.columns:
-        evaluation_datasets["eICU external"] = (
-            prepare_features(external_df, FEATURE_COLUMNS),
-            external_df[target],
-        )
-
-    probability_map: Dict[str, np.ndarray] = {}
-    label_map: Dict[str, np.ndarray] = {}
-    dataset_metric_map: Dict[str, Dict[str, float]] = {}
-
-    for dataset_name, (features, labels) in evaluation_datasets.items():
-        probs = model.predict_proba(features)
-        probability_map[dataset_name] = probs
-        label_map[dataset_name] = np.asarray(labels)
-        metrics = compute_binary_metrics(probs, labels)
-        dataset_metric_map[dataset_name] = metrics
-        metric_row = {
-            "target": target,
-            "dataset": dataset_name,
-            **metrics,
-        }
-        metrics_records.append(metric_row)
-
-    calibration_path = OUTPUT_DIR / f"calibration_{target}.png"
-    plot_calibration_curves(
-        probability_map, label_map, target_name=target, output_path=calibration_path
-    )
-    calibration_paths[target] = calibration_path
-
-    latent_features = {
-        name: features for name, (features, _) in evaluation_datasets.items()
-    }
-    latent_labels = {
-        name: labels for name, (_, labels) in evaluation_datasets.items()
-    }
-    latent_path = OUTPUT_DIR / f"latent_{target}.png"
-    plot_latent_space(
-        model,
-        latent_features,
-        latent_labels,
-        target_name=target,
-        output_path=latent_path,
-    )
-    latent_paths[target] = latent_path
-
-    train_probabilities = probability_map["Train"]
-    test_probabilities = probability_map["MIMIC test"]
-
-    membership = simple_membership_inference(
-        train_probabilities,
-        np.asarray(y_train_model),
-        test_probabilities,
-        np.asarray(evaluation_datasets["MIMIC test"][1]),
-    )
-    membership_records.append({"target": target, **membership})
-
-    trial_rows: List[Dict[str, object]] = []
-    for trial in study.trials:
-        record: Dict[str, object] = {
-            "trial_number": trial.number,
-            "value": trial.value,
-        }
-        record.update(trial.params)
-        val_metrics = trial.user_attrs.get("validation_metrics")
-        if isinstance(val_metrics, Mapping):
-            for metric_name, metric_value in val_metrics.items():
-                record[f"validation_{metric_name.lower()}"] = metric_value
-        fit_seconds = trial.user_attrs.get("fit_seconds")
-        if fit_seconds is not None:
-            record["fit_seconds"] = fit_seconds
-        trial_rows.append(record)
-    trials_df = pd.DataFrame(trial_rows)
-    trials_path = OUTPUT_DIR / f"optuna_trials_{target}.csv"
-    if not trials_df.empty:
-        trials_df.to_csv(trials_path, index=False)
-    else:
-        trials_path.write_text("trial_number,value")
-
-    optuna_reports[target] = {
-        "best": best_info,
-        "best_params": best_params,
-        "metrics": dataset_metric_map,
-        "trials_csv": trials_path,
-    }
-
-metrics_df = pd.DataFrame(metrics_records)
-metrics_path = OUTPUT_DIR / "evaluation_metrics.csv"
-metrics_df.to_csv(metrics_path, index=False)
-
-membership_df = pd.DataFrame(membership_records)
-membership_path = OUTPUT_DIR / "membership_inference.csv"
-membership_df.to_csv(membership_path, index=False)
-
-in_hospital_model = models.get("in_hospital_mortality")
-if in_hospital_model is not None:
+else:
     print("Generating synthetic data for TSTR/TRTR comparisons…")
-    X_train_full = prepare_features(train_df, FEATURE_COLUMNS)
-    y_train_full = train_df["in_hospital_mortality"]
-    numeric_train = to_numeric_frame(X_train_full)
+    numeric_train = to_numeric_frame(X_full)
 
     rng = np.random.default_rng(RANDOM_STATE)
-    synthetic_labels = rng.choice(
-        y_train_full, size=len(y_train_full), replace=True
-    )
+    synthetic_labels = rng.choice(y_full, size=len(y_full), replace=True)
 
-    synthetic_features = in_hospital_model.sample(
+    synthetic_features = model.sample(
         len(synthetic_labels), conditional=True, y=synthetic_labels
     )
     numeric_synthetic = to_numeric_frame(synthetic_features[FEATURE_COLUMNS])
 
-    numeric_test = to_numeric_frame(prepare_features(test_df, FEATURE_COLUMNS))
-    y_test = test_df["in_hospital_mortality"]
+    numeric_test = to_numeric_frame(X_test)
 
     tstr_metrics = evaluate_tstr(
         (numeric_synthetic.to_numpy(), np.asarray(synthetic_labels)),
@@ -562,7 +778,7 @@ if in_hospital_model is not None:
         make_logistic_pipeline,
     )
     trtr_metrics = evaluate_trtr(
-        (numeric_train.to_numpy(), y_train_full.to_numpy()),
+        (numeric_train.to_numpy(), y_full.to_numpy()),
         (numeric_test.to_numpy(), y_test.to_numpy()),
         make_logistic_pipeline,
     )
@@ -574,6 +790,7 @@ if in_hospital_model is not None:
     )
     tstr_path = OUTPUT_DIR / "tstr_trtr_comparison.csv"
     tstr_results.to_csv(tstr_path, index=False)
+    render_dataframe(tstr_results, title="TSTR vs TRTR", floatfmt=".3f")
 
     distribution_rows: List[Dict[str, object]] = []
     for column in FEATURE_COLUMNS:
@@ -592,94 +809,126 @@ if in_hospital_model is not None:
     distribution_df = pd.DataFrame(distribution_rows)
     distribution_path = OUTPUT_DIR / "distribution_shift_metrics.csv"
     distribution_df.to_csv(distribution_path, index=False)
-else:
-    print("Primary target model not available; skipping TSTR/TRTR and distribution analysis.")
+    distribution_top = (
+        distribution_df.sort_values("ks", ascending=False).head(10).reset_index(drop=True)
+    )
+    render_dataframe(
+        distribution_top,
+        title="Top distribution shift features (KS)",
+        floatfmt=".3f",
+    )
 
+
+#%% [markdown]
+# ## Latent space interpretation
+#
+# Project latent representations using PCA for qualitative assessment of class
+# separation across cohorts.
+
+# %%
+
+latent_features = {name: features for name, (features, _) in evaluation_datasets.items()}
+latent_labels = {name: labels for name, (_, labels) in evaluation_datasets.items()}
+latent_path = OUTPUT_DIR / f"latent_{TARGET_LABEL}.png"
+plot_latent_space(
+    model,
+    latent_features,
+    latent_labels,
+    target_name=TARGET_LABEL,
+    output_path=latent_path,
+)
+
+
+#%% [markdown]
+# ## Reporting
+#
+# Collate metrics, Optuna summary, and artifact locations into a Markdown
+# summary mirroring the original analysis output.
+
+# %%
 
 summary_lines: List[str] = [
     "# Mortality modelling report",
     "",
     "## Schema",
-    schema_table,
+    dataframe_to_markdown(schema_df, floatfmt=None),
     "",
     "## Model selection and performance",
+    f"### {TARGET_LABEL}",
 ]
 
-if not optuna_reports:
-    summary_lines.append("No models were trained by optuna.")
+best_value = optuna_best_info.get("value")
+value_text = f"{best_value:.4f}" if isinstance(best_value, (int, float)) else "n/a"
+summary_lines.append(
+    f"Best Optuna trial #{optuna_best_info.get('trial_number')} with validation ROAUC {value_text}"
+)
+summary_lines.append("Best parameters:")
+summary_lines.append("```json")
+summary_lines.append(json.dumps(optuna_best_params, indent=2, ensure_ascii=False))
+summary_lines.append("```")
 
-for target, report in optuna_reports.items():
-    best = report["best"]
-    best_params = report["best_params"]
-    metrics_map: Mapping[str, Dict[str, float]] = report["metrics"]
-    summary_lines.append(f"### {target}")
-    best_value = best.get("value")
-    value_text = (
-        f"{best_value:.4f}" if isinstance(best_value, (int, float)) else "n/a"
-    )
-    summary_lines.append(
-        f"Best Optuna trial #{best.get('trial_number')} with validation ROAUC {value_text}"
-    )
-    summary_lines.append("Best parameters:")
-    summary_lines.append("```json")
-    summary_lines.append(json.dumps(best_params, indent=2, ensure_ascii=False))
-    summary_lines.append("```")
-    summary_lines.append("| Dataset | AUC | ACC | SPE | SEN | Brier |")
-    summary_lines.append("| --- | --- | --- | --- | --- | --- |")
-    for dataset_name, metrics in metrics_map.items():
-        summary_lines.append(
-            "| {dataset} | {auc} | {acc} | {spe} | {sen} | {brier} |".format(
-                dataset=dataset_name,
-                auc=format_float(metrics.get("AUC")),
-                acc=format_float(metrics.get("ACC")),
-                spe=format_float(metrics.get("SPE")),
-                sen=format_float(metrics.get("SEN")),
-                brier=format_float(metrics.get("Brier")),
-            )
-        )
-    summary_lines.append(
-        f"Optuna trials logged at: {report['trials_csv'].relative_to(OUTPUT_DIR)}"
-    )
-    summary_lines.append(
-        f"Calibration plot: {calibration_paths[target].relative_to(OUTPUT_DIR)}"
-    )
-    summary_lines.append(
-        f"Latent projection: {latent_paths[target].relative_to(OUTPUT_DIR)}"
-    )
-    summary_lines.append("")
+metrics_summary_df = metrics_df.rename(
+    columns={"target": "Target", "dataset": "Dataset"}
+)
+metric_column_order = [
+    "Target",
+    "Dataset",
+    "AUC",
+    "ACC",
+    "SPE",
+    "SEN",
+    "Brier",
+]
+existing_metric_columns = [
+    column for column in metric_column_order if column in metrics_summary_df.columns
+]
+if existing_metric_columns:
+    metrics_summary_df = metrics_summary_df.loc[:, existing_metric_columns]
+summary_lines.append(dataframe_to_markdown(metrics_summary_df, floatfmt=".3f"))
+summary_lines.append(
+    f"Optuna trials logged at: {optuna_trials_path.relative_to(OUTPUT_DIR)}"
+)
+summary_lines.append(
+    f"Calibration plot: {calibration_path.relative_to(OUTPUT_DIR)}"
+)
+summary_lines.append(
+    f"Latent projection: {latent_path.relative_to(OUTPUT_DIR)}"
+)
+summary_lines.append("")
 
-if tstr_results is not None:
+if tstr_results is not None and tstr_path is not None:
     summary_lines.append("## TSTR vs TRTR")
-    summary_lines.append("| Setting | Accuracy | AUROC | AUPRC | Brier | ECE |")
-    summary_lines.append("| --- | --- | --- | --- | --- | --- |")
-    for _, row in tstr_results.iterrows():
-        summary_lines.append(
-            "| {setting} | {acc:.3f} | {auroc:.3f} | {auprc:.3f} | {brier:.3f} | {ece:.3f} |".format(
-                setting=row["setting"],
-                acc=row.get("accuracy", np.nan),
-                auroc=row.get("auroc", row.get("auc", np.nan)),
-                auprc=row.get("auprc", np.nan),
-                brier=row.get("brier", np.nan),
-                ece=row.get("ece", np.nan),
-            )
-        )
+    tstr_summary_df = tstr_results.rename(columns={"setting": "Setting"})
+    summary_lines.append(dataframe_to_markdown(tstr_summary_df, floatfmt=".3f"))
     summary_lines.append("")
 
 summary_lines.append("## Distribution shift and privacy")
 if distribution_df is not None and distribution_path is not None:
-    distribution_top = distribution_df.sort_values("ks", ascending=False).head(10)
+    base_distribution_df = (
+        distribution_top if distribution_top is not None else distribution_df
+    )
+    distribution_summary_df = base_distribution_df.rename(
+        columns={
+            "feature": "Feature",
+            "ks": "KS",
+            "mmd": "MMD",
+            "mutual_information": "Mutual information",
+        }
+    )
+    distribution_columns = [
+        "Feature",
+        "KS",
+        "MMD",
+        "Mutual information",
+    ]
+    existing_distribution_columns = [
+        column for column in distribution_columns if column in distribution_summary_df.columns
+    ]
+    if existing_distribution_columns:
+        distribution_summary_df = distribution_summary_df.loc[:, existing_distribution_columns]
+    distribution_summary_df = distribution_summary_df.reset_index(drop=True)
     summary_lines.append("Top 10 features by KS statistic:")
-    summary_lines.append("| Feature | KS | MMD | Mutual information |")
-    summary_lines.append("| --- | --- | --- | --- |")
-    for _, row in distribution_top.iterrows():
-        summary_lines.append(
-            "| {feature} | {ks:.3f} | {mmd:.3f} | {mi:.3f} |".format(
-                feature=row["feature"],
-                ks=row.get("ks", np.nan),
-                mmd=row.get("mmd", np.nan),
-                mi=row.get("mutual_information", np.nan),
-            )
-        )
+    summary_lines.append(dataframe_to_markdown(distribution_summary_df, floatfmt=".3f"))
     summary_lines.append(
         f"Full distribution metrics: {distribution_path.relative_to(OUTPUT_DIR)}"
     )
@@ -689,21 +938,32 @@ else:
 if membership_df.empty:
     summary_lines.append("No membership inference metrics were recorded.")
 else:
-    summary_lines.append("Membership inference results:")
-    summary_lines.append(
-        "| Target | Attack AUC | Best accuracy | Threshold | Majority baseline |"
+    membership_summary_df = membership_df.rename(
+        columns={
+            "target": "Target",
+            "attack_auc": "Attack AUC",
+            "attack_best_accuracy": "Best accuracy",
+            "attack_best_threshold": "Threshold",
+            "attack_majority_class_accuracy": "Majority baseline",
+        }
     )
-    summary_lines.append("| --- | --- | --- | --- | --- |")
-    for _, row in membership_df.iterrows():
-        summary_lines.append(
-            "| {target} | {auc:.3f} | {best_acc:.3f} | {threshold:.3f} | {majority:.3f} |".format(
-                target=row["target"],
-                auc=row.get("attack_auc", np.nan),
-                best_acc=row.get("attack_best_accuracy", np.nan),
-                threshold=row.get("attack_best_threshold", np.nan),
-                majority=row.get("attack_majority_class_accuracy", np.nan),
-            )
-        )
+    membership_columns = [
+        "Target",
+        "Attack AUC",
+        "Best accuracy",
+        "Threshold",
+        "Majority baseline",
+    ]
+    existing_membership_columns = [
+        column for column in membership_columns if column in membership_summary_df.columns
+    ]
+    if existing_membership_columns:
+        membership_summary_df = membership_summary_df.loc[
+            :, existing_membership_columns
+        ]
+    membership_summary_df = membership_summary_df.reset_index(drop=True)
+    summary_lines.append("Membership inference results:")
+    summary_lines.append(dataframe_to_markdown(membership_summary_df, floatfmt=".3f"))
     summary_lines.append(
         f"Membership metrics saved to: {membership_path.relative_to(OUTPUT_DIR)}"
     )
@@ -713,16 +973,10 @@ summary_path.write_text("\n".join(summary_lines), encoding="utf-8")
 
 print("Analysis complete.")
 print(f"Metric table saved to {metrics_path}")
-for target, path in calibration_paths.items():
-    print(f"Calibration plot for {target}: {path}")
-for target, path in latent_paths.items():
-    print(f"Latent space plot for {target}: {path}")
+print(f"Calibration plot saved to {calibration_path}")
+print(f"Latent space plot saved to {latent_path}")
 print(f"Membership inference results saved to {membership_path}")
-if (
-    in_hospital_model is not None
-    and tstr_path is not None
-    and distribution_path is not None
-):
+if tstr_results is not None and tstr_path is not None and distribution_path is not None:
     print(f"TSTR/TRTR comparison saved to {tstr_path}")
     print(f"Distribution metrics saved to {distribution_path}")
 print(f"Summary written to {summary_path}")

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ matplotlib>=3.7
 tqdm>=4.65
 scikit-learn>=1.3
 optuna>=3.4
+tabulate>=0.9
 
 # Optional extras for interactive schema builder (install separately)
 flask>=2.3,<3


### PR DESCRIPTION
## Summary
- add a configurable TARGET_LABEL so the script focuses on a single modelling task
- restructure the mortality supervised analysis into clear #%% cells with markdown headers and comments
- refactor evaluation, reporting, and optional TSTR/TRTR analysis to operate on the selected label and persist artefacts
- add classical scikit-learn baselines before SUAVE training, normalising KNN/SVM and skipping unavailable eICU targets
- render schema, evaluation, and comparison tables as pandas DataFrames with tabulate formatting/display helpers for both console and interactive environments, and emit Markdown summaries from those tables
- add tabulate as a runtime dependency for the example

## Testing
- python -m compileall examples/mimic_mortality_supervised.py

------
https://chatgpt.com/codex/tasks/task_e_68d40502b4508320a0616724077912b3