### PR TITLE
Refactor MIMIC mortality utilities and add isotonic calibration

### DIFF
--- a/examples/mimic_mortality_utils.py
+++ b/examples/mimic_mortality_utils.py
@@ -4,16 +4,41 @@ from __future__ import annotations
 
 import sys
 from pathlib import Path
-from typing import Iterable, MutableMapping, Optional, Tuple
+from typing import (
+    Dict,
+    Iterable,
+    List,
+    Mapping,
+    MutableMapping,
+    Optional,
+    Sequence,
+    Tuple,
+)
 
 import numpy as np
 import pandas as pd
+from IPython.display import display
+from matplotlib import pyplot as plt
+from tabulate import tabulate
+
+from sklearn.calibration import calibration_curve
+from sklearn.decomposition import PCA
+from sklearn.metrics import (
+    accuracy_score,
+    brier_score_loss,
+    confusion_matrix,
+    roc_auc_score,
+    roc_curve,
+)
+from sklearn.pipeline import Pipeline
+from sklearn.isotonic import IsotonicRegression
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
-from suave import Schema, SchemaInferencer  # noqa: E402
+from suave import Schema, SchemaInferencer, SUAVE  # noqa: E402
+
 
 RANDOM_STATE: int = 20201021
 TARGET_COLUMNS: Tuple[str, str] = ("in_hospital_mortality", "28d_mortality")
@@ -28,18 +53,184 @@ __all__ = [
     "VALIDATION_SIZE",
     "Schema",
     "SchemaInferencer",
-    "load_dataset",
-    "define_schema",
-    "prepare_features",
-    "split_train_validation_calibration",
-    "schema_markdown_table",
-    "format_float",
+    "apply_isotonic_calibration",
+    "build_prediction_dataframe",
     "compute_auc",
-    "to_numeric_frame",
+    "compute_binary_metrics",
+    "dataframe_to_markdown",
+    "define_schema",
+    "extract_positive_probabilities",
+    "fit_isotonic_calibrator",
+    "format_float",
+    "is_interactive_session",
     "kolmogorov_smirnov_statistic",
-    "rbf_mmd",
+    "load_dataset",
+    "load_or_create_iteratively_imputed_features",
+    "make_logistic_pipeline",
     "mutual_information_feature",
+    "plot_benchmark_curves",
+    "plot_calibration_curves",
+    "plot_latent_space",
+    "prepare_features",
+    "render_dataframe",
+    "rbf_mmd",
+    "schema_markdown_table",
+    "schema_to_dataframe",
+    "slugify_identifier",
+    "split_train_validation_calibration",
+    "to_numeric_frame",
 ]
