### PR TITLE
Plot training AUROC in monitor

### DIFF
--- a/suave/model.py
+++ b/suave/model.py
@@ -1312,6 +1312,7 @@ class SUAVE:
                     epoch=epoch_offset,
                     train_metrics={},
                     val_metrics=val_metrics,
+                    beta=self.beta,
                 )
             final_temperature = temperature if temperature is not None else 1.0
             return {"final_temperature": float(final_temperature), "history": history}
@@ -1333,6 +1334,7 @@ class SUAVE:
         )
         progress = tqdm(range(warmup_epochs), desc=description, leave=False)
         for epoch in progress:
+            last_beta_scale = 0.0
             temperature = (
                 self._gumbel_temperature_for_epoch(epoch)
                 if self.behaviour == "unsupervised"
@@ -1370,6 +1372,7 @@ class SUAVE:
 
                 global_step += 1
                 beta_scale = losses.kl_warmup(global_step, warmup_steps, self.beta)
+                last_beta_scale = float(beta_scale)
                 outputs = self._forward_elbo_batch(
                     batch_input,
                     batch_data,
@@ -1421,6 +1424,7 @@ class SUAVE:
                         "kl": average_cat_kl + average_gauss_kl,
                     },
                     val_metrics=val_metrics,
+                    beta=last_beta_scale if warmup_steps > 0 else self.beta,
                 )
 
         final_temperature = final_temperature if final_temperature is not None else 1.0
@@ -1655,6 +1659,8 @@ class SUAVE:
             permutation = torch.randperm(n_samples, device=device)
             epoch_loss = 0.0
             epoch_samples = 0
+            train_probabilities: list[np.ndarray] = []
+            train_targets: list[np.ndarray] = []
             for start in range(0, n_samples, effective_batch):
                 batch_indices = permutation[start : start + effective_batch]
                 logits = self._classifier(latent_mu[batch_indices])
@@ -1666,9 +1672,22 @@ class SUAVE:
                 batch_count = batch_indices.numel()
                 epoch_loss += float(loss.item()) * batch_count
                 epoch_samples += batch_count
+                probabilities = torch.softmax(logits.detach(), dim=-1)
+                train_probabilities.append(probabilities.detach().cpu().numpy())
+                train_targets.append(targets.detach().cpu().numpy())
 
             average_loss = epoch_loss / max(epoch_samples, 1)
             progress.set_postfix({"loss": average_loss})
+
+            if train_probabilities and train_targets:
+                prob_array = np.concatenate(train_probabilities, axis=0)
+                target_array = np.concatenate(train_targets, axis=0)
+                try:
+                    train_auroc = float(compute_auroc(prob_array, target_array))
+                except ValueError:
+                    train_auroc = float("nan")
+            else:
+                train_auroc = float("nan")
 
             if plot_monitor is not None:
                 val_metrics: dict[str, float] = {}
@@ -1701,8 +1720,10 @@ class SUAVE:
                         "classification_loss": average_loss,
                         "total_loss": None,
                         "joint_objective": None,
+                        "auroc": train_auroc,
                     },
                     val_metrics=val_metrics,
+                    beta=self.beta,
                 )
 
         if not was_training:
@@ -1799,6 +1820,8 @@ class SUAVE:
             epoch_recon_total = 0.0
             epoch_cat_kl_total = 0.0
             epoch_gauss_kl_total = 0.0
+            train_probabilities: list[np.ndarray] = []
+            train_targets: list[np.ndarray] = []
             for start in range(0, n_samples, max(effective_batch, 1)):
                 batch_indices = permutation[start : start + effective_batch]
                 batch_input = encoder_inputs[batch_indices]
@@ -1837,6 +1860,9 @@ class SUAVE:
                     joint_loss = joint_loss + class_loss * classification_weight
                     epoch_class_loss += float(class_loss.item()) * batch_count
                     epoch_class_samples += batch_count
+                    probabilities = torch.softmax(logits.detach(), dim=-1)
+                    train_probabilities.append(probabilities.detach().cpu().numpy())
+                    train_targets.append(targets.detach().cpu().numpy())
                 optimizer.zero_grad()
                 joint_loss.backward()
                 optimizer.step()
