### PR TITLE
Plot training AUROC in monitor

### DIFF
--- a/suave/model.py
+++ b/suave/model.py
@@ -1312,6 +1312,7 @@ class SUAVE:
                     epoch=epoch_offset,
                     train_metrics={},
                     val_metrics=val_metrics,
+                    beta=self.beta,
                 )
             final_temperature = temperature if temperature is not None else 1.0
             return {"final_temperature": float(final_temperature), "history": history}
@@ -1333,6 +1334,7 @@ class SUAVE:
         )
         progress = tqdm(range(warmup_epochs), desc=description, leave=False)
         for epoch in progress:
+            last_beta_scale = 0.0
             temperature = (
                 self._gumbel_temperature_for_epoch(epoch)
                 if self.behaviour == "unsupervised"
@@ -1370,6 +1372,7 @@ class SUAVE:
 
                 global_step += 1
                 beta_scale = losses.kl_warmup(global_step, warmup_steps, self.beta)
+                last_beta_scale = float(beta_scale)
                 outputs = self._forward_elbo_batch(
                     batch_input,
                     batch_data,
@@ -1421,6 +1424,7 @@ class SUAVE:
                         "kl": average_cat_kl + average_gauss_kl,
                     },
                     val_metrics=val_metrics,
+                    beta=last_beta_scale if warmup_steps > 0 else self.beta,
                 )
 
         final_temperature = final_temperature if final_temperature is not None else 1.0
@@ -1655,6 +1659,8 @@ class SUAVE:
             permutation = torch.randperm(n_samples, device=device)
             epoch_loss = 0.0
             epoch_samples = 0
+            train_probabilities: list[np.ndarray] = []
+            train_targets: list[np.ndarray] = []
             for start in range(0, n_samples, effective_batch):
                 batch_indices = permutation[start : start + effective_batch]
                 logits = self._classifier(latent_mu[batch_indices])
@@ -1666,9 +1672,22 @@ class SUAVE:
                 batch_count = batch_indices.numel()
                 epoch_loss += float(loss.item()) * batch_count
                 epoch_samples += batch_count
+                probabilities = torch.softmax(logits.detach(), dim=-1)
+                train_probabilities.append(probabilities.detach().cpu().numpy())
+                train_targets.append(targets.detach().cpu().numpy())
 
             average_loss = epoch_loss / max(epoch_samples, 1)
             progress.set_postfix({"loss": average_loss})
+
+            if train_probabilities and train_targets:
+                prob_array = np.concatenate(train_probabilities, axis=0)
+                target_array = np.concatenate(train_targets, axis=0)
+                try:
+                    train_auroc = float(compute_auroc(prob_array, target_array))
+                except ValueError:
+                    train_auroc = float("nan")
+            else:
+                train_auroc = float("nan")
 
             if plot_monitor is not None:
                 val_metrics: dict[str, float] = {}
@@ -1701,8 +1720,10 @@ class SUAVE:
                         "classification_loss": average_loss,
                         "total_loss": None,
                         "joint_objective": None,
+                        "auroc": train_auroc,
                     },
                     val_metrics=val_metrics,
+                    beta=self.beta,
                 )
 
         if not was_training:
@@ -1799,6 +1820,8 @@ class SUAVE:
             epoch_recon_total = 0.0
             epoch_cat_kl_total = 0.0
             epoch_gauss_kl_total = 0.0
+            train_probabilities: list[np.ndarray] = []
+            train_targets: list[np.ndarray] = []
             for start in range(0, n_samples, max(effective_batch, 1)):
                 batch_indices = permutation[start : start + effective_batch]
                 batch_input = encoder_inputs[batch_indices]
@@ -1837,6 +1860,9 @@ class SUAVE:
                     joint_loss = joint_loss + class_loss * classification_weight
                     epoch_class_loss += float(class_loss.item()) * batch_count
                     epoch_class_samples += batch_count
+                    probabilities = torch.softmax(logits.detach(), dim=-1)
+                    train_probabilities.append(probabilities.detach().cpu().numpy())
+                    train_targets.append(targets.detach().cpu().numpy())
                 optimizer.zero_grad()
                 joint_loss.backward()
                 optimizer.step()
@@ -1866,6 +1892,15 @@ class SUAVE:
             average_class_loss: float | None = None
             if epoch_class_samples > 0:
                 average_class_loss = epoch_class_loss / epoch_class_samples
+            if train_probabilities and train_targets:
+                prob_array = np.concatenate(train_probabilities, axis=0)
+                target_array = np.concatenate(train_targets, axis=0)
+                try:
+                    train_auroc = float(compute_auroc(prob_array, target_array))
+                except ValueError:
+                    train_auroc = float("nan")
+            else:
+                train_auroc = float("nan")
             progress.set_postfix(
                 {
                     "joint": average_joint,
@@ -1891,8 +1926,11 @@ class SUAVE:
                         "classification_loss": average_class_loss,
                         "reconstruction": average_recon,
                         "kl": average_cat_kl + average_gauss_kl,
+                        "auroc": train_auroc,
                     },
                     val_metrics=val_metrics,
+                    beta=self.beta,
+                    classification_loss_weight=classification_weight,
                 )
 
             if best_metrics is None or self._is_better_metrics(metrics, best_metrics):

--- a/tests/test_plots.py
+++ b/tests/test_plots.py
@@ -1,0 +1,22 @@
+import matplotlib.pyplot as plt
+import pytest
+
+from suave.plots import TrainingPlotMonitor
+
+
+def test_training_plot_monitor_flips_reconstruction_sign():
+    monitor = TrainingPlotMonitor("supervised")
+
+    monitor.update(
+        epoch=0,
+        train_metrics={"reconstruction": -3.5},
+        val_metrics={"reconstruction": -4.25},
+    )
+
+    train_history = monitor._history["reconstruction"]["train"]
+    val_history = monitor._history["reconstruction"]["val"]
+
+    assert train_history[-1] == pytest.approx(3.5)
+    assert val_history[-1] == pytest.approx(4.25)
+
+    plt.close(monitor._figure)

--- a/tests/test_training_schedule.py
+++ b/tests/test_training_schedule.py
@@ -79,6 +79,8 @@ def test_training_monitor_keeps_elbo_semantics(monkeypatch):
             epoch: int,
             train_metrics: dict[str, float | None] | None = None,
             val_metrics: dict[str, float | None] | None = None,
+            beta: float | None = None,
+            classification_loss_weight: float | None = None,
         ) -> None:
             updates.append(
                 (


### PR DESCRIPTION
## Summary
- reorder the training monitor panels so reconstruction, KL, and ELBO occupy the first row with AUROC, classification loss, and joint objective on the second row
- render ELBO and joint objective plot titles with dynamic formulas that reflect the current beta and classification loss weight values
- propagate beta and classification loss weight updates from the training loop and update the monitor test double to accept the new parameters
- plot training AUROC alongside validation by computing epoch-level training AUROC during the head and joint phases and surfacing it in the monitor
- flip the reconstruction traces in the monitor so they display positive reconstruction loss values

## Testing
- ruff check suave/plots.py tests/test_plots.py
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d407cccd988320969a959ce9dbfeb8