+
+
+def is_interactive_session() -> bool:
+    """Return ``True`` when executed inside an interactive IPython session."""
+
+    try:
+        from IPython import get_ipython
+    except ImportError:  # pragma: no cover - optional dependency
+        return False
+    return get_ipython() is not None
+
+
+def render_dataframe(
+    df: pd.DataFrame,
+    *,
+    title: Optional[str] = None,
+    floatfmt: Optional[str] = ".3f",
+) -> None:
+    """Render a dataframe either via ``display`` or ``tabulate``."""
+
+    if title:
+        print(title)
+    if df.empty:
+        print("(empty table)")
+        return
+    if is_interactive_session():
+        display(df)
+        return
+    tabulate_kwargs = {"headers": "keys", "tablefmt": "github", "showindex": False}
+    if floatfmt is not None:
+        tabulate_kwargs["floatfmt"] = floatfmt
+    print(tabulate(df, **tabulate_kwargs))
+
+
+def dataframe_to_markdown(df: pd.DataFrame, *, floatfmt: Optional[str] = ".3f") -> str:
+    """Return a GitHub-flavoured Markdown representation of ``df``."""
+
+    if df.empty:
+        return "_No data available._"
+    tabulate_kwargs = {"headers": "keys", "tablefmt": "github", "showindex": False}
+    if floatfmt is not None:
+        tabulate_kwargs["floatfmt"] = floatfmt
+    return tabulate(df, **tabulate_kwargs)
+
+
+def schema_to_dataframe(schema: Schema) -> pd.DataFrame:
+    """Convert a :class:`Schema` into a tidy dataframe."""
+
+    records: List[Dict[str, object]] = []
+    for column, spec in schema.to_dict().items():
+        records.append(
+            {
+                "Column": column,
+                "Type": spec.get("type", ""),
+                "n_classes": spec.get("n_classes", ""),
+                "y_dim": spec.get("y_dim", ""),
+            }
+        )
+    return pd.DataFrame(records)
+
+
+def slugify_identifier(value: str) -> str:
+    """Return a filesystem-friendly identifier derived from ``value``."""
+
+    cleaned = [char.lower() if char.isalnum() else "_" for char in value.strip()]
+    slug = "".join(cleaned)
+    while "__" in slug:
+        slug = slug.replace("__", "_")
+    return slug.strip("_")
+
+
+def load_or_create_iteratively_imputed_features(
+    feature_sets: Mapping[str, pd.DataFrame],
+    *,
+    output_dir: Path,
+    target_label: str,
+    reference_key: str,
+) -> Tuple[Dict[str, pd.DataFrame], Dict[str, Path], bool]:
+    """Load cached iterative imputations or fit a new imputer."""
+
+    if reference_key not in feature_sets:
+        raise KeyError(
+            f"Reference key '{reference_key}' missing from feature sets: {list(feature_sets)}"
+        )
+
+    dataset_paths: Dict[str, Path] = {
+        name: output_dir
+        / f"iterative_imputed_{slugify_identifier(name)}_{slugify_identifier(target_label)}.csv"
+        for name in feature_sets
+    }
+
+    loaded_features: Dict[str, pd.DataFrame] = {}
+    load_successful = True
+    for name, path in dataset_paths.items():
+        features = feature_sets[name]
+        if not path.exists():
+            load_successful = False
+            break
+        cached = pd.read_csv(path, index_col=0)
+        column_match = list(cached.columns) == list(features.columns)
+        length_match = len(cached) == len(features)
+        if not (column_match and length_match):
+            load_successful = False
+            break
+        try:
+            cached = cached.loc[features.index]
+        except KeyError:
+            load_successful = False
+            break
+        loaded_features[name] = cached
+
+    if load_successful:
+        return loaded_features, dataset_paths, True
+
+    from sklearn.experimental import enable_iterative_imputer  # noqa: F401
+    from sklearn.impute import IterativeImputer
+
+    imputer = IterativeImputer()
+    imputer.fit(feature_sets[reference_key])
+
+    imputed_features: Dict[str, pd.DataFrame] = {}
+    for name, features in feature_sets.items():
+        transformed = imputer.transform(features)
+        imputed_df = pd.DataFrame(
+            transformed,
+            columns=features.columns,
+            index=features.index,
+        )
+        path = dataset_paths[name]
+        path.parent.mkdir(parents=True, exist_ok=True)
+        imputed_df.to_csv(path)
+        imputed_features[name] = imputed_df
+
+    return imputed_features, dataset_paths, False
+
+
+def make_logistic_pipeline() -> Pipeline:
+    """Factory for the baseline classifier used in TSTR/TRTR evaluations."""
+
+    from sklearn.experimental import enable_iterative_imputer  # noqa: F401
+    from sklearn.impute import IterativeImputer
+    from sklearn.linear_model import LogisticRegression
+    from sklearn.preprocessing import StandardScaler
+
+    return Pipeline(
+        [
+            ("imputer", IterativeImputer()),
+            ("scaler", StandardScaler()),
+            ("classifier", LogisticRegression(max_iter=200)),
+        ]
+    )
 
 
 def load_dataset(path: Path) -> pd.DataFrame:
@@ -138,8 +329,6 @@ def format_float(value: Optional[float]) -> str:
 
 def compute_auc(probabilities: np.ndarray, targets: pd.Series | np.ndarray) -> float:
     """Return the ROC AUC given predicted probabilities and targets."""