@@ -1866,6 +1892,15 @@ class SUAVE:
             average_class_loss: float | None = None
             if epoch_class_samples > 0:
                 average_class_loss = epoch_class_loss / epoch_class_samples
+            if train_probabilities and train_targets:
+                prob_array = np.concatenate(train_probabilities, axis=0)
+                target_array = np.concatenate(train_targets, axis=0)
+                try:
+                    train_auroc = float(compute_auroc(prob_array, target_array))
+                except ValueError:
+                    train_auroc = float("nan")
+            else:
+                train_auroc = float("nan")
             progress.set_postfix(
                 {
                     "joint": average_joint,
@@ -1891,8 +1926,11 @@ class SUAVE:
                         "classification_loss": average_class_loss,
                         "reconstruction": average_recon,
                         "kl": average_cat_kl + average_gauss_kl,
+                        "auroc": train_auroc,
                     },
                     val_metrics=val_metrics,
+                    beta=self.beta,
+                    classification_loss_weight=classification_weight,
                 )
 
             if best_metrics is None or self._is_better_metrics(metrics, best_metrics):

--- a/suave/plots.py
+++ b/suave/plots.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import math
 from pathlib import Path
 from typing import Iterable, Mapping
 
@@ -69,12 +70,17 @@ class TrainingPlotMonitor:
         axes = axes.flatten()
 
         self._metrics = self._metric_configuration()
+        self._config_by_name = {metric["name"]: metric for metric in self._metrics}
+        self._coefficients: dict[str, float | None] = {
+            "beta": None,
+            "classification_loss_weight": None,
+        }
         self._axes: dict[str, Axes] = {}
         self._lines: dict[str, dict[str, Line2D | None]] = {}
         self._history: dict[str, dict[str, list[float]]] = {}
 
         for axis, metric in zip(axes, self._metrics):
-            axis.set_title(metric["title"])
+            axis.set_title(self._format_metric_title(metric["name"]))
             axis.set_xlabel("Epoch")
             axis.set_ylabel(metric["ylabel"])
 
@@ -120,11 +126,22 @@ class TrainingPlotMonitor:
         epoch: int,
         train_metrics: Mapping[str, float | int | None] | None = None,
         val_metrics: Mapping[str, float | int | None] | None = None,
+        beta: float | None = None,
+        classification_loss_weight: float | None = None,
     ) -> None:
         """Append metrics for ``epoch`` and refresh the visualisation."""
 
         train_metrics = train_metrics or {}
         val_metrics = val_metrics or {}
+
+        if beta is not None and math.isfinite(float(beta)):
+            self._coefficients["beta"] = float(beta)
+        if classification_loss_weight is not None and math.isfinite(
+            float(classification_loss_weight)
+        ):
+            self._coefficients["classification_loss_weight"] = float(
+                classification_loss_weight
+            )
 
         for metric in self._metrics:
             name = metric["name"]
@@ -143,6 +160,8 @@ class TrainingPlotMonitor:
 
             axis.relim()
             axis.autoscale_view()
+
+            axis.set_title(self._format_metric_title(name))
 
         self._figure.tight_layout()
         self._refresh()