-
-    from sklearn.metrics import roc_auc_score
 
     prob_matrix = np.asarray(probabilities)
     if prob_matrix.ndim == 1:
@@ -261,3 +450,288 @@ def mutual_information_feature(
     if np.unique(feature_bins).size <= 1:
         return 0.0
     return float(mutual_info_score(dataset_indicator, feature_bins))
+
+
+def extract_positive_probabilities(probabilities: np.ndarray) -> np.ndarray:
+    """Return the positive-class probabilities as a 1-D array."""
+
+    prob_matrix = np.asarray(probabilities)
+    if prob_matrix.ndim == 1:
+        return prob_matrix
+    return prob_matrix[:, -1]
+
+
+def compute_binary_metrics(
+    probabilities: np.ndarray, targets: pd.Series | np.ndarray
+) -> Dict[str, float]:
+    """Compute AUROC, accuracy, specificity, sensitivity, and Brier score."""
+
+    positive_probs = extract_positive_probabilities(probabilities)
+    labels = np.asarray(targets)
+    predictions = (positive_probs >= 0.5).astype(int)
+
+    metrics: Dict[str, float] = {}
+
+    try:
+        roauc = float(roc_auc_score(labels, positive_probs))
+    except ValueError:
+        roauc = float("nan")
+
+    metrics["ROAUC"] = roauc
+    metrics["AUC"] = roauc
+
+    metrics["ACC"] = float(accuracy_score(labels, predictions))
+    tn, fp, fn, tp = confusion_matrix(labels, predictions, labels=[0, 1]).ravel()
+    metrics["SPE"] = float(tn / (tn + fp)) if (tn + fp) > 0 else float("nan")
+    metrics["SEN"] = float(tp / (tp + fn)) if (tp + fn) > 0 else float("nan")
+    metrics["Brier"] = float(brier_score_loss(labels, positive_probs))
+    return metrics
+
+
+def fit_isotonic_calibrator(
+    probabilities: np.ndarray, targets: pd.Series | np.ndarray
+) -> IsotonicRegression:
+    """Fit an :class:`IsotonicRegression` calibrator on validation outputs."""
+
+    calibrator = IsotonicRegression(out_of_bounds="clip")
+    positive_probs = extract_positive_probabilities(probabilities)
+    calibrator.fit(positive_probs, np.asarray(targets))
+    return calibrator
+
+
+def apply_isotonic_calibration(
+    probabilities: np.ndarray, calibrator: Optional[IsotonicRegression]
+) -> np.ndarray:
+    """Apply an isotonic calibrator to positive-class probabilities."""
+
+    if calibrator is None:
+        return np.asarray(probabilities)
+
+    prob_matrix = np.asarray(probabilities)
+    positive_probs = extract_positive_probabilities(prob_matrix)
+    calibrated_pos = calibrator.transform(positive_probs)
+    calibrated_pos = np.clip(calibrated_pos, 0.0, 1.0)
+
+    if prob_matrix.ndim == 1:
+        return calibrated_pos
+
+    calibrated = prob_matrix.copy()
+    calibrated[:, -1] = calibrated_pos
+    if calibrated.shape[1] == 2:
+        calibrated[:, 0] = 1.0 - calibrated_pos
+    else:
+        normaliser = calibrated.sum(axis=1, keepdims=True)
+        normaliser = np.where(normaliser > 0.0, normaliser, 1.0)
+        calibrated = calibrated / normaliser
+    return calibrated
+
+
+def plot_calibration_curves(
+    probability_map: Mapping[str, np.ndarray],
+    label_map: Mapping[str, np.ndarray],
+    *,
+    target_name: str,
+    output_path: Path,
+    n_bins: int = 10,
+) -> None:
+    """Generate calibration curves with Brier scores annotated in the legend."""
+
+    fig, ax = plt.subplots(figsize=(6, 5))
+    ax.plot(
+        [0, 1], [0, 1], linestyle="--", color="tab:gray", label="Perfect calibration"
+    )
+
+    for dataset_name, probs in probability_map.items():
+        labels = label_map[dataset_name]
+        pos_probs = extract_positive_probabilities(probs)
+        try:
+            frac_pos, mean_pred = calibration_curve(labels, pos_probs, n_bins=n_bins)
+        except ValueError:
+            continue
+        brier = brier_score_loss(labels, pos_probs)
+        ax.plot(
+            mean_pred,
+            frac_pos,
+            marker="o",
+            label=f"{dataset_name} (Brier={brier:.3f})",
+        )
+
+    ax.set_xlabel("Predicted probability")
+    ax.set_ylabel("Observed frequency")
+    ax.set_title(f"Calibration: {target_name}")
+    ax.legend()
+    fig.tight_layout()
+    fig.savefig(output_path, dpi=300)
+    plt.close(fig)
+
+
+def plot_latent_space(
+    model: "SUAVE",
+    feature_map: Mapping[str, pd.DataFrame],
+    label_map: Mapping[str, Sequence[object]],
+    *,
+    target_name: str,
+    output_path: Path,
+) -> None:
+    """Project latent representations with PCA and create scatter plots."""
+
+    latent_blocks: List[np.ndarray] = []
+    dataset_keys: List[str] = []
+    for name, features in feature_map.items():
+        if features.empty:
+            continue
+        latents = model.encode(features)
+        if latents.size == 0:
+            continue
+        latent_blocks.append(latents)
+        dataset_keys.append(name)
+
+    if not latent_blocks:
+        return
+
+    concatenated = np.vstack(latent_blocks)
+    pca = PCA(n_components=2)
+    projected = pca.fit_transform(concatenated)
+
+    offsets = np.cumsum([0] + [block.shape[0] for block in latent_blocks])
+    fig, axes = plt.subplots(
+        1,
+        len(latent_blocks),
+        figsize=(6 * len(latent_blocks), 5),
+        sharex=True,
+        sharey=True,
+    )
+
+    if len(latent_blocks) == 1:
+        axes = [axes]
+
+    for idx, (ax, name) in enumerate(zip(axes, dataset_keys)):
+        start, end = offsets[idx], offsets[idx + 1]
+        subset = projected[start:end]
+        labels = np.asarray(label_map[name])
+        scatter = ax.scatter(
+            subset[:, 0],
+            subset[:, 1],
+            c=labels,
+            cmap="coolwarm",
+            alpha=0.7,
+            edgecolor="none",
+        )
+        ax.set_title(f"{name}")
+        ax.set_xlabel("PC1")
+        ax.set_ylabel("PC2")
+        legend = ax.legend(*scatter.legend_elements(), title="Label")
+        ax.add_artist(legend)
+
+    fig.suptitle(f"Latent space projection: {target_name}")
+    fig.tight_layout(rect=(0, 0, 1, 0.96))
+    fig.savefig(output_path, dpi=300)
+    plt.close(fig)
+
+
+def plot_benchmark_curves(
+    dataset_name: str,
+    y_true: np.ndarray,
+    model_probability_lookup: Mapping[str, np.ndarray],
+    *,
+    output_dir: Path,
+    target_label: str,
+    abbreviation_lookup: Optional[Mapping[str, str]] = None,
+    n_bins: int = 10,
+) -> Optional[Path]:
+    """Plot ROC and calibration curves for the supplied dataset."""
+
+    unique_labels = np.unique(y_true)
+    if unique_labels.size < 2:
+        print(f"Skipping {dataset_name} curves because only one class is present.")
+        return None
+
+    fig, (roc_ax, cal_ax) = plt.subplots(1, 2, figsize=(12, 5))
+
+    roc_ax.plot([0, 1], [0, 1], linestyle="--", color="gray", label="Chance")
+    roc_ax.set_title(f"ROC – {dataset_name}")
+    roc_ax.set_xlabel("False positive rate")
+    roc_ax.set_ylabel("True positive rate")
+
+    cal_ax.plot([0, 1], [0, 1], linestyle="--", color="gray", label="Perfect")
+    cal_ax.set_title(f"Calibration – {dataset_name}")
+    cal_ax.set_xlabel("Mean predicted probability")
+    cal_ax.set_ylabel("Fraction of positives")
+
+    for model_name, probs in model_probability_lookup.items():
+        abbrev = (
+            model_name
+            if abbreviation_lookup is None
+            else abbreviation_lookup.get(model_name, model_name)
+        )
+        positive_probs = extract_positive_probabilities(probs)
+        fpr, tpr, _ = roc_curve(y_true, positive_probs)
+        roc_ax.plot(fpr, tpr, label=abbrev)
+
+        try:
+            frac_pos, mean_pred = calibration_curve(
+                y_true, positive_probs, n_bins=n_bins, strategy="quantile"
+            )
+        except ValueError:
+            print(
+                f"Calibration curve for {model_name} on {dataset_name} skipped due to insufficient variation."
+            )
+        else:
+            cal_ax.plot(mean_pred, frac_pos, marker="o", label=abbrev)
+
+    roc_ax.legend(loc="lower right")
+    cal_ax.legend(loc="upper left")
+    fig.suptitle(f"Benchmark ROC & calibration – {dataset_name}")
+    fig.tight_layout()
+
+    dataset_slug = dataset_name.lower().replace(" ", "_")
+    figure_path = output_dir / f"benchmark_curves_{dataset_slug}_{target_label}.png"
+    fig.savefig(figure_path, dpi=300, bbox_inches="tight")
+    plt.close(fig)
+    print(f"Saved benchmark curves for {dataset_name} to {figure_path}")
+    return figure_path
+
+
+def build_prediction_dataframe(
+    probabilities: np.ndarray,
+    labels: Sequence[object],
+    predictions: Sequence[object],
+    class_names: Sequence[str],
+) -> pd.DataFrame:
+    """Assemble a dataframe compatible with :func:`evaluate_predictions`."""
+
+    prob_matrix = np.asarray(probabilities)
+    class_names = list(class_names)
+    if prob_matrix.ndim == 1:
+        if len(class_names) == 2:
+            negative_name, positive_name = class_names[0], class_names[-1]
+            proba_dict = {
+                f"pred_proba_{negative_name}": 1.0 - prob_matrix,
+                f"pred_proba_{positive_name}": prob_matrix,
+            }
+        else:
+            proba_dict = {"pred_proba_0": prob_matrix}
+    else:
+        if prob_matrix.shape[1] == len(class_names) and len(class_names) > 0:
+            proba_dict = {
+                f"pred_proba_{class_names[idx]}": prob_matrix[:, idx]
+                for idx in range(prob_matrix.shape[1])
+            }
+        else:
+            proba_dict = {
+                f"pred_proba_{idx}": prob_matrix[:, idx]
+                for idx in range(prob_matrix.shape[1])
+            }
+
+    base_df = pd.DataFrame(
+        {
+            "label": np.asarray(labels),
+            "y_pred": np.asarray(predictions),
+        }
+    )
+    if proba_dict:
+        proba_df = pd.DataFrame(proba_dict)
+        base_df = pd.concat([base_df.reset_index(drop=True), proba_df], axis=1)
+    else:
+        base_df = base_df.reset_index(drop=True)
+    return base_df


### PR DESCRIPTION
## Summary
- factor out shared display, schema, evaluation, and calibration helpers from the supervised script into `mimic_mortality_utils`
- extend the helper module with Optuna-ready metric utilities, isotonic calibration support, and plotting helpers used by the mortality workflow
- update the supervised analysis to use the shared helpers, widen the classification loss weight search space, and apply isotonic regression calibration on the validation split

## Testing
- pytest -q
- ruff check examples/mimic_mortality_utils.py examples/mimic_mortality_supervised.py
- black examples/mimic_mortality_utils.py examples/mimic_mortality_supervised.py

------
https://chatgpt.com/codex/tasks/task_e_68d42adfb9b88320b12bac7fe70663ea