@@ -177,34 +196,6 @@ class TrainingPlotMonitor:
         if self._behaviour == "supervised":
             return [
                 {
-                    "name": "total_loss",
-                    "title": "Total Loss",
-                    "ylabel": "Loss",
-                    "plot_train": True,
-                    "plot_val": True,
-                },
-                {
-                    "name": "joint_objective",
-                    "title": "Joint Objective",
-                    "ylabel": "Loss",
-                    "plot_train": True,
-                    "plot_val": True,
-                },
-                {
-                    "name": "classification_loss",
-                    "title": "Classification Loss",
-                    "ylabel": "Loss",
-                    "plot_train": True,
-                    "plot_val": True,
-                },
-                {
-                    "name": "auroc",
-                    "title": "Validation AUROC",
-                    "ylabel": "AUROC",
-                    "plot_train": False,
-                    "plot_val": True,
-                },
-                {
                     "name": "reconstruction",
                     "title": "Reconstruction",
                     "ylabel": "Value",
@@ -218,16 +209,37 @@ class TrainingPlotMonitor:
                     "plot_train": True,
                     "plot_val": True,
                 },
+                {
+                    "name": "total_loss",
+                    "title": "ELBO",
+                    "ylabel": "Loss",
+                    "plot_train": True,
+                    "plot_val": True,
+                },
+                {
+                    "name": "auroc",
+                    "title": "AUROC",
+                    "ylabel": "AUROC",
+                    "plot_train": True,
+                    "plot_val": True,
+                },
+                {
+                    "name": "classification_loss",
+                    "title": "Classification Loss",
+                    "ylabel": "Loss",
+                    "plot_train": True,
+                    "plot_val": True,
+                },
+                {
+                    "name": "joint_objective",
+                    "title": "Joint Objective",
+                    "ylabel": "Loss",
+                    "plot_train": True,
+                    "plot_val": True,
+                },
             ]
 
         return [
-            {
-                "name": "total_loss",
-                "title": "Total Loss",
-                "ylabel": "Loss",
-                "plot_train": True,
-                "plot_val": True,
-            },
             {
                 "name": "reconstruction",
                 "title": "Reconstruction",
@@ -242,7 +254,57 @@ class TrainingPlotMonitor:
                 "plot_train": True,
                 "plot_val": True,
             },
+            {
+                "name": "total_loss",
+                "title": "ELBO",
+                "ylabel": "Loss",
+                "plot_train": True,
+                "plot_val": True,
+            },
         ]
+
+    def _format_metric_title(self, metric_name: str) -> str:
+        config = self._config_by_name.get(metric_name, {})
+        base_title = str(config.get("title", metric_name))
+        if metric_name == "total_loss":
+            return self._format_elbo_title(base_title)
+        if metric_name == "joint_objective":
+            return self._format_joint_title(base_title)
+        return base_title
+
+    def _format_elbo_title(self, base_title: str) -> str:
+        beta = self._coefficients.get("beta")
+        if beta is None or not math.isfinite(beta):
+            formula = "reconstruction + KL"
+        else:
+            formatted = self._format_coefficient(beta)
+            if formatted is None:
+                formula = "reconstruction + KL"
+            else:
+                formula = f"reconstruction + {formatted}×KL"
+        return f"{base_title}\n({formula})"
+
+    def _format_joint_title(self, base_title: str) -> str:
+        weight = self._coefficients.get("classification_loss_weight")
+        if weight is None or not math.isfinite(weight):
+            formula = "ELBO + Classification Loss"
+        else:
+            formatted = self._format_coefficient(weight)
+            if formatted is None:
+                formula = "ELBO + Classification Loss"
+            else:
+                formula = f"ELBO + {formatted}×Classification Loss"
+        return f"{base_title}\n({formula})"
+
+    @staticmethod
+    def _format_coefficient(value: float) -> str | None:
+        rounded = round(float(value), 1)
+        if math.isclose(rounded, 1.0, rel_tol=1e-9, abs_tol=1e-9):
+            return None
+        if math.isclose(rounded, 0.0, rel_tol=1e-9, abs_tol=1e-9):
+            return "0"
+        text = f"{rounded:.1f}".rstrip("0").rstrip(".")
+        return text
 
 
 def plot_reliability_curve(

--- a/tests/test_training_schedule.py
+++ b/tests/test_training_schedule.py
@@ -79,6 +79,8 @@ def test_training_monitor_keeps_elbo_semantics(monkeypatch):
             epoch: int,
             train_metrics: dict[str, float | None] | None = None,
             val_metrics: dict[str, float | None] | None = None,
+            beta: float | None = None,
+            classification_loss_weight: float | None = None,
         ) -> None:
             updates.append(
                 (


### PR DESCRIPTION
## Summary
- reorder the training monitor panels so reconstruction, KL, and ELBO occupy the first row with AUROC, classification loss, and joint objective on the second row
- render ELBO and joint objective plot titles with dynamic formulas that reflect the current beta and classification loss weight values
- propagate beta and classification loss weight updates from the training loop and update the monitor test double to accept the new parameters
- plot training AUROC alongside validation by computing epoch-level training AUROC during the head and joint phases and surfacing it in the monitor

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d407cccd988320969a959ce9dbfeb8