### PR TITLE
Add reusable synthetic data quality metrics

### DIFF
--- a/README-CN.md
+++ b/README-CN.md
@@ -127,6 +127,35 @@ ece = compute_ece(proba, val_y.to_numpy(), n_bins=15)
 
 各指标函数会自动校验概率矩阵的形状，在输入退化时返回 `numpy.nan`。
 
+### 生成数据质量评估
+
+```python
+from sklearn.linear_model import LogisticRegression
+
+from suave.evaluate import (
+    evaluate_trtr,
+    evaluate_tstr,
+    kolmogorov_smirnov_statistic,
+    mutual_information_feature,
+    rbf_mmd,
+    simple_membership_inference,
+)
+
+# 对比真实数据与合成数据的迁移表现
+tstr_scores = evaluate_tstr((X_syn, y_syn), (X_test, y_test), LogisticRegression)
+trtr_scores = evaluate_trtr((X_train, y_train), (X_test, y_test), LogisticRegression)
+
+# 检查特征分布的一致性
+ks_age = kolmogorov_smirnov_statistic(real_age.values, synthetic_age.values)
+mmd_labs = rbf_mmd(real_labs.values, synthetic_labs.values, random_state=0)
+mi_unit = mutual_information_feature(real_unit.values, synthetic_unit.values)
+
+# 评估隐私泄露风险
+attack = simple_membership_inference(train_probs, train_labels, test_probs, test_labels)
+```
+
+`evaluate_tstr` / `evaluate_trtr` 可以搭配任意监督模型验证迁移性能；KS、RBF-MMD 与互信息用于量化单个特征的分布一致性，常见经验是 KS `<0.1`、MMD 接近 `0.0`、互信息接近 `0` 表示较好的拟合。成员推断攻击给出区分训练样本与保留样本的 AUROC 与准确率，用于监控潜在的隐私泄露。
+
 ### 潜变量编码
 
 ```python

--- a/README.md
+++ b/README.md
@@ -145,6 +145,35 @@ ece = compute_ece(proba, val_y.to_numpy(), n_bins=15)
 
 Each helper validates probability shapes, performs necessary conversions for binary tasks, and returns `numpy.nan` when inputs are degenerate.
 
+### Synthetic data quality
+
+```python
+from sklearn.linear_model import LogisticRegression
+
+from suave.evaluate import (
+    evaluate_trtr,
+    evaluate_tstr,
+    kolmogorov_smirnov_statistic,
+    mutual_information_feature,
+    rbf_mmd,
+    simple_membership_inference,
+)
+
+# Compare real-vs-real and synthetic-vs-real transfer
+tstr_scores = evaluate_tstr((X_syn, y_syn), (X_test, y_test), LogisticRegression)
+trtr_scores = evaluate_trtr((X_train, y_train), (X_test, y_test), LogisticRegression)
+
+# Inspect per-feature distribution alignment
+ks_age = kolmogorov_smirnov_statistic(real_age.values, synthetic_age.values)
+mmd_labs = rbf_mmd(real_labs.values, synthetic_labs.values, random_state=0)
+mi_unit = mutual_information_feature(real_unit.values, synthetic_unit.values)
+
+# Audit membership privacy leakage
+attack = simple_membership_inference(train_probs, train_labels, test_probs, test_labels)
+```
+
+The `evaluate_tstr`/`evaluate_trtr` pair supports model-agnostic baselines for benchmarking synthetic cohorts, while the Kolmogorov–Smirnov statistic, RBF-MMD, and mutual information helpers quantify per-feature fidelity. Low KS (`<0.1`), low MMD (≈`0.0`), and near-zero mutual information indicate strong alignment; larger values call for manual inspection. The membership attack reports AUROC and accuracy for separating training members from held-out data, highlighting potential privacy leakage.
+
 ### Latent representations
 
 ```python

--- a/examples/mimic_mortality_optimize.py
+++ b/examples/mimic_mortality_optimize.py
@@ -1,0 +1,431 @@
+# %% [markdown]
+# # MIMIC mortality – hyperparameter optimisation
+#
+# This script runs Optuna to tune SUAVE hyperparameters for the selected
+# mortality target and fits an isotonic calibrator on the internal validation
+# split. The resulting artefacts (model checkpoint, calibrator, and Optuna
+# summary) are written to the analysis output directory for downstream
+# evaluation.
+
+# %%
+
+from __future__ import annotations
+
+import json
+import sys
+import time
+from pathlib import Path
+from typing import Dict, Optional, Sequence, Tuple
+
+import joblib
+import numpy as np
+import pandas as pd
+from sklearn.model_selection import train_test_split
+
+EXAMPLES_DIR = Path(__file__).resolve().parent
+if not EXAMPLES_DIR.exists():
+    raise RuntimeError(
+        "Run this script from the repository so the 'examples' directory is available."
+    )
+if str(EXAMPLES_DIR) not in sys.path:
+    sys.path.insert(0, str(EXAMPLES_DIR))
+
+from mimic_mortality_utils import (  # noqa: E402
+    HIDDEN_DIMENSION_OPTIONS,
+    HEAD_HIDDEN_DIMENSION_OPTIONS,
+    RANDOM_STATE,
+    TARGET_COLUMNS,
+    VALIDATION_SIZE,
+    Schema,
+    build_suave_model,
+    compute_binary_metrics,
+    define_schema,
+    fit_isotonic_calibrator,
+    load_dataset,
+    make_logistic_pipeline,
+    prepare_features,
+    render_dataframe,
+    schema_to_dataframe,
+    to_numeric_frame,
+)
+
+from suave.evaluate import evaluate_tstr, evaluate_trtr  # noqa: E402
+
+try:
+    import optuna
+except ImportError as exc:  # pragma: no cover - optuna provided via requirements
+    raise RuntimeError(
+        "Optuna is required for the mortality optimisation. Install it via 'pip install optuna'."
+    ) from exc
+
+
+# %% [markdown]
+# ## Analysis configuration
+#
+# Configure the analysis outputs and Optuna storage. Artefacts are written to
+# ``analysis_outputs_supervised`` so they can be reused by the downstream
+# evaluation script.
+
+# %%
+
+TARGET_LABEL = "in_hospital_mortality"
+
+analysis_config = {
+    "optuna_trials": 60,
+    "optuna_timeout": 3600 * 48,
+    "optuna_study_prefix": "supervised",
+    "optuna_storage": None,
+    "output_dir_name": "analysis_outputs_supervised",
+}
+
+
+# %% [markdown]
+# ## Data loading and schema definition
+
+# %%
+
+DATA_DIR = (EXAMPLES_DIR / "data" / "sepsis_mortality_dataset").resolve()
+OUTPUT_DIR = EXAMPLES_DIR / analysis_config["output_dir_name"]
+OUTPUT_DIR.mkdir(exist_ok=True)
+analysis_config["optuna_storage"] = (
+    f"sqlite:///{OUTPUT_DIR}/{analysis_config['optuna_study_prefix']}_optuna.db"
+)
+
+train_df = load_dataset(DATA_DIR / "mimic-mortality-train.tsv")
+test_df = load_dataset(DATA_DIR / "mimic-mortality-test.tsv")
+
+if TARGET_LABEL not in TARGET_COLUMNS:
+    raise ValueError(
+        f"Target label '{TARGET_LABEL}' is not one of the configured targets: {TARGET_COLUMNS}"
+    )
+
+FEATURE_COLUMNS = [
+    column for column in train_df.columns if column not in TARGET_COLUMNS
+]
+schema = define_schema(train_df, FEATURE_COLUMNS, mode="interactive")
+schema.update(
+    {
+        "BMI": {"type": "real"},
+        "Respiratory_Support": {"type": "ordinal", "n_classes": 5},
+        "LYM%": {"type": "real"},
+    }
+)
+
+schema_df = schema_to_dataframe(schema).sort_values("Column").reset_index(drop=True)
+render_dataframe(schema_df, title="Schema overview", floatfmt=None)
+
+
+# %% [markdown]
+# ## Optuna study helper
+
+
+def run_optuna_search(
+    X_train: pd.DataFrame,
+    y_train: pd.Series,
+    X_validation: pd.DataFrame,
+    y_validation: pd.Series,
+    *,
+    feature_columns: Sequence[str],
+    schema: Schema,
+    random_state: int,
+    n_trials: Optional[int],
+    timeout: Optional[int],
+    study_name: Optional[str] = None,
+    storage: Optional[str] = None,
+) -> tuple["optuna.study.Study", Dict[str, object]]:
+    """Perform Optuna hyperparameter optimisation for :class:`SUAVE`."""
+
+    if n_trials is not None and n_trials <= 0:
+        n_trials = None
+    if timeout is not None and timeout <= 0:
+        timeout = None
+
+    def objective(trial: "optuna.trial.Trial") -> Tuple[float, float]:
+        trial.suggest_categorical("latent_dim", [8, 16, 24, 32, 48, 64])
+        trial.suggest_categorical("n_components", [1, 2, 4, 6])
+        trial.suggest_categorical("hidden_dims", list(HIDDEN_DIMENSION_OPTIONS.keys()))
+        trial.suggest_categorical(
+            "head_hidden_dims", list(HEAD_HIDDEN_DIMENSION_OPTIONS.keys())
+        )
+        trial.suggest_float("beta", 0.1, 6.0)
+        trial.suggest_categorical("use_classification_loss_weight", [True, False])
+        if trial.params.get("use_classification_loss_weight"):
+            trial.suggest_float("classification_loss_weight", 1.0, 200.0, log=True)
+        trial.suggest_float("dropout", 0.0, 0.7)
+        trial.suggest_float("learning_rate", 1e-5, 5e-2, log=True)
+        trial.suggest_categorical("batch_size", [32, 64, 128, 256, 512, 1024])
+        trial.suggest_int("warmup_epochs", 1, 100)
+        trial.suggest_int("kl_warmup_epochs", 0, 80)
+        trial.suggest_int("head_epochs", 1, 80)
+        trial.suggest_int("finetune_epochs", 1, 60)
+        trial.suggest_int("early_stop_patience", 3, 30)
+        trial.suggest_float("joint_decoder_lr_scale", 1e-4, 1.0, log=True)
+
+        model = build_suave_model(trial.params, schema, random_state=random_state)
+
+        start_time = time.perf_counter()
+        model.fit(
+            X_train,
+            y_train,
+            warmup_epochs=int(trial.params.get("warmup_epochs", 3)),
+            kl_warmup_epochs=int(trial.params.get("kl_warmup_epochs", 0)),
+            head_epochs=int(trial.params.get("head_epochs", 2)),
+            finetune_epochs=int(trial.params.get("finetune_epochs", 2)),
+            joint_decoder_lr_scale=float(
+                trial.params.get("joint_decoder_lr_scale", 0.1)
+            ),
+            early_stop_patience=int(trial.params.get("early_stop_patience", 10)),
+        )
+        fit_seconds = time.perf_counter() - start_time
+        validation_probs = model.predict_proba(X_validation)
+        validation_metrics = compute_binary_metrics(validation_probs, y_validation)
+        trial.set_user_attr("validation_metrics", validation_metrics)
+        trial.set_user_attr("fit_seconds", fit_seconds)
+
+        roauc = validation_metrics.get("ROAUC", float("nan"))
+        if not np.isfinite(roauc):
+            raise optuna.exceptions.TrialPruned("Non-finite validation ROAUC")
+
+        try:
+            numeric_train = to_numeric_frame(X_train.loc[:, feature_columns])
+            numeric_validation = to_numeric_frame(X_validation.loc[:, feature_columns])
+
+            rng = np.random.default_rng(random_state + trial.number)
+            synthetic_labels = rng.choice(y_train, size=len(y_train), replace=True)
+            synthetic_samples = model.sample(
+                len(synthetic_labels), conditional=True, y=synthetic_labels
+            )
+            if not isinstance(synthetic_samples, pd.DataFrame):
+                synthetic_features = pd.DataFrame(
+                    synthetic_samples, columns=feature_columns
+                )
+            else:
+                synthetic_features = synthetic_samples.loc[:, feature_columns].copy()
+            numeric_synthetic = to_numeric_frame(synthetic_features)
+
+            tstr_metrics = evaluate_tstr(
+                (
+                    numeric_synthetic.to_numpy(),
+                    np.asarray(synthetic_labels),
+                ),
+                (
+                    numeric_validation.to_numpy(),
+                    y_validation.to_numpy(),
+                ),
+                make_logistic_pipeline,
+            )
+            trtr_metrics = evaluate_trtr(
+                (
+                    numeric_train.to_numpy(),
+                    y_train.to_numpy(),
+                ),
+                (
+                    numeric_validation.to_numpy(),
+                    y_validation.to_numpy(),
+                ),
+                make_logistic_pipeline,
+            )
+            trial.set_user_attr("tstr_metrics", tstr_metrics)
+            trial.set_user_attr("trtr_metrics", trtr_metrics)
+
+            delta_auc = abs(
+                float(trtr_metrics.get("auroc", float("nan")))
+                - float(tstr_metrics.get("auroc", float("nan")))
+            )
+            if not np.isfinite(delta_auc):
+                raise ValueError("Non-finite TSTR/TRTR delta AUC")
+        except Exception as error:
+            trial.set_user_attr("tstr_trtr_error", repr(error))
+            raise optuna.exceptions.TrialPruned(
+                f"Failed to compute TSTR/TRTR delta AUC: {error}"
+            ) from error
+
+        trial.set_user_attr("tstr_trtr_delta_auc", delta_auc)
+        return roauc, delta_auc
+
+    study = optuna.create_study(
+        directions=("maximize", "minimize"),
+        study_name=study_name,
+        storage=storage,
+        load_if_exists=bool(storage and study_name),
+    )
+    study.optimize(objective, n_trials=n_trials, timeout=timeout)
+
+    feasible_trials = [trial for trial in study.trials if trial.values is not None]
+    if not feasible_trials:
+        raise RuntimeError("Optuna search did not produce any completed trials")
+
+    def sort_key(trial: "optuna.trial.Trial") -> Tuple[float, float]:
+        values = trial.values or (float("nan"), float("inf"))
+        primary = values[0]
+        secondary = values[1]
+        return (primary, -secondary if np.isfinite(secondary) else float("-inf"))
+
+    best_trial = max(feasible_trials, key=sort_key)
+    best_attributes: Dict[str, object] = {
+        "trial_number": best_trial.number,
+        "values": tuple(best_trial.values or ()),
+        "params": dict(best_trial.params),
+        "validation_metrics": best_trial.user_attrs.get("validation_metrics", {}),
+        "fit_seconds": best_trial.user_attrs.get("fit_seconds"),
+        "tstr_metrics": best_trial.user_attrs.get("tstr_metrics", {}),
+        "trtr_metrics": best_trial.user_attrs.get("trtr_metrics", {}),
+        "tstr_trtr_delta_auc": best_trial.user_attrs.get("tstr_trtr_delta_auc"),
+    }
+    return study, best_attributes
+
+
+# %% [markdown]
+# ## Train/validation split for optimisation
+
+# %%
+
+X_full = prepare_features(train_df, FEATURE_COLUMNS)
+y_full = train_df[TARGET_LABEL]
+
+X_train_model, X_validation, y_train_model, y_validation = train_test_split(
+    X_full,
+    y_full,
+    test_size=VALIDATION_SIZE,
+    stratify=y_full,
+    random_state=RANDOM_STATE,
+)
+
+X_train_model = X_train_model.reset_index(drop=True)
+X_validation = X_validation.reset_index(drop=True)
+y_train_model = y_train_model.reset_index(drop=True)
+y_validation = y_validation.reset_index(drop=True)
+
+
+# %% [markdown]
+# ## Execute Optuna search
+
+# %%
+
+study_name = (
+    f"{analysis_config['optuna_study_prefix']}_{TARGET_LABEL}"
+    if analysis_config["optuna_study_prefix"]
+    else None
+)
+
+study, optuna_best_info = run_optuna_search(
+    X_train_model,
+    y_train_model,
+    X_validation,
+    y_validation,
+    feature_columns=FEATURE_COLUMNS,
+    schema=schema,
+    random_state=RANDOM_STATE,
+    n_trials=analysis_config["optuna_trials"],
+    timeout=analysis_config["optuna_timeout"],
+    study_name=study_name,
+    storage=analysis_config["optuna_storage"],
+)
+
+trial_rows: list[dict[str, object]] = []
+for trial in study.trials:
+    values = trial.values or (float("nan"), float("nan"))
+    trial_rows.append(
+        {
+            "trial_number": trial.number,
+            "validation_roauc": values[0],
+            "tstr_trtr_delta_auc": values[1],
+            **trial.params,
+        }
+    )
+
+optuna_trials_df = pd.DataFrame(trial_rows)
+optuna_trials_path = OUTPUT_DIR / f"optuna_trials_{TARGET_LABEL}.csv"
+if not optuna_trials_df.empty:
+    optuna_trials_df.to_csv(optuna_trials_path, index=False)
+else:
+    optuna_trials_path.write_text("trial_number,value")
+
+
+# %% [markdown]
+# ## Serialise Optuna artefacts
+
+# %%
+
+
+def _json_ready(value: object) -> object:
+    if isinstance(value, (np.floating, np.integer)):
+        return value.item()
+    if isinstance(value, dict):
+        return {key: _json_ready(val) for key, val in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_json_ready(val) for val in value]
+    return value
+
+
+best_params = dict(optuna_best_info.get("params", {}))
+best_info_path = OUTPUT_DIR / f"optuna_best_info_{TARGET_LABEL}.json"
+best_params_path = OUTPUT_DIR / f"optuna_best_params_{TARGET_LABEL}.json"
+best_info_path.write_text(
+    json.dumps(_json_ready(optuna_best_info), indent=2, ensure_ascii=False)
+)
+best_params_path.write_text(
+    json.dumps(_json_ready(best_params), indent=2, ensure_ascii=False)
+)
+
+
+# %% [markdown]
+# ## Train best SUAVE model and calibrator
+
+# %%
+
+if not best_params:
+    raise RuntimeError(
+        "Optuna did not return best parameters; cannot train final model"
+    )
+
+model = build_suave_model(best_params, schema, random_state=RANDOM_STATE)
+
+model.fit(
+    X_train_model,
+    y_train_model,
+    warmup_epochs=int(best_params.get("warmup_epochs", 3)),
+    kl_warmup_epochs=int(best_params.get("kl_warmup_epochs", 0)),
+    head_epochs=int(best_params.get("head_epochs", 2)),
+    finetune_epochs=int(best_params.get("finetune_epochs", 2)),
+    joint_decoder_lr_scale=float(best_params.get("joint_decoder_lr_scale", 0.1)),
+    early_stop_patience=int(best_params.get("early_stop_patience", 10)),
+)
+
+isotonic_calibrator = fit_isotonic_calibrator(model, X_validation, y_validation)
+
+model_path = OUTPUT_DIR / f"suave_best_{TARGET_LABEL}.pt"
+calibrator_path = OUTPUT_DIR / f"isotonic_calibrator_{TARGET_LABEL}.joblib"
+
+model.save(model_path)
+joblib.dump(isotonic_calibrator, calibrator_path)
+
+
+# %% [markdown]
+# ## Summary
+
+# %%
+
+summary_lines = [
+    "# Optimisation summary",
+    f"Target label: {TARGET_LABEL}",
+    f"Best trial: #{optuna_best_info.get('trial_number')}",
+    f"Validation ROAUC: {optuna_best_info.get('values', (float('nan'),))[0]:.4f}",
+    f"TSTR/TRTR ΔAUC: {optuna_best_info.get('values', (float('nan'), float('nan')))[1]:.4f}",
+    "\nBest parameters:",
+    json.dumps(_json_ready(best_params), indent=2, ensure_ascii=False),
+    "",
+    "Saved artefacts:",
+    f"- Optuna trials: {optuna_trials_path.relative_to(OUTPUT_DIR)}",
+    f"- Best info: {best_info_path.relative_to(OUTPUT_DIR)}",
+    f"- Best params: {best_params_path.relative_to(OUTPUT_DIR)}",
+    f"- SUAVE model: {model_path.relative_to(OUTPUT_DIR)}",
+    f"- Isotonic calibrator: {calibrator_path.relative_to(OUTPUT_DIR)}",
+]
+
+summary_path = OUTPUT_DIR / f"optimisation_summary_{TARGET_LABEL}.md"
+summary_path.write_text("\n".join(summary_lines))
+render_dataframe(
+    pd.DataFrame([_json_ready(optuna_best_info.get("validation_metrics", {}))]),
+    title="Best validation metrics",
+)

--- a/examples/mimic_mortality_supervised.py
+++ b/examples/mimic_mortality_supervised.py
@@ -1,35 +1,25 @@
 # %% [markdown]
-# # MIMIC mortality (supervised)
-# 
-# This notebook reproduces the supervised SUAVE mortality analysis with Optuna-based hyperparameter tuning.
+# # MIMIC mortality (evaluation)
+#
+# This notebook-style script loads the artefacts produced by the Optuna
+# optimisation pipeline, ensures a calibrated SUAVE model is available, and runs
+# the downstream evaluation suite (classical baselines, prognosis metrics,
+# synthetic-vs-real analysis, and reporting).
 
 # %%
 
-import sys
+from __future__ import annotations
+
 import json
+import sys
 from pathlib import Path
-import time
-from typing import Dict, List, Mapping, Optional, Tuple
+from typing import Any, Dict, List, Mapping, Optional, Tuple
 
-from IPython.display import display
-from tabulate import tabulate
-
+import joblib
 import numpy as np
 import pandas as pd
-from matplotlib import pyplot as plt
-from sklearn.calibration import calibration_curve
-from sklearn.decomposition import PCA
-from sklearn.experimental import enable_iterative_imputer  # noqa: F401
-from sklearn.impute import IterativeImputer
 from sklearn.ensemble import RandomForestClassifier
 from sklearn.linear_model import LogisticRegression
-from sklearn.metrics import (
-    accuracy_score,
-    brier_score_loss,
-    confusion_matrix,
-    roc_auc_score,
-    roc_curve,
-)
 from sklearn.model_selection import train_test_split
 from sklearn.neighbors import KNeighborsClassifier
 from sklearn.pipeline import Pipeline
@@ -37,183 +27,58 @@ from sklearn.preprocessing import StandardScaler
 from sklearn.svm import SVC
 from sklearn.tree import DecisionTreeClassifier
 
-EXAMPLES_DIR = Path().resolve()
+EXAMPLES_DIR = Path(__file__).resolve().parent
 if not EXAMPLES_DIR.exists():
-    raise RuntimeError("Run this notebook from the repository root so 'examples' is available.")
+    raise RuntimeError(
+        "Run this notebook from the repository root so 'examples' is available."
+    )
 if str(EXAMPLES_DIR) not in sys.path:
     sys.path.insert(0, str(EXAMPLES_DIR))
 
-from mimic_mortality_utils import (
+from mimic_mortality_utils import (  # noqa: E402
     RANDOM_STATE,
     TARGET_COLUMNS,
     VALIDATION_SIZE,
-    Schema,
+    build_prediction_dataframe,
+    build_suave_model,
+    build_tstr_training_sets,
+    compute_binary_metrics,
+    dataframe_to_markdown,
     define_schema,
+    evaluate_transfer_baselines,
+    extract_positive_probabilities,
+    fit_isotonic_calibrator,
     kolmogorov_smirnov_statistic,
     load_dataset,
+    load_or_create_iteratively_imputed_features,
+    make_baseline_model_factories,
     mutual_information_feature,
+    plot_benchmark_curves,
+    plot_calibration_curves,
+    plot_latent_space,
+    plot_transfer_metric_bars,
     prepare_features,
+    render_dataframe,
     rbf_mmd,
+    schema_to_dataframe,
     to_numeric_frame,
 )
-from cls_eval import evaluate_predictions, write_results_to_excel_unique
+from cls_eval import evaluate_predictions, write_results_to_excel_unique  # noqa: E402
 
-from suave import SUAVE
-from suave.evaluate import evaluate_tstr, evaluate_trtr, simple_membership_inference
-
-try:
-    import optuna
-except ImportError as exc:  # pragma: no cover - optuna provided via requirements
-    raise RuntimeError(
-        "Optuna is required for the mortality analysis. Install it via 'pip install optuna'."
-    ) from exc
+from suave import SUAVE  # noqa: E402
+from suave.evaluate import simple_membership_inference  # noqa: E402
 
 
-def is_interactive_session() -> bool:
-    """Return ``True`` when running inside an interactive IPython session."""
-
-    try:
-        from IPython import get_ipython
-    except ImportError:
-        return False
-    return get_ipython() is not None
-
-
-def render_dataframe(
-    df: pd.DataFrame,
-    *,
-    title: Optional[str] = None,
-    floatfmt: Optional[str] = ".3f",
-) -> None:
-    """Display ``df`` using ``display`` when interactive, otherwise print via tabulate."""
-
-    if title:
-        print(title)
-    if df.empty:
-        print("(empty table)")
-        return
-    if is_interactive_session():
-        display(df)
-    else:
-        tabulate_kwargs = {"headers": "keys", "tablefmt": "github", "showindex": False}
-        if floatfmt is not None:
-            tabulate_kwargs["floatfmt"] = floatfmt
-        print(tabulate(df, **tabulate_kwargs))
-
-
-def dataframe_to_markdown(df: pd.DataFrame, *, floatfmt: Optional[str] = ".3f") -> str:
-    """Return a GitHub-flavoured Markdown table representing ``df``."""
-
-    if df.empty:
-        return "_No data available._"
-    tabulate_kwargs = {"headers": "keys", "tablefmt": "github", "showindex": False}
-    if floatfmt is not None:
-        tabulate_kwargs["floatfmt"] = floatfmt
-    return tabulate(df, **tabulate_kwargs)
-
-
-def schema_to_dataframe(schema: Schema) -> pd.DataFrame:
-    """Convert a :class:`Schema` into a tidy :class:`pandas.DataFrame`."""
-
-    schema_records: List[Dict[str, object]] = []
-    for column, spec in schema.to_dict().items():
-        schema_records.append(
-            {
-                "Column": column,
-                "Type": spec.get("type", ""),
-                "n_classes": spec.get("n_classes", ""),
-                "y_dim": spec.get("y_dim", ""),
-            }
-        )
-    return pd.DataFrame(schema_records)
-
-
-def slugify_identifier(value: str) -> str:
-    """Return a filesystem-friendly identifier based on ``value``."""
-
-    cleaned = [char.lower() if char.isalnum() else "_" for char in value.strip()]
-    slug = "".join(cleaned)
-    while "__" in slug:
-        slug = slug.replace("__", "_")
-    return slug.strip("_")
-
-
-def load_or_create_iteratively_imputed_features(
-    feature_sets: Mapping[str, pd.DataFrame],
-    *,
-    output_dir: Path,
-    target_label: str,
-    reference_key: str,
-) -> Tuple[Dict[str, pd.DataFrame], Dict[str, Path], bool]:
-    """Load cached iterative imputations or fit a new :class:`IterativeImputer`."""
-
-    if reference_key not in feature_sets:
-        raise KeyError(
-            f"Reference key '{reference_key}' missing from feature sets: {list(feature_sets)}"
-        )
-
-    dataset_paths: Dict[str, Path] = {
-        name: output_dir
-        / f"iterative_imputed_{slugify_identifier(name)}_{slugify_identifier(target_label)}.csv"
-        for name in feature_sets
-    }
-
-    loaded_features: Dict[str, pd.DataFrame] = {}
-    load_successful = True
-    for name, path in dataset_paths.items():
-        features = feature_sets[name]
-        if not path.exists():
-            load_successful = False
-            break
-        cached = pd.read_csv(path, index_col=0)
-        column_match = list(cached.columns) == list(features.columns)
-        length_match = len(cached) == len(features)
-        if not (column_match and length_match):
-            load_successful = False
-            break
-        try:
-            cached = cached.loc[features.index]
-        except KeyError:
-            load_successful = False
-            break
-        loaded_features[name] = cached
-
-    if load_successful:
-        return loaded_features, dataset_paths, True
-
-    imputer = IterativeImputer()
-    imputer.fit(feature_sets[reference_key])
-
-    imputed_features: Dict[str, pd.DataFrame] = {}
-    for name, features in feature_sets.items():
-        transformed = imputer.transform(features)
-        imputed_df = pd.DataFrame(
-            transformed,
-            columns=features.columns,
-            index=features.index,
-        )
-        path = dataset_paths[name]
-        path.parent.mkdir(parents=True, exist_ok=True)
-        imputed_df.to_csv(path)
-        imputed_features[name] = imputed_df
-
-    return imputed_features, dataset_paths, False
-
-
-#%% [markdown]
+# %% [markdown]
 # ## Analysis configuration
 #
-# Define the label to model and tuning/runtime parameters. Setting the label up
-# front avoids looping over every possible prediction task so that the analysis
-# remains focused on a single clinical question.
+# Define the label of interest and locations for cached outputs from the
+# optimisation script.
 
 # %%
 
-# Select the target label to model. Choose from the columns listed in
-# ``TARGET_COLUMNS`` loaded from ``mimic_mortality_utils``.
 TARGET_LABEL = "in_hospital_mortality"
 
-# Configuration for Optuna search and output artifacts.
 analysis_config = {
     "optuna_trials": 60,
     "optuna_timeout": 3600 * 48,
@@ -222,7 +87,8 @@ analysis_config = {
     "output_dir_name": "analysis_outputs_supervised",
 }
 
-#%% [markdown]
+
+# %% [markdown]
 # ## Data loading and schema definition
 #
 # Load train/test/external splits, construct the schema, and validate the
@@ -247,7 +113,9 @@ if TARGET_LABEL not in TARGET_COLUMNS:
         f"Target label '{TARGET_LABEL}' is not one of the configured targets: {TARGET_COLUMNS}"
     )
 
-FEATURE_COLUMNS = [column for column in train_df.columns if column not in TARGET_COLUMNS]
+FEATURE_COLUMNS = [
+    column for column in train_df.columns if column not in TARGET_COLUMNS
+]
 schema = define_schema(train_df, FEATURE_COLUMNS, mode="interactive")
 
 # Manual schema corrections ensure columns with ambiguous types are treated
@@ -266,280 +134,104 @@ render_dataframe(schema_df, title="Schema overview", floatfmt=None)
 
 # %%
 
-HIDDEN_DIMENSION_OPTIONS: Dict[str, Tuple[int, int]] = {
-    "lean": (64, 32),
-    "compact": (96, 48),
-    "small": (128, 64),
-    "medium": (256, 128),
-    "wide": (384, 192),
-    "extra_wide": (512, 256),
-    "ultra_wide": (640, 320),
-}
 
-HEAD_HIDDEN_DIMENSION_OPTIONS: Dict[str, Tuple[int, int]] = {
-    "minimal": (16,),
-    "compact": (32,),
-    "small": (48,),
-    "medium": (48, 32),
-    "wide": (96, 48, 16),
-    "extra_wide": (64, 128, 64, 16),
-    "deep": (128, 64, 32),
-}
-def make_logistic_pipeline() -> Pipeline:
-    """Factory for the baseline classifier used in TSTR/TRTR."""
+def make_study_name(prefix: Optional[str], target_label: str) -> Optional[str]:
+    """Return the Optuna study name for ``target_label`` given ``prefix``."""
 
-    return Pipeline(
-        [
-            ("imputer", IterativeImputer()),
-            ("scaler", StandardScaler()),
-            ("classifier", LogisticRegression(max_iter=200)),
-        ]
-    )
+    if not prefix:
+        return None
+    return f"{prefix}_{target_label}"
 
 
-def extract_positive_probabilities(probabilities: np.ndarray) -> np.ndarray:
-    """Return the positive-class probabilities as a 1-D array."""
-
-    prob_matrix = np.asarray(probabilities)
-    if prob_matrix.ndim == 1:
-        return prob_matrix
-    return prob_matrix[:, -1]
-
-
-def compute_binary_metrics(
-    probabilities: np.ndarray, targets: pd.Series | np.ndarray
-) -> Dict[str, float]:
-    """Compute AUROC, accuracy, specificity, sensitivity, and Brier score."""
-
-    positive_probs = extract_positive_probabilities(probabilities)
-    labels = np.asarray(targets)
-    predictions = (positive_probs >= 0.5).astype(int)
-
-    metrics: Dict[str, float] = {}
-
-    try:
-        roauc = float(roc_auc_score(labels, positive_probs))
-    except ValueError:
-        roauc = float("nan")
-
-    metrics["ROAUC"] = roauc
-    metrics["AUC"] = roauc
-
-    metrics["ACC"] = float(accuracy_score(labels, predictions))
-    tn, fp, fn, tp = confusion_matrix(labels, predictions, labels=[0, 1]).ravel()
-    metrics["SPE"] = float(tn / (tn + fp)) if (tn + fp) > 0 else float("nan")
-    metrics["SEN"] = float(tp / (tp + fn)) if (tp + fn) > 0 else float("nan")
-    metrics["Brier"] = float(brier_score_loss(labels, positive_probs))
-    return metrics
-
-
-def run_optuna_search(
-    X_train: pd.DataFrame,
-    y_train: pd.Series,
-    X_validation: pd.DataFrame,
-    y_validation: pd.Series,
-    schema: Schema,
+def load_optuna_results(
+    output_dir: Path,
+    target_label: str,
     *,
-    random_state: int,
-    n_trials: Optional[int],
-    timeout: Optional[int],
-    study_name: Optional[str] = None,
-    storage: Optional[str] = None,
-) -> tuple["optuna.study.Study", Dict[str, object]]:
-    """Perform Optuna hyperparameter optimisation for :class:`SUAVE`."""
+    study_prefix: Optional[str],
+    storage: Optional[str],
+) -> tuple[Dict[str, Any], Dict[str, Any]]:
+    """Load the best Optuna trial metadata and parameters if available."""
 
-    if n_trials is not None and n_trials <= 0:
-        n_trials = None
-    if timeout is not None and timeout <= 0:
-        timeout = None
+    best_info_path = output_dir / f"optuna_best_info_{target_label}.json"
+    best_params_path = output_dir / f"optuna_best_params_{target_label}.json"
 
-    def objective(trial: "optuna.trial.Trial") -> float:
-        latent_dim = trial.suggest_categorical("latent_dim", [8, 16, 24, 32, 48, 64])
-        n_components = trial.suggest_categorical("n_components", [1, 2, 4, 6])
-        hidden_key = trial.suggest_categorical("hidden_dims", list(HIDDEN_DIMENSION_OPTIONS.keys()))
-        head_hidden_key = trial.suggest_categorical("head_hidden_dims", list(HEAD_HIDDEN_DIMENSION_OPTIONS.keys()))
-        beta = trial.suggest_float("beta", 0.1, 6.0)
-        classification_loss_weight = trial.suggest_float(
-            "classification_loss_weight", 0.1, 5.0, log=True
-        )
-        dropout = trial.suggest_float("dropout", 0.0, 0.7)
-        learning_rate = trial.suggest_float("learning_rate", 1e-5, 5e-2, log=True)
-        batch_size = trial.suggest_categorical("batch_size", [32, 64, 128, 256, 512, 1024])
-        warmup_epochs = trial.suggest_int("warmup_epochs", 1, 100)
-        kl_warmup_epochs = trial.suggest_int("kl_warmup_epochs", 0, 80)
-        head_epochs = trial.suggest_int("head_epochs", 1, 80)
-        finetune_epochs = trial.suggest_int("finetune_epochs", 1, 60)
-        early_stop_patience = trial.suggest_int("early_stop_patience", 3, 30)
-        joint_decoder_lr_scale = trial.suggest_float(
-            "joint_decoder_lr_scale", 1e-4, 1.0, log=True
-        )
-
-        model = SUAVE(
-            schema=schema,
-            latent_dim=latent_dim,
-            n_components=int(n_components),
-            hidden_dims=HIDDEN_DIMENSION_OPTIONS[hidden_key],
-            head_hidden_dims=HEAD_HIDDEN_DIMENSION_OPTIONS[head_hidden_key],
-            dropout=dropout,
-            learning_rate=learning_rate,
-            batch_size=batch_size,
-            beta=beta,
-            classification_loss_weight=classification_loss_weight,
-            random_state=random_state,
-            behaviour="supervised",
-        )
-
-        start_time = time.perf_counter()
-        model.fit(
-            X_train,
-            y_train,
-            warmup_epochs=warmup_epochs,
-            kl_warmup_epochs=kl_warmup_epochs,
-            head_epochs=head_epochs,
-            finetune_epochs=finetune_epochs,
-            joint_decoder_lr_scale=joint_decoder_lr_scale,
-            early_stop_patience=early_stop_patience,
-        )
-        fit_seconds = time.perf_counter() - start_time
-        validation_probs = model.predict_proba(X_validation)
-        validation_metrics = compute_binary_metrics(validation_probs, y_validation)
-        trial.set_user_attr("validation_metrics", validation_metrics)
-        trial.set_user_attr("fit_seconds", fit_seconds)
-
-        roauc = validation_metrics.get("ROAUC", float("nan"))
-        if not np.isfinite(roauc):
-            raise optuna.exceptions.TrialPruned("Non-finite validation ROAUC")
-        return roauc
-
-    study = optuna.create_study(
-        direction="maximize",
-        study_name=study_name,
-        storage=storage,
-        load_if_exists=bool(storage and study_name),
+    best_info: Dict[str, Any] = (
+        json.loads(best_info_path.read_text()) if best_info_path.exists() else {}
     )
-    study.optimize(objective, n_trials=n_trials, timeout=timeout)
-
-    if study.best_trial is None:
-        raise RuntimeError("Optuna search did not produce a best trial")
-    best_attributes: Dict[str, object] = {
-        "trial_number": study.best_trial.number,
-        "value": study.best_value,
-        "params": dict(study.best_trial.params),
-        "validation_metrics": study.best_trial.user_attrs.get("validation_metrics", {}),
-        "fit_seconds": study.best_trial.user_attrs.get("fit_seconds"),
-    }
-    return study, best_attributes
-
-
-def plot_calibration_curves(
-    probability_map: Mapping[str, np.ndarray],
-    label_map: Mapping[str, np.ndarray],
-    *,
-    target_name: str,
-    output_path: Path,
-    n_bins: int = 10,
-) -> None:
-    """Generate calibration curves with Brier scores annotated in the legend."""
-
-    fig, ax = plt.subplots(figsize=(6, 5))
-    ax.plot(
-        [0, 1], [0, 1], linestyle="--", color="tab:gray", label="Perfect calibration"
+    best_params: Dict[str, Any] = (
+        json.loads(best_params_path.read_text()) if best_params_path.exists() else {}
     )
 
-    for dataset_name, probs in probability_map.items():
-        labels = label_map[dataset_name]
-        if probs.ndim == 2:
-            pos_probs = probs[:, -1]
-        else:
-            pos_probs = probs
+    study_name = make_study_name(study_prefix, target_label)
+    if (not best_info or not best_params) and storage and study_name:
         try:
-            frac_pos, mean_pred = calibration_curve(labels, pos_probs, n_bins=n_bins)
-        except ValueError:
-            continue
-        brier = brier_score_loss(labels, pos_probs)
-        ax.plot(
-            mean_pred, frac_pos, marker="o", label=f"{dataset_name} (Brier={brier:.3f})"
-        )
+            import optuna  # type: ignore
+        except ImportError:
+            optuna = None  # type: ignore
+        if optuna is not None:  # pragma: no cover - optuna available in examples env
+            study = optuna.load_study(study_name=study_name, storage=storage)
+            feasible_trials = [
+                trial for trial in study.trials if trial.values is not None
+            ]
+            if feasible_trials:
 
-    ax.set_xlabel("Predicted probability")
-    ax.set_ylabel("Observed frequency")
-    ax.set_title(f"Calibration: {target_name}")
-    ax.legend()
-    fig.tight_layout()
-    fig.savefig(output_path, dpi=300)
-    plt.close(fig)
+                def sort_key(trial: "optuna.trial.FrozenTrial") -> Tuple[float, float]:
+                    values = trial.values or (float("nan"), float("inf"))
+                    primary = values[0]
+                    secondary = values[1]
+                    return (
+                        primary,
+                        -secondary if np.isfinite(secondary) else float("-inf"),
+                    )
 
-
-def plot_latent_space(
-    model: SUAVE,
-    feature_map: Mapping[str, pd.DataFrame],
-    label_map: Mapping[str, pd.Series | np.ndarray],
-    *,
-    target_name: str,
-    output_path: Path,
-) -> None:
-    """Project latent representations with PCA and create scatter plots."""
-
-    latent_blocks: List[np.ndarray] = []
-    dataset_keys: List[str] = []
-    for name, features in feature_map.items():
-        if features.empty:
-            continue
-        latents = model.encode(features)
-        if latents.size == 0:
-            continue
-        latent_blocks.append(latents)
-        dataset_keys.append(name)
-
-    if not latent_blocks:
-        return
-
-    concatenated = np.vstack(latent_blocks)
-    pca = PCA(n_components=2)
-    projected = pca.fit_transform(concatenated)
-
-    offsets = np.cumsum([0] + [block.shape[0] for block in latent_blocks])
-    fig, axes = plt.subplots(
-        1,
-        len(latent_blocks),
-        figsize=(6 * len(latent_blocks), 5),
-        sharex=True,
-        sharey=True,
-    )
-
-    if len(latent_blocks) == 1:
-        axes = [axes]
-
-    for idx, (ax, name) in enumerate(zip(axes, dataset_keys)):
-        start, end = offsets[idx], offsets[idx + 1]
-        subset = projected[start:end]
-        labels = np.asarray(label_map[name])
-        scatter = ax.scatter(
-            subset[:, 0],
-            subset[:, 1],
-            c=labels,
-            cmap="coolwarm",
-            alpha=0.7,
-            edgecolor="none",
-        )
-        ax.set_title(f"{name}")
-        ax.set_xlabel("PC1")
-        ax.set_ylabel("PC2")
-        legend = ax.legend(*scatter.legend_elements(), title="Label")
-        ax.add_artist(legend)
-
-    fig.suptitle(f"Latent space projection: {target_name}")
-    fig.tight_layout(rect=(0, 0, 1, 0.96))
-    fig.savefig(output_path, dpi=300)
-    plt.close(fig)
+                best_trial = max(feasible_trials, key=sort_key)
+                best_info = {
+                    "trial_number": best_trial.number,
+                    "values": tuple(best_trial.values or ()),
+                    "params": dict(best_trial.params),
+                    "validation_metrics": best_trial.user_attrs.get(
+                        "validation_metrics", {}
+                    ),
+                    "fit_seconds": best_trial.user_attrs.get("fit_seconds"),
+                    "tstr_metrics": best_trial.user_attrs.get("tstr_metrics", {}),
+                    "trtr_metrics": best_trial.user_attrs.get("trtr_metrics", {}),
+                    "tstr_trtr_delta_auc": best_trial.user_attrs.get(
+                        "tstr_trtr_delta_auc"
+                    ),
+                }
+                best_params = dict(best_trial.params)
+    if not best_info:
+        best_info = {}
+    if not best_params and isinstance(best_info.get("params"), Mapping):
+        best_params = dict(best_info["params"])
+    return best_info, best_params
 
 
-#%% [markdown]
+def extract_calibrator_estimator(calibrator: Any) -> Optional[SUAVE]:
+    """Return the underlying SUAVE estimator from ``calibrator`` if present."""
+
+    if calibrator is None:
+        return None
+    candidate = getattr(calibrator, "base_estimator", None)
+    if isinstance(candidate, SUAVE):
+        return candidate
+    candidate = getattr(calibrator, "estimator", None)
+    if isinstance(candidate, SUAVE):
+        return candidate
+    calibrated_list = getattr(calibrator, "calibrated_classifiers_", None)
+    if calibrated_list:
+        base_est = getattr(calibrated_list[0], "base_estimator", None)
+        if isinstance(base_est, SUAVE):
+            return base_est
+    return None
+
+
+# %% [markdown]
 # ## Prepare modelling datasets
 #
 # Split the training cohort into train and validation folds for the selected
-# label. The validation fold later supports both Optuna model selection and
-# temperature calibration.
+# label. The validation fold later supports calibration if a saved model is
+# unavailable.
 
 # %%
 
@@ -573,10 +265,10 @@ else:
     external_labels = None
 
 
-#%% [markdown]
+# %% [markdown]
 # ## Classical model benchmarks
 #
-# Fit a suite of scikit-learn classifiers as quick baselines before training
+# Fit a suite of scikit-learn classifiers as quick baselines before evaluating
 # SUAVE. These provide a reference point for MIMIC test performance and, when
 # available, eICU external validation.
 
@@ -677,8 +369,8 @@ for model_name, estimator in baseline_models.items():
     fitted_estimator = estimator.fit(train_features_imputed, train_labels)
     for dataset_name, (features, labels) in baseline_evaluation_sets.items():
         probabilities = fitted_estimator.predict_proba(features)
-        baseline_probability_map[dataset_name][model_name] = extract_positive_probabilities(
-            probabilities
+        baseline_probability_map[dataset_name][model_name] = (
+            extract_positive_probabilities(probabilities)
         )
         metrics = compute_binary_metrics(probabilities, labels)
         row = {
@@ -686,7 +378,9 @@ for model_name, estimator in baseline_models.items():
             "Dataset": dataset_name,
             "Notes": "",
         }
-        row.update({column: metrics.get(column, float("nan")) for column in metric_columns})
+        row.update(
+            {column: metrics.get(column, float("nan")) for column in metric_columns}
+        )
         baseline_rows.append(row)
 
     if "eICU external" not in baseline_evaluation_sets:
@@ -711,104 +405,94 @@ render_dataframe(
 )
 
 
-#%% [markdown]
-# ## Hyperparameter search with Optuna
+# %% [markdown]
+# ## Load optimisation artefacts
 #
-# Optimise SUAVE hyperparameters on the training/validation split. The trial
-# history is persisted to CSV for later inspection.
+# Retrieve the best Optuna trial information saved by the optimisation script.
 
 # %%
 
-study_name = (
-    f"{analysis_config['optuna_study_prefix']}_{TARGET_LABEL}"
-    if analysis_config["optuna_study_prefix"]
-    else None
+optuna_best_info, optuna_best_params = load_optuna_results(
+    OUTPUT_DIR,
+    TARGET_LABEL,
+    study_prefix=analysis_config.get("optuna_study_prefix"),
+    storage=analysis_config.get("optuna_storage"),
 )
-study, optuna_best_info = run_optuna_search(
-    X_train_model,
-    y_train_model,
-    X_validation,
-    y_validation,
-    schema,
-    random_state=RANDOM_STATE,
-    n_trials=analysis_config["optuna_trials"],
-    timeout=analysis_config["optuna_timeout"],
-    study_name=study_name,
-    storage=analysis_config["optuna_storage"],
-)
-
-optuna_best_params = dict(optuna_best_info.get("params", {}))
-
-trial_rows: List[Dict[str, object]] = []
-for trial in study.trials:
-    record: Dict[str, object] = {
-        "trial_number": trial.number,
-        "value": trial.value,
-    }
-    record.update(trial.params)
-    val_metrics = trial.user_attrs.get("validation_metrics")
-    if isinstance(val_metrics, Mapping):
-        for metric_name, metric_value in val_metrics.items():
-            record[f"validation_{metric_name.lower()}"] = metric_value
-    fit_seconds = trial.user_attrs.get("fit_seconds")
-    if fit_seconds is not None:
-        record["fit_seconds"] = fit_seconds
-    trial_rows.append(record)
-
-optuna_trials_df = pd.DataFrame(trial_rows)
 optuna_trials_path = OUTPUT_DIR / f"optuna_trials_{TARGET_LABEL}.csv"
-if not optuna_trials_df.empty:
-    optuna_trials_df.to_csv(optuna_trials_path, index=False)
-else:
-    optuna_trials_path.write_text("trial_number,value")
+
+if not optuna_best_params:
+    print(
+        "Optuna best parameters were not found on disk; subsequent steps will "
+        "rely on defaults unless the storage backend is available."
+    )
 
 
-#%% [markdown]
-# ## Model training
+# %% [markdown]
+# ## Ensure calibrated SUAVE model
 #
-# Instantiate SUAVE with the best Optuna configuration and fit/calibrate on the
-# appropriate subsets.
+# Load the trained SUAVE model and isotonic calibrator if they were saved by the
+# optimisation pipeline. When the artefacts are unavailable, retrain the model
+# using the best Optuna parameters and calibrate on the validation split.
 
 # %%
 
-hidden_key = str(optuna_best_params.get("hidden_dims", "medium"))
-head_hidden_key = str(optuna_best_params.get("head_hidden_dims", "medium"))
-hidden_dims = HIDDEN_DIMENSION_OPTIONS.get(hidden_key, HIDDEN_DIMENSION_OPTIONS["medium"])
-head_hidden_dims = HEAD_HIDDEN_DIMENSION_OPTIONS.get(
-    head_hidden_key, HEAD_HIDDEN_DIMENSION_OPTIONS["medium"]
-)
+model_path = OUTPUT_DIR / f"suave_best_{TARGET_LABEL}.pt"
+calibrator_path = OUTPUT_DIR / f"isotonic_calibrator_{TARGET_LABEL}.joblib"
 
-model = SUAVE(
-    schema=schema,
-    latent_dim=int(optuna_best_params.get("latent_dim", 16)),
-    n_components=int(optuna_best_params.get("n_components", 1)),
-    hidden_dims=hidden_dims,
-    head_hidden_dims=head_hidden_dims,
-    dropout=float(optuna_best_params.get("dropout", 0.1)),
-    learning_rate=float(optuna_best_params.get("learning_rate", 1e-3)),
-    batch_size=int(optuna_best_params.get("batch_size", 256)),
-    beta=float(optuna_best_params.get("beta", 1.5)),
-    classification_loss_weight=float(
-        optuna_best_params.get("classification_loss_weight", 1.0)
-    ),
-    random_state=RANDOM_STATE,
-    behaviour="supervised",
-)
+model: Optional[SUAVE] = None
+calibrator: Optional[Any] = None
 
-model.fit(
-    X_train_model,
-    y_train_model,
-    warmup_epochs=int(optuna_best_params.get("warmup_epochs", 3)),
-    kl_warmup_epochs=int(optuna_best_params.get("kl_warmup_epochs", 0)),
-    head_epochs=int(optuna_best_params.get("head_epochs", 2)),
-    finetune_epochs=int(optuna_best_params.get("finetune_epochs", 2)),
-    joint_decoder_lr_scale=float(optuna_best_params.get("joint_decoder_lr_scale", 0.1)),
-    early_stop_patience=int(optuna_best_params.get("early_stop_patience", 10)),
-)
-model.calibrate(X_validation, y_validation)
+if calibrator_path.exists():
+    calibrator = joblib.load(calibrator_path)
+    model = extract_calibrator_estimator(calibrator)
+    if model is not None:
+        print(
+            f"Loaded isotonic calibrator and embedded SUAVE model from {calibrator_path}."
+        )
+
+if model is None and model_path.exists():
+    model = SUAVE.load(model_path)
+    print(f"Loaded SUAVE model from {model_path}.")
+
+if model is None and optuna_best_params:
+    print(
+        "Training SUAVE with best Optuna parameters because no saved model was found…"
+    )
+    model = build_suave_model(optuna_best_params, schema, random_state=RANDOM_STATE)
+    model.fit(
+        X_train_model,
+        y_train_model,
+        warmup_epochs=int(optuna_best_params.get("warmup_epochs", 3)),
+        kl_warmup_epochs=int(optuna_best_params.get("kl_warmup_epochs", 0)),
+        head_epochs=int(optuna_best_params.get("head_epochs", 2)),
+        finetune_epochs=int(optuna_best_params.get("finetune_epochs", 2)),
+        joint_decoder_lr_scale=float(
+            optuna_best_params.get("joint_decoder_lr_scale", 0.1)
+        ),
+        early_stop_patience=int(optuna_best_params.get("early_stop_patience", 10)),
+    )
+else:
+    if model is None:
+        raise RuntimeError(
+            "Unable to load or reconstruct the SUAVE model. Ensure the optimisation "
+            "script has been executed to produce the necessary artefacts."
+        )
+
+if calibrator is None:
+    calibrator = fit_isotonic_calibrator(model, X_validation, y_validation)
+    print("Fitted a new isotonic calibrator on the validation split.")
+else:
+    embedded = extract_calibrator_estimator(calibrator)
+    if embedded is None:
+        print(
+            "Calibrator did not contain a usable SUAVE estimator; refitting calibrator."
+        )
+        calibrator = fit_isotonic_calibrator(model, X_validation, y_validation)
+    else:
+        model = embedded
 
 
-#%% [markdown]
+# %% [markdown]
 # ## Prognosis prediction and evaluation
 #
 # Evaluate the trained model on train/validation/test/eICU cohorts, generate
@@ -829,7 +513,10 @@ label_map: Dict[str, np.ndarray] = {}
 metrics_rows: List[Dict[str, object]] = []
 
 for dataset_name, (features, labels) in evaluation_datasets.items():
-    probs = model.predict_proba(features)
+    if calibrator is not None:
+        probs = calibrator.predict_proba(features)
+    else:
+        probs = model.predict_proba(features)
     probability_map[dataset_name] = probs
     label_map[dataset_name] = np.asarray(labels)
     metrics = compute_binary_metrics(probs, labels)
@@ -845,7 +532,9 @@ ordered_metric_columns = [
     "SEN",
     "Brier",
 ]
-existing_columns = [column for column in ordered_metric_columns if column in metrics_df.columns]
+existing_columns = [
+    column for column in ordered_metric_columns if column in metrics_df.columns
+]
 if existing_columns:
     metrics_df = metrics_df.loc[:, existing_columns]
 metrics_path = OUTPUT_DIR / "evaluation_metrics.csv"
@@ -879,77 +568,13 @@ render_dataframe(
 )
 
 
-#%% [markdown]
+# %% [markdown]
 # ## Benchmark ROC and calibration curves
 #
 # Visualise the discriminative and calibration performance of the classical
-# baselines alongside SUAVE across the train, test, and external cohorts. Each
-# figure contains ROC and calibration curves with Times New Roman styling and
-# abbreviated legend entries for clarity.
+# baselines alongside SUAVE across the train, test, and external cohorts.
 
 # %%
-
-plt.rcParams["font.family"] = "Times New Roman"
-
-
-def plot_benchmark_curves(
-    dataset_name: str,
-    y_true: np.ndarray,
-    model_probability_lookup: Mapping[str, np.ndarray],
-) -> Optional[Path]:
-    """Plot ROC and calibration curves for the supplied dataset."""
-
-    unique_labels = np.unique(y_true)
-    if unique_labels.size < 2:
-        print(f"Skipping {dataset_name} curves because only one class is present.")
-        return None
-
-    roc_ax: plt.Axes
-    cal_ax: plt.Axes
-    fig, (roc_ax, cal_ax) = plt.subplots(1, 2, figsize=(12, 5))
-
-    roc_ax.plot([0, 1], [0, 1], linestyle="--", color="gray", label="Chance")
-    roc_ax.set_title(f"ROC – {dataset_name}")
-    roc_ax.set_xlabel("False positive rate")
-    roc_ax.set_ylabel("True positive rate")
-
-    cal_ax.plot([0, 1], [0, 1], linestyle="--", color="gray", label="Perfect")
-    cal_ax.set_title(f"Calibration – {dataset_name}")
-    cal_ax.set_xlabel("Mean predicted probability")
-    cal_ax.set_ylabel("Fraction of positives")
-
-    for model_name, probs in model_probability_lookup.items():
-        abbrev = model_abbreviation_lookup.get(model_name, model_name)
-        fpr, tpr, _ = roc_curve(y_true, probs)
-        roc_ax.plot(fpr, tpr, label=abbrev)
-
-        try:
-            frac_pos, mean_pred = calibration_curve(
-                y_true, probs, n_bins=10, strategy="quantile"
-            )
-        except ValueError:
-            print(
-                f"Calibration curve for {model_name} on {dataset_name} skipped due to insufficient variation."
-            )
-        else:
-            cal_ax.plot(mean_pred, frac_pos, marker="o", label=abbrev)
-
-    roc_ax.legend(loc="lower right")
-    cal_ax.legend(loc="upper left")
-    fig.suptitle(f"Benchmark ROC & calibration – {dataset_name}")
-    fig.tight_layout()
-
-    dataset_slug = dataset_name.lower().replace(" ", "_")
-    figure_path = OUTPUT_DIR / f"benchmark_curves_{dataset_slug}_{TARGET_LABEL}.png"
-    fig.savefig(figure_path, dpi=300, bbox_inches="tight")
-
-    if is_interactive_session():
-        display(fig)
-
-    plt.close(fig)
-    print(f"Saved benchmark curves for {dataset_name} to {figure_path}")
-    return figure_path
-
 
 benchmark_datasets = ["Train", "MIMIC test", "eICU external"]
 benchmark_curve_paths: List[Path] = []
@@ -963,19 +588,28 @@ for dataset_name in benchmark_datasets:
     suave_probs = extract_positive_probabilities(probability_map[dataset_name])
     model_probabilities["SUAVE"] = suave_probs
 
-    for baseline_name, baseline_probs in baseline_probability_map.get(dataset_name, {}).items():
+    for baseline_name, baseline_probs in baseline_probability_map.get(
+        dataset_name, {}
+    ).items():
         model_probabilities[baseline_name] = baseline_probs
 
     if not model_probabilities:
         print(f"No model probabilities available for {dataset_name}.")
         continue
 
-    figure_path = plot_benchmark_curves(dataset_name, label_map[dataset_name], model_probabilities)
+    figure_path = plot_benchmark_curves(
+        dataset_name,
+        label_map[dataset_name],
+        model_probabilities,
+        output_dir=OUTPUT_DIR,
+        target_label=TARGET_LABEL,
+        abbreviation_lookup=model_abbreviation_lookup,
+    )
     if figure_path is not None:
         benchmark_curve_paths.append(figure_path)
 
 
-#%% [markdown]
+# %% [markdown]
 # ## Bootstrap benchmarking
 #
 # Derive confidence intervals for each cohort using the reusable classification
@@ -996,58 +630,22 @@ if model_classes_array is None or len(model_classes_array) == 0:
 class_value_list = list(model_classes_array)
 class_name_strings = [str(value) for value in class_value_list]
 positive_label_name = class_name_strings[-1] if len(class_name_strings) == 2 else None
-
-
-def build_prediction_dataframe(
-    probabilities: np.ndarray,
-    labels: pd.Series | np.ndarray,
-    predictions: np.ndarray,
-) -> pd.DataFrame:
-    """Assemble a dataframe compatible with :func:`evaluate_predictions`."""
-
-    prob_matrix = np.asarray(probabilities)
-    if prob_matrix.ndim == 1:
-        if len(class_name_strings) == 2:
-            negative_name, positive_name = class_name_strings[0], class_name_strings[-1]
-            proba_dict = {
-                f"pred_proba_{negative_name}": 1.0 - prob_matrix,
-                f"pred_proba_{positive_name}": prob_matrix,
-            }
-        else:
-            proba_dict = {"pred_proba_0": prob_matrix}
-    else:
-        if prob_matrix.shape[1] == len(class_name_strings) and len(class_name_strings) > 0:
-            proba_dict = {
-                f"pred_proba_{class_name_strings[idx]}": prob_matrix[:, idx]
-                for idx in range(prob_matrix.shape[1])
-            }
-        else:
-            proba_dict = {
-                f"pred_proba_{idx}": prob_matrix[:, idx]
-                for idx in range(prob_matrix.shape[1])
-            }
-
-    base_df = pd.DataFrame(
-        {
-            "label": np.asarray(labels),
-            "y_pred": np.asarray(predictions),
-        }
-    )
-    if proba_dict:
-        proba_df = pd.DataFrame(proba_dict)
-        base_df = pd.concat([base_df.reset_index(drop=True), proba_df], axis=1)
-    else:
-        base_df = base_df.reset_index(drop=True)
-    return base_df
-
-
 for dataset_name, (features, labels) in evaluation_datasets.items():
-    dataset_predictions = model.predict(features)
     dataset_probabilities = probability_map[dataset_name]
+    positive_probs = extract_positive_probabilities(dataset_probabilities)
+    if len(class_value_list) == 2:
+        negative_label = class_value_list[0]
+        positive_label = class_value_list[-1]
+        dataset_predictions = np.where(
+            positive_probs >= 0.5, positive_label, negative_label
+        )
+    else:
+        dataset_predictions = model.predict(features)
     prediction_df = build_prediction_dataframe(
         dataset_probabilities,
         labels,
         dataset_predictions,
+        class_name_strings,
     )
 
     results = evaluate_predictions(
@@ -1122,7 +720,6 @@ for metric_name in summary_metric_candidates:
         if high_col in bootstrap_overall_df.columns:
             summary_columns.append(high_col)
 
-
 bootstrap_summary_df = bootstrap_overall_df.loc[:, summary_columns]
 bootstrap_summary_path = OUTPUT_DIR / f"bootstrap_summary_{TARGET_LABEL}.csv"
 bootstrap_summary_df.to_csv(bootstrap_summary_path, index=False)
@@ -1133,7 +730,7 @@ render_dataframe(
 )
 
 
-#%% [markdown]
+# %% [markdown]
 # ## TSTR/TRTR comparison
 #
 # Compare models trained on synthetic versus real data. The analysis is only
@@ -1142,8 +739,11 @@ render_dataframe(
 
 # %%
 
-tstr_results: Optional[pd.DataFrame] = None
-tstr_path: Optional[Path] = None
+tstr_summary_df: Optional[pd.DataFrame] = None
+tstr_plot_df: Optional[pd.DataFrame] = None
+tstr_summary_path: Optional[Path] = None
+tstr_plot_path: Optional[Path] = None
+tstr_figure_paths: List[Path] = []
 distribution_df: Optional[pd.DataFrame] = None
 distribution_path: Optional[Path] = None
 distribution_top: Optional[pd.DataFrame] = None
@@ -1155,47 +755,73 @@ if TARGET_LABEL != "in_hospital_mortality":
     )
 else:
     print("Generating synthetic data for TSTR/TRTR comparisons…")
-    numeric_train = to_numeric_frame(X_full)
-
-    rng = np.random.default_rng(RANDOM_STATE)
-    synthetic_labels = rng.choice(y_full, size=len(y_full), replace=True)
-
-    synthetic_features = model.sample(
-        len(synthetic_labels), conditional=True, y=synthetic_labels
+    training_sets = build_tstr_training_sets(
+        model,
+        FEATURE_COLUMNS,
+        X_full,
+        y_full,
+        random_state=RANDOM_STATE,
     )
-    numeric_synthetic = to_numeric_frame(synthetic_features[FEATURE_COLUMNS])
+    evaluation_sets_numeric: Dict[str, Tuple[pd.DataFrame, pd.Series]] = {
+        "MIMIC test": (to_numeric_frame(X_test), y_test.reset_index(drop=True)),
+    }
+    if external_features is not None and external_labels is not None:
+        evaluation_sets_numeric["eICU external"] = (
+            to_numeric_frame(external_features),
+            external_labels.reset_index(drop=True),
+        )
 
-    numeric_test = to_numeric_frame(X_test)
+    model_factories = make_baseline_model_factories(RANDOM_STATE)
+    (
+        tstr_summary_df,
+        tstr_plot_df,
+        _,
+    ) = evaluate_transfer_baselines(
+        training_sets,
+        evaluation_sets_numeric,
+        model_factories=model_factories,
+        bootstrap_n=1000,
+        random_state=RANDOM_STATE,
+    )
+    tstr_summary_path = OUTPUT_DIR / f"tstr_trtr_summary_{TARGET_LABEL}.csv"
+    tstr_plot_path = OUTPUT_DIR / f"tstr_trtr_plot_data_{TARGET_LABEL}.csv"
+    tstr_summary_df.to_csv(tstr_summary_path, index=False)
+    tstr_plot_df.to_csv(tstr_plot_path, index=False)
+    render_dataframe(
+        tstr_summary_df,
+        title="TSTR/TRTR supervised evaluation",
+        floatfmt=".3f",
+    )
 
-    tstr_metrics = evaluate_tstr(
-        (numeric_synthetic.to_numpy(), np.asarray(synthetic_labels)),
-        (numeric_test.to_numpy(), y_test.to_numpy()),
-        make_logistic_pipeline,
-    )
-    trtr_metrics = evaluate_trtr(
-        (numeric_train.to_numpy(), y_full.to_numpy()),
-        (numeric_test.to_numpy(), y_test.to_numpy()),
-        make_logistic_pipeline,
-    )
-    tstr_results = pd.DataFrame(
-        [
-            {"setting": "TSTR", **tstr_metrics},
-            {"setting": "TRTR", **trtr_metrics},
-        ]
-    )
-    tstr_path = OUTPUT_DIR / "tstr_trtr_comparison.csv"
-    tstr_results.to_csv(tstr_path, index=False)
-    render_dataframe(tstr_results, title="TSTR vs TRTR", floatfmt=".3f")
+    training_order = list(training_sets.keys())
+    model_order = list(model_factories.keys())
+    for evaluation_name in evaluation_sets_numeric.keys():
+        for metric_name in ("accuracy", "roc_auc"):
+            figure_path = plot_transfer_metric_bars(
+                tstr_plot_df,
+                metric=metric_name,
+                evaluation_dataset=evaluation_name,
+                training_order=training_order,
+                model_order=model_order,
+                output_dir=OUTPUT_DIR,
+                target_label=TARGET_LABEL,
+            )
+            if figure_path is not None:
+                tstr_figure_paths.append(figure_path)
 
+    real_features_numeric = training_sets["TRTR (real)"][0]
+    synthesis_features_numeric = training_sets["TSTR synthesis"][0]
     distribution_rows: List[Dict[str, object]] = []
     for column in FEATURE_COLUMNS:
-        real_values = numeric_train[column].to_numpy()
-        synthetic_values = numeric_synthetic[column].to_numpy()
+        real_values = real_features_numeric[column].to_numpy()
+        synthetic_values = synthesis_features_numeric[column].to_numpy()
         distribution_rows.append(
             {
                 "feature": column,
                 "ks": kolmogorov_smirnov_statistic(real_values, synthetic_values),
-                "mmd": rbf_mmd(real_values, synthetic_values, random_state=RANDOM_STATE),
+                "mmd": rbf_mmd(
+                    real_values, synthetic_values, random_state=RANDOM_STATE
+                ),
                 "mutual_information": mutual_information_feature(
                     real_values, synthetic_values
                 ),
@@ -1205,7 +831,9 @@ else:
     distribution_path = OUTPUT_DIR / "distribution_shift_metrics.csv"
     distribution_df.to_csv(distribution_path, index=False)
     distribution_top = (
-        distribution_df.sort_values("ks", ascending=False).head(10).reset_index(drop=True)
+        distribution_df.sort_values("ks", ascending=False)
+        .head(10)
+        .reset_index(drop=True)
     )
     render_dataframe(
         distribution_top,
@@ -1214,7 +842,7 @@ else:
     )
 
 
-#%% [markdown]
+# %% [markdown]
 # ## Latent space interpretation
 #
 # Project latent representations using PCA for qualitative assessment of class
@@ -1222,7 +850,9 @@ else:
 
 # %%
 
-latent_features = {name: features for name, (features, _) in evaluation_datasets.items()}
+latent_features = {
+    name: features for name, (features, _) in evaluation_datasets.items()
+}
 latent_labels = {name: labels for name, (_, labels) in evaluation_datasets.items()}
 latent_path = OUTPUT_DIR / f"latent_{TARGET_LABEL}.png"
 plot_latent_space(
@@ -1234,7 +864,7 @@ plot_latent_space(
 )
 
 
-#%% [markdown]
+# %% [markdown]
 # ## Reporting
 #
 # Collate metrics, Optuna summary, and artifact locations into a Markdown
@@ -1252,11 +882,30 @@ summary_lines: List[str] = [
     f"### {TARGET_LABEL}",
 ]
 
-best_value = optuna_best_info.get("value")
-value_text = f"{best_value:.4f}" if isinstance(best_value, (int, float)) else "n/a"
-summary_lines.append(
-    f"Best Optuna trial #{optuna_best_info.get('trial_number')} with validation ROAUC {value_text}"
-)
+best_values = optuna_best_info.get("values") if optuna_best_info else None
+if isinstance(best_values, (list, tuple)) and best_values:
+    best_roauc = best_values[0]
+    roauc_text = f"{best_roauc:.4f}" if np.isfinite(best_roauc) else "n/a"
+    delta_text: Optional[str]
+    if len(best_values) > 1 and np.isfinite(best_values[1]):
+        delta_text = f" (ΔAUC {best_values[1]:.4f})"
+    else:
+        delta_text = None
+else:
+    roauc_text = "n/a"
+    delta_text = None
+
+if optuna_best_info:
+    summary_line = (
+        f"Best Optuna trial #{optuna_best_info.get('trial_number')} "
+        f"with validation ROAUC {roauc_text}"
+    )
+    if delta_text:
+        summary_line += delta_text
+    summary_lines.append(summary_line)
+else:
+    summary_lines.append("Best Optuna trial: information unavailable.")
+
 summary_lines.append("Best parameters:")
 summary_lines.append("```json")
 summary_lines.append(json.dumps(optuna_best_params, indent=2, ensure_ascii=False))
@@ -1283,12 +932,8 @@ summary_lines.append(dataframe_to_markdown(metrics_summary_df, floatfmt=".3f"))
 summary_lines.append(
     f"Optuna trials logged at: {optuna_trials_path.relative_to(OUTPUT_DIR)}"
 )
-summary_lines.append(
-    f"Calibration plot: {calibration_path.relative_to(OUTPUT_DIR)}"
-)
-summary_lines.append(
-    f"Latent projection: {latent_path.relative_to(OUTPUT_DIR)}"
-)
+summary_lines.append(f"Calibration plot: {calibration_path.relative_to(OUTPUT_DIR)}")
+summary_lines.append(f"Latent projection: {latent_path.relative_to(OUTPUT_DIR)}")
 summary_lines.append("")
 
 summary_lines.append("Bootstrap evaluation artefacts:")
@@ -1310,93 +955,34 @@ if bootstrap_warning_path is not None:
     )
 summary_lines.append("")
 
-if tstr_results is not None and tstr_path is not None:
-    summary_lines.append("## TSTR vs TRTR")
-    tstr_summary_df = tstr_results.rename(columns={"setting": "Setting"})
+if tstr_summary_df is not None and tstr_summary_path is not None:
+    summary_lines.append("## TSTR/TRTR supervised baselines")
     summary_lines.append(dataframe_to_markdown(tstr_summary_df, floatfmt=".3f"))
+    summary_lines.append("")
+    summary_lines.append("Artefacts:")
+    summary_lines.append(
+        f"- Summary table: {tstr_summary_path.relative_to(OUTPUT_DIR)}"
+    )
+    if tstr_plot_path is not None:
+        summary_lines.append(f"- Plot data: {tstr_plot_path.relative_to(OUTPUT_DIR)}")
+    for figure_path in tstr_figure_paths:
+        summary_lines.append(f"- Figure: {figure_path.relative_to(OUTPUT_DIR)}")
     summary_lines.append("")
 
 summary_lines.append("## Distribution shift and privacy")
 if distribution_df is not None and distribution_path is not None:
-    base_distribution_df = (
-        distribution_top if distribution_top is not None else distribution_df
-    )
-    distribution_summary_df = base_distribution_df.rename(
-        columns={
-            "feature": "Feature",
-            "ks": "KS",
-            "mmd": "MMD",
-            "mutual_information": "Mutual information",
-        }
-    )
-    distribution_columns = [
-        "Feature",
-        "KS",
-        "MMD",
-        "Mutual information",
-    ]
-    existing_distribution_columns = [
-        column for column in distribution_columns if column in distribution_summary_df.columns
-    ]
-    if existing_distribution_columns:
-        distribution_summary_df = distribution_summary_df.loc[:, existing_distribution_columns]
-    distribution_summary_df = distribution_summary_df.reset_index(drop=True)
-    summary_lines.append("Top 10 features by KS statistic:")
-    summary_lines.append(dataframe_to_markdown(distribution_summary_df, floatfmt=".3f"))
     summary_lines.append(
-        f"Full distribution metrics: {distribution_path.relative_to(OUTPUT_DIR)}"
+        f"- Distribution metrics: {distribution_path.relative_to(OUTPUT_DIR)}"
     )
-else:
-    summary_lines.append("Distribution metrics were not computed.")
-
-if membership_df.empty:
-    summary_lines.append("No membership inference metrics were recorded.")
-else:
-    membership_summary_df = membership_df.rename(
-        columns={
-            "target": "Target",
-            "attack_auc": "Attack AUC",
-            "attack_best_accuracy": "Best accuracy",
-            "attack_best_threshold": "Threshold",
-            "attack_majority_class_accuracy": "Majority baseline",
-        }
-    )
-    membership_columns = [
-        "Target",
-        "Attack AUC",
-        "Best accuracy",
-        "Threshold",
-        "Majority baseline",
-    ]
-    existing_membership_columns = [
-        column for column in membership_columns if column in membership_summary_df.columns
-    ]
-    if existing_membership_columns:
-        membership_summary_df = membership_summary_df.loc[
-            :, existing_membership_columns
-        ]
-    membership_summary_df = membership_summary_df.reset_index(drop=True)
-    summary_lines.append("Membership inference results:")
-    summary_lines.append(dataframe_to_markdown(membership_summary_df, floatfmt=".3f"))
+if membership_path.exists():
     summary_lines.append(
-        f"Membership metrics saved to: {membership_path.relative_to(OUTPUT_DIR)}"
+        f"- Membership inference: {membership_path.relative_to(OUTPUT_DIR)}"
     )
+summary_lines.append(f"- Baseline metrics: {baseline_path.relative_to(OUTPUT_DIR)}")
+for figure_path in benchmark_curve_paths:
+    summary_lines.append(f"- Benchmark curves: {figure_path.relative_to(OUTPUT_DIR)}")
+summary_lines.append("")
 
-summary_path = OUTPUT_DIR / "summary.md"
-summary_path.write_text("\n".join(summary_lines), encoding="utf-8")
-
-print("Analysis complete.")
-print(f"Metric table saved to {metrics_path}")
-print(f"Calibration plot saved to {calibration_path}")
-print(f"Latent space plot saved to {latent_path}")
-print(f"Membership inference results saved to {membership_path}")
-if tstr_results is not None and tstr_path is not None and distribution_path is not None:
-    print(f"TSTR/TRTR comparison saved to {tstr_path}")
-    print(f"Distribution metrics saved to {distribution_path}")
+summary_path = OUTPUT_DIR / f"evaluation_summary_{TARGET_LABEL}.md"
+summary_path.write_text("\n".join(summary_lines))
 print(f"Summary written to {summary_path}")
-
-
-# %%
-
-
-

--- a/examples/mimic_mortality_utils.py
+++ b/examples/mimic_mortality_utils.py
@@ -2,24 +2,81 @@
 
 from __future__ import annotations
 
+from __future__ import annotations
+
 import sys
 from pathlib import Path
-from typing import Iterable, MutableMapping, Optional, Tuple
+from typing import (
+    Callable,
+    Dict,
+    Iterable,
+    List,
+    Mapping,
+    MutableMapping,
+    Optional,
+    Sequence,
+    Tuple,
+)
 
 import numpy as np
 import pandas as pd
+from IPython.display import display
+from matplotlib import pyplot as plt
+from tabulate import tabulate
+
+from sklearn.calibration import CalibratedClassifierCV, calibration_curve
+from sklearn.decomposition import PCA
+from sklearn.metrics import (
+    accuracy_score,
+    brier_score_loss,
+    confusion_matrix,
+    roc_auc_score,
+    roc_curve,
+)
+from sklearn.pipeline import Pipeline
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
-from suave import Schema, SchemaInferencer  # noqa: E402
+EXAMPLES_DIR = Path(__file__).resolve().parent
+if str(EXAMPLES_DIR) not in sys.path:
+    sys.path.insert(0, str(EXAMPLES_DIR))
+
+from suave import Schema, SchemaInferencer, SUAVE  # noqa: E402
+from suave.evaluate import (  # noqa: E402
+    kolmogorov_smirnov_statistic,
+    mutual_information_feature,
+    rbf_mmd,
+)
+from cls_eval import evaluate_predictions  # noqa: E402
+
 
 RANDOM_STATE: int = 20201021
 TARGET_COLUMNS: Tuple[str, str] = ("in_hospital_mortality", "28d_mortality")
 
 CALIBRATION_SIZE: float = 0.2
 VALIDATION_SIZE: float = 0.2
+
+HIDDEN_DIMENSION_OPTIONS: Dict[str, Tuple[int, ...]] = {
+    "lean": (64, 32),
+    "compact": (96, 48),
+    "small": (128, 64),
+    "medium": (256, 128),
+    "wide": (384, 192),
+    "extra_wide": (512, 256),
+    "ultra_wide": (640, 320),
+}
+
+HEAD_HIDDEN_DIMENSION_OPTIONS: Dict[str, Tuple[int, ...]] = {
+    "minimal": (16,),
+    "compact": (32,),
+    "small": (48,),
+    "medium": (48, 32),
+    "wide": (96, 48, 16),
+    "extra_wide": (64, 128, 64, 16),
+    "deep": (128, 64, 32),
+}
 
 __all__ = [
     "RANDOM_STATE",
@@ -28,24 +85,273 @@ __all__ = [
     "VALIDATION_SIZE",
     "Schema",
     "SchemaInferencer",
-    "load_dataset",
-    "define_schema",
-    "prepare_features",
-    "split_train_validation_calibration",
-    "schema_markdown_table",
-    "format_float",
+    "HIDDEN_DIMENSION_OPTIONS",
+    "HEAD_HIDDEN_DIMENSION_OPTIONS",
+    "build_prediction_dataframe",
     "compute_auc",
-    "to_numeric_frame",
+    "compute_binary_metrics",
+    "dataframe_to_markdown",
+    "define_schema",
+    "extract_positive_probabilities",
+    "fit_isotonic_calibrator",
+    "format_float",
+    "is_interactive_session",
     "kolmogorov_smirnov_statistic",
-    "rbf_mmd",
+    "load_dataset",
+    "load_or_create_iteratively_imputed_features",
+    "make_logistic_pipeline",
+    "make_random_forest_pipeline",
+    "make_xgboost_pipeline",
+    "make_baseline_model_factories",
     "mutual_information_feature",
+    "plot_benchmark_curves",
+    "plot_calibration_curves",
+    "plot_latent_space",
+    "plot_transfer_metric_bars",
+    "prepare_features",
+    "render_dataframe",
+    "rbf_mmd",
+    "schema_markdown_table",
+    "schema_to_dataframe",
+    "slugify_identifier",
+    "split_train_validation_calibration",
+    "to_numeric_frame",
+    "build_tstr_training_sets",
+    "evaluate_transfer_baselines",
+    "build_suave_model",
+    "resolve_classification_loss_weight",
 ]
+
+
+def is_interactive_session() -> bool:
+    """Return ``True`` when executed inside an interactive IPython session."""
+
+    try:
+        from IPython import get_ipython
+    except ImportError:  # pragma: no cover - optional dependency
+        return False
+    return get_ipython() is not None
+
+
+def render_dataframe(
+    df: pd.DataFrame,
+    *,
+    title: Optional[str] = None,
+    floatfmt: Optional[str] = ".3f",
+) -> None:
+    """Render a dataframe either via ``display`` or ``tabulate``."""
+
+    if title:
+        print(title)
+    if df.empty:
+        print("(empty table)")
+        return
+    if is_interactive_session():
+        display(df)
+        return
+    tabulate_kwargs = {"headers": "keys", "tablefmt": "github", "showindex": False}
+    if floatfmt is not None:
+        tabulate_kwargs["floatfmt"] = floatfmt
+    print(tabulate(df, **tabulate_kwargs))
+
+
+def dataframe_to_markdown(df: pd.DataFrame, *, floatfmt: Optional[str] = ".3f") -> str:
+    """Return a GitHub-flavoured Markdown representation of ``df``."""
+
+    if df.empty:
+        return "_No data available._"
+    tabulate_kwargs = {"headers": "keys", "tablefmt": "github", "showindex": False}
+    if floatfmt is not None:
+        tabulate_kwargs["floatfmt"] = floatfmt
+    return tabulate(df, **tabulate_kwargs)
+
+
+def schema_to_dataframe(schema: Schema) -> pd.DataFrame:
+    """Convert a :class:`Schema` into a tidy dataframe."""
+
+    records: List[Dict[str, object]] = []
+    for column, spec in schema.to_dict().items():
+        records.append(
+            {
+                "Column": column,
+                "Type": spec.get("type", ""),
+                "n_classes": spec.get("n_classes", ""),
+                "y_dim": spec.get("y_dim", ""),
+            }
+        )
+    return pd.DataFrame(records)
+
+
+def slugify_identifier(value: str) -> str:
+    """Return a filesystem-friendly identifier derived from ``value``."""
+
+    cleaned = [char.lower() if char.isalnum() else "_" for char in value.strip()]
+    slug = "".join(cleaned)
+    while "__" in slug:
+        slug = slug.replace("__", "_")
+    return slug.strip("_")
+
+
+def load_or_create_iteratively_imputed_features(
+    feature_sets: Mapping[str, pd.DataFrame],
+    *,
+    output_dir: Path,
+    target_label: str,
+    reference_key: str,
+) -> Tuple[Dict[str, pd.DataFrame], Dict[str, Path], bool]:
+    """Load cached iterative imputations or fit a new imputer."""
+
+    if reference_key not in feature_sets:
+        raise KeyError(
+            f"Reference key '{reference_key}' missing from feature sets: {list(feature_sets)}"
+        )
+
+    dataset_paths: Dict[str, Path] = {
+        name: output_dir
+        / f"iterative_imputed_{slugify_identifier(name)}_{slugify_identifier(target_label)}.csv"
+        for name in feature_sets
+    }
+
+    loaded_features: Dict[str, pd.DataFrame] = {}
+    load_successful = True
+    for name, path in dataset_paths.items():
+        features = feature_sets[name]
+        if not path.exists():
+            load_successful = False
+            break
+        cached = pd.read_csv(path, index_col=0)
+        column_match = list(cached.columns) == list(features.columns)
+        length_match = len(cached) == len(features)
+        if not (column_match and length_match):
+            load_successful = False
+            break
+        try:
+            cached = cached.loc[features.index]
+        except KeyError:
+            load_successful = False
+            break
+        loaded_features[name] = cached
+
+    if load_successful:
+        return loaded_features, dataset_paths, True
+
+    from sklearn.experimental import enable_iterative_imputer  # noqa: F401
+    from sklearn.impute import IterativeImputer
+
+    imputer = IterativeImputer()
+    imputer.fit(feature_sets[reference_key])
+
+    imputed_features: Dict[str, pd.DataFrame] = {}
+    for name, features in feature_sets.items():
+        transformed = imputer.transform(features)
+        imputed_df = pd.DataFrame(
+            transformed,
+            columns=features.columns,
+            index=features.index,
+        )
+        path = dataset_paths[name]
+        path.parent.mkdir(parents=True, exist_ok=True)
+        imputed_df.to_csv(path)
+        imputed_features[name] = imputed_df
+
+    return imputed_features, dataset_paths, False
+
+
+def make_logistic_pipeline(random_state: Optional[int] = None) -> Pipeline:
+    """Factory for the baseline classifier used in TSTR/TRTR evaluations."""
+
+    from sklearn.experimental import enable_iterative_imputer  # noqa: F401
+    from sklearn.impute import IterativeImputer
+    from sklearn.linear_model import LogisticRegression
+    from sklearn.preprocessing import StandardScaler
+
+    return Pipeline(
+        [
+            ("imputer", IterativeImputer()),
+            ("scaler", StandardScaler()),
+            (
+                "classifier",
+                LogisticRegression(max_iter=200, random_state=random_state),
+            ),
+        ]
+    )
 
 
 def load_dataset(path: Path) -> pd.DataFrame:
     """Load a TSV file into a :class:`pandas.DataFrame`."""
 
     return pd.read_csv(path, sep="\t")
+
+
+def make_random_forest_pipeline(random_state: Optional[int] = None) -> Pipeline:
+    """Return a random forest pipeline with iterative imputation."""
+
+    from sklearn.ensemble import RandomForestClassifier
+    from sklearn.experimental import enable_iterative_imputer  # noqa: F401
+    from sklearn.impute import IterativeImputer
+
+    return Pipeline(
+        [
+            ("imputer", IterativeImputer()),
+            (
+                "classifier",
+                RandomForestClassifier(
+                    n_estimators=400,
+                    max_depth=None,
+                    random_state=random_state,
+                    n_jobs=-1,
+                ),
+            ),
+        ]
+    )
+
+
+def make_xgboost_pipeline(random_state: Optional[int] = None) -> Pipeline:
+    """Return an XGBoost pipeline with iterative imputation."""
+
+    from sklearn.experimental import enable_iterative_imputer  # noqa: F401
+    from sklearn.impute import IterativeImputer
+
+    try:
+        from xgboost import XGBClassifier
+    except ImportError as error:  # pragma: no cover - optional dependency
+        raise ImportError(
+            "xgboost is required for the mortality TSTR evaluation."
+        ) from error
+
+    return Pipeline(
+        [
+            ("imputer", IterativeImputer()),
+            (
+                "classifier",
+                XGBClassifier(
+                    n_estimators=400,
+                    learning_rate=0.05,
+                    max_depth=4,
+                    subsample=0.8,
+                    colsample_bytree=0.8,
+                    objective="binary:logistic",
+                    eval_metric="auc",
+                    reg_lambda=1.0,
+                    random_state=random_state,
+                    tree_method="hist",
+                    n_jobs=-1,
+                ),
+            ),
+        ]
+    )
+
+
+def make_baseline_model_factories(
+    random_state: int,
+) -> Dict[str, Callable[[], Pipeline]]:
+    """Return model factories for the supervised transfer comparison."""
+
+    return {
+        "Logistic regression": lambda: make_logistic_pipeline(random_state),
+        "Random forest": lambda: make_random_forest_pipeline(random_state),
+        "XGBoost": lambda: make_xgboost_pipeline(random_state),
+    }
 
 
 def define_schema(
@@ -139,8 +445,6 @@ def format_float(value: Optional[float]) -> str:
 def compute_auc(probabilities: np.ndarray, targets: pd.Series | np.ndarray) -> float:
     """Return the ROC AUC given predicted probabilities and targets."""
 
-    from sklearn.metrics import roc_auc_score
-
     prob_matrix = np.asarray(probabilities)
     if prob_matrix.ndim == 1:
         positive_probs = prob_matrix
@@ -164,100 +468,661 @@ def to_numeric_frame(df: pd.DataFrame) -> pd.DataFrame:
     return numeric
 
 
-def kolmogorov_smirnov_statistic(real: np.ndarray, synthetic: np.ndarray) -> float:
-    """Compute the Kolmogorov-Smirnov statistic between two samples."""
+def _ensure_feature_frame(
+    samples: pd.DataFrame | np.ndarray,
+    feature_columns: Sequence[str],
+) -> pd.DataFrame:
+    """Return ``samples`` restricted to ``feature_columns`` as a dataframe."""
 
-    real = np.asarray(real, dtype=float)
-    synthetic = np.asarray(synthetic, dtype=float)
-    real = real[np.isfinite(real)]
-    synthetic = synthetic[np.isfinite(synthetic)]
-    if real.size == 0 or synthetic.size == 0:
-        return float("nan")
-
-    real_sorted = np.sort(real)
-    synthetic_sorted = np.sort(synthetic)
-    combined = np.concatenate([real_sorted, synthetic_sorted])
-    cdf_real = np.searchsorted(real_sorted, combined, side="right") / real_sorted.size
-    cdf_synth = (
-        np.searchsorted(synthetic_sorted, combined, side="right")
-        / synthetic_sorted.size
-    )
-    return float(np.max(np.abs(cdf_real - cdf_synth)))
+    if isinstance(samples, pd.DataFrame):
+        missing = [
+            column for column in feature_columns if column not in samples.columns
+        ]
+        if missing:
+            raise KeyError(
+                "Sampled dataframe is missing expected feature columns: " f"{missing}"
+            )
+        frame = samples.loc[:, list(feature_columns)].copy()
+    else:
+        frame = pd.DataFrame(samples, columns=list(feature_columns))
+    return frame
 
 
-def rbf_mmd(
-    real: np.ndarray,
-    synthetic: np.ndarray,
+def _generate_balanced_labels(
+    labels: Sequence[object],
+    total_samples: int,
     *,
     random_state: int,
-    max_samples: int = 5000,
-) -> float:
-    """Compute the RBF maximum mean discrepancy between ``real`` and ``synthetic``."""
+) -> np.ndarray:
+    """Generate a balanced label vector using ``labels`` as candidates."""
 
-    real = np.asarray(real, dtype=float)
-    synthetic = np.asarray(synthetic, dtype=float)
-    real = real[np.isfinite(real)]
-    synthetic = synthetic[np.isfinite(synthetic)]
-    if real.size == 0 or synthetic.size == 0:
-        return float("nan")
+    unique = np.unique(np.asarray(labels))
+    if unique.size == 0:
+        raise ValueError("Cannot balance labels when no classes are present")
+
+    base = total_samples // unique.size
+    remainder = total_samples % unique.size
+    counts = {value: base for value in unique}
 
     rng = np.random.default_rng(random_state)
-    if real.size > max_samples:
-        real = rng.choice(real, size=max_samples, replace=False)
-    if synthetic.size > max_samples:
-        synthetic = rng.choice(synthetic, size=max_samples, replace=False)
+    if remainder > 0:
+        extras = rng.choice(unique, size=remainder, replace=False)
+        for value in extras:
+            counts[value] += 1
 
-    real = real[:, None]
-    synthetic = synthetic[:, None]
-    data = np.concatenate([real, synthetic], axis=0)
-    squared_distances = (data - data.T) ** 2
-    median_sq = float(np.median(squared_distances))
-    bandwidth = np.sqrt(0.5 * median_sq) if median_sq > 1e-12 else 1.0
-
-    def kernel(a: np.ndarray, b: np.ndarray) -> np.ndarray:
-        distances = (a - b.T) ** 2
-        return np.exp(-distances / (2.0 * bandwidth**2))
-
-    k_xx = kernel(real, real)
-    k_yy = kernel(synthetic, synthetic)
-    k_xy = kernel(real, synthetic)
-    mmd = k_xx.mean() + k_yy.mean() - 2.0 * k_xy.mean()
-    return float(max(mmd, 0.0))
+    balanced = np.concatenate([np.full(counts[value], value) for value in unique])
+    shuffle_rng = np.random.default_rng(random_state + 1)
+    shuffle_rng.shuffle(balanced)
+    return balanced
 
 
-def mutual_information_feature(
-    real: np.ndarray, synthetic: np.ndarray, n_bins: int = 10
-) -> float:
-    """Estimate mutual information between dataset indicator and feature bins."""
+def build_tstr_training_sets(
+    model: SUAVE,
+    feature_columns: Sequence[str],
+    real_features: pd.DataFrame,
+    real_labels: pd.Series,
+    *,
+    random_state: int,
+) -> Dict[str, Tuple[pd.DataFrame, pd.Series]]:
+    """Construct real and synthetic training sets for TSTR/TRTR evaluation."""
 
-    from sklearn.metrics import mutual_info_score
+    feature_columns = list(feature_columns)
+    real_feature_frame = to_numeric_frame(real_features.loc[:, feature_columns])
+    real_label_series = pd.Series(real_labels).reset_index(drop=True)
+    real_label_series.name = real_labels.name
 
-    real = np.asarray(real, dtype=float)
-    synthetic = np.asarray(synthetic, dtype=float)
-    real = real[np.isfinite(real)]
-    synthetic = synthetic[np.isfinite(synthetic)]
-    if real.size == 0 or synthetic.size == 0:
-        return float("nan")
+    datasets: Dict[str, Tuple[pd.DataFrame, pd.Series]] = {
+        "TRTR (real)": (
+            real_feature_frame.reset_index(drop=True),
+            real_label_series.copy(),
+        )
+    }
 
-    combined = np.concatenate([real, synthetic])
-    quantiles = np.quantile(combined, np.linspace(0.0, 1.0, n_bins + 1))
-    bin_edges = np.unique(quantiles)
-    if bin_edges.size <= 1:
-        return 0.0
-    interior = bin_edges[1:-1]
-    real_binned = np.digitize(real, interior, right=False)
-    synthetic_binned = np.digitize(synthetic, interior, right=False)
+    n_train = len(real_label_series)
+    label_array = real_label_series.to_numpy()
 
-    if np.unique(real_binned).size <= 1 and np.unique(synthetic_binned).size <= 1:
-        return 0.0
+    def sample_features(
+        n_samples: int,
+        *,
+        conditional: bool,
+        labels: Optional[np.ndarray] = None,
+    ) -> pd.DataFrame:
+        sampled = model.sample(
+            n_samples,
+            conditional=conditional,
+            y=labels if conditional else None,
+        )
+        frame = _ensure_feature_frame(sampled, feature_columns)
+        return to_numeric_frame(frame).reset_index(drop=True)
 
-    dataset_indicator = np.concatenate(
-        [
-            np.zeros(real_binned.size, dtype=int),
-            np.ones(synthetic_binned.size, dtype=int),
-        ]
+    # Conditional sampling that mirrors the empirical class distribution.
+    unconditional_labels = np.random.default_rng(random_state).choice(
+        label_array,
+        size=n_train,
+        replace=True,
     )
-    feature_bins = np.concatenate([real_binned, synthetic_binned])
-    if np.unique(feature_bins).size <= 1:
-        return 0.0
-    return float(mutual_info_score(dataset_indicator, feature_bins))
+    datasets["TSTR synthesis"] = (
+        sample_features(
+            n_train,
+            conditional=True,
+            labels=np.asarray(unconditional_labels),
+        ),
+        pd.Series(unconditional_labels, name=real_label_series.name),
+    )
+
+    balanced_labels = _generate_balanced_labels(
+        label_array,
+        n_train,
+        random_state=random_state + 10,
+    )
+    datasets["TSTR synthesis-balance"] = (
+        sample_features(
+            len(balanced_labels),
+            conditional=True,
+            labels=np.asarray(balanced_labels),
+        ),
+        pd.Series(balanced_labels, name=real_label_series.name),
+    )
+
+    label_counts = real_label_series.value_counts().sort_index()
+    target_count = int(label_counts.max()) if not label_counts.empty else 0
+    augmented_features = [real_feature_frame.reset_index(drop=True)]
+    augmented_labels = [real_label_series.copy()]
+    for value, count in label_counts.items():
+        deficit = target_count - int(count)
+        if deficit <= 0:
+            continue
+        class_labels = np.full(deficit, value)
+        synthetic_block = sample_features(
+            deficit,
+            conditional=True,
+            labels=class_labels,
+        )
+        augmented_features.append(synthetic_block)
+        augmented_labels.append(pd.Series(class_labels, name=real_label_series.name))
+
+    datasets["TSTR synthesis-augment"] = (
+        to_numeric_frame(pd.concat(augmented_features, ignore_index=True)),
+        pd.concat(augmented_labels, ignore_index=True).reset_index(drop=True),
+    )
+
+    five_x = n_train * 5
+    five_x_labels = np.random.default_rng(random_state + 20).choice(
+        label_array,
+        size=five_x,
+        replace=True,
+    )
+    datasets["TSTR synthesis-5x"] = (
+        sample_features(
+            five_x,
+            conditional=True,
+            labels=np.asarray(five_x_labels),
+        ),
+        pd.Series(five_x_labels, name=real_label_series.name),
+    )
+
+    five_x_balanced = _generate_balanced_labels(
+        label_array,
+        five_x,
+        random_state=random_state + 30,
+    )
+    datasets["TSTR synthesis-5x balance"] = (
+        sample_features(
+            len(five_x_balanced),
+            conditional=True,
+            labels=np.asarray(five_x_balanced),
+        ),
+        pd.Series(five_x_balanced, name=real_label_series.name),
+    )
+
+    return datasets
+
+
+def evaluate_transfer_baselines(
+    training_sets: Mapping[str, Tuple[pd.DataFrame, pd.Series]],
+    evaluation_sets: Mapping[str, Tuple[pd.DataFrame, pd.Series]],
+    *,
+    model_factories: Mapping[str, Callable[[], Pipeline]],
+    bootstrap_n: int,
+    random_state: int,
+) -> Tuple[
+    pd.DataFrame, pd.DataFrame, Dict[str, Dict[str, Dict[str, Dict[str, pd.DataFrame]]]]
+]:
+    """Train classical models on each training set and evaluate with bootstraps."""
+
+    summary_rows: List[Dict[str, object]] = []
+    long_rows: List[Dict[str, object]] = []
+    nested_results: Dict[str, Dict[str, Dict[str, Dict[str, pd.DataFrame]]]] = {}
+
+    for training_name, (train_X, train_y) in training_sets.items():
+        nested_results.setdefault(training_name, {})
+        train_columns = list(train_X.columns)
+        for model_name, factory in model_factories.items():
+            estimator = factory()
+            estimator.fit(train_X, train_y)
+            nested_results[training_name].setdefault(model_name, {})
+            classes = getattr(estimator, "classes_", None)
+            if classes is None:
+                classes = np.unique(np.asarray(train_y))
+            class_names = [str(value) for value in classes]
+            positive_label = class_names[-1] if len(class_names) == 2 else None
+
+            for evaluation_name, (eval_X, eval_y) in evaluation_sets.items():
+                if eval_X.empty or len(eval_y) == 0:
+                    continue
+                aligned_eval = eval_X.loc[:, train_columns]
+                probabilities = estimator.predict_proba(aligned_eval)
+                predictions = estimator.predict(aligned_eval)
+                prediction_df = build_prediction_dataframe(
+                    probabilities,
+                    eval_y,
+                    predictions,
+                    class_names,
+                )
+
+                results = evaluate_predictions(
+                    prediction_df,
+                    label_col="label",
+                    pred_col="y_pred",
+                    positive_label=positive_label,
+                    bootstrap_n=bootstrap_n,
+                    random_state=random_state,
+                )
+                nested_results[training_name][model_name][evaluation_name] = results
+
+                overall_df = results.get("overall", pd.DataFrame())
+                if overall_df.empty:
+                    continue
+                row: Dict[str, object] = {
+                    "training_dataset": training_name,
+                    "evaluation_dataset": evaluation_name,
+                    "model": model_name,
+                }
+                for metric in ("accuracy", "roc_auc"):
+                    if metric in overall_df.columns:
+                        value = overall_df.at[0, metric]
+                        row[metric] = float(value)
+                        low_col = f"{metric}_ci_low"
+                        high_col = f"{metric}_ci_high"
+                        row[low_col] = (
+                            float(overall_df.at[0, low_col])
+                            if low_col in overall_df.columns
+                            else float("nan")
+                        )
+                        row[high_col] = (
+                            float(overall_df.at[0, high_col])
+                            if high_col in overall_df.columns
+                            else float("nan")
+                        )
+                        long_rows.append(
+                            {
+                                "training_dataset": training_name,
+                                "evaluation_dataset": evaluation_name,
+                                "model": model_name,
+                                "metric": metric,
+                                "estimate": float(value),
+                                "ci_low": (
+                                    float(overall_df.at[0, low_col])
+                                    if low_col in overall_df.columns
+                                    else float("nan")
+                                ),
+                                "ci_high": (
+                                    float(overall_df.at[0, high_col])
+                                    if high_col in overall_df.columns
+                                    else float("nan")
+                                ),
+                            }
+                        )
+                    else:
+                        row[metric] = float("nan")
+                        row[f"{metric}_ci_low"] = float("nan")
+                        row[f"{metric}_ci_high"] = float("nan")
+                summary_rows.append(row)
+
+    summary_df = pd.DataFrame(summary_rows)
+    long_df = pd.DataFrame(long_rows)
+    return summary_df, long_df, nested_results
+
+
+def extract_positive_probabilities(probabilities: np.ndarray) -> np.ndarray:
+    """Return the positive-class probabilities as a 1-D array."""
+
+    prob_matrix = np.asarray(probabilities)
+    if prob_matrix.ndim == 1:
+        return prob_matrix
+    return prob_matrix[:, -1]
+
+
+def compute_binary_metrics(
+    probabilities: np.ndarray, targets: pd.Series | np.ndarray
+) -> Dict[str, float]:
+    """Compute AUROC, accuracy, specificity, sensitivity, and Brier score."""
+
+    positive_probs = extract_positive_probabilities(probabilities)
+    labels = np.asarray(targets)
+    predictions = (positive_probs >= 0.5).astype(int)
+
+    metrics: Dict[str, float] = {}
+
+    try:
+        roauc = float(roc_auc_score(labels, positive_probs))
+    except ValueError:
+        roauc = float("nan")
+
+    metrics["ROAUC"] = roauc
+    metrics["AUC"] = roauc
+
+    metrics["ACC"] = float(accuracy_score(labels, predictions))
+    tn, fp, fn, tp = confusion_matrix(labels, predictions, labels=[0, 1]).ravel()
+    metrics["SPE"] = float(tn / (tn + fp)) if (tn + fp) > 0 else float("nan")
+    metrics["SEN"] = float(tp / (tp + fn)) if (tp + fn) > 0 else float("nan")
+    metrics["Brier"] = float(brier_score_loss(labels, positive_probs))
+    return metrics
+
+
+def fit_isotonic_calibrator(
+    model: SUAVE,
+    features: pd.DataFrame,
+    targets: pd.Series | np.ndarray,
+) -> CalibratedClassifierCV:
+    """Wrap ``model`` with an isotonic :class:`CalibratedClassifierCV`."""
+
+    calibrator = CalibratedClassifierCV(
+        base_estimator=model,
+        method="isotonic",
+        cv="prefit",
+    )
+    calibrator.fit(features, np.asarray(targets))
+    return calibrator
+
+
+def plot_calibration_curves(
+    probability_map: Mapping[str, np.ndarray],
+    label_map: Mapping[str, np.ndarray],
+    *,
+    target_name: str,
+    output_path: Path,
+    n_bins: int = 10,
+) -> None:
+    """Generate calibration curves with Brier scores annotated in the legend."""
+
+    fig, ax = plt.subplots(figsize=(6, 5))
+    ax.plot(
+        [0, 1], [0, 1], linestyle="--", color="tab:gray", label="Perfect calibration"
+    )
+
+    for dataset_name, probs in probability_map.items():
+        labels = label_map[dataset_name]
+        pos_probs = extract_positive_probabilities(probs)
+        try:
+            frac_pos, mean_pred = calibration_curve(labels, pos_probs, n_bins=n_bins)
+        except ValueError:
+            continue
+        brier = brier_score_loss(labels, pos_probs)
+        ax.plot(
+            mean_pred,
+            frac_pos,
+            marker="o",
+            label=f"{dataset_name} (Brier={brier:.3f})",
+        )
+
+    ax.set_xlabel("Predicted probability")
+    ax.set_ylabel("Observed frequency")
+    ax.set_title(f"Calibration: {target_name}")
+    ax.legend()
+    fig.tight_layout()
+    fig.savefig(output_path, dpi=300)
+    plt.close(fig)
+
+
+def plot_latent_space(
+    model: "SUAVE",
+    feature_map: Mapping[str, pd.DataFrame],
+    label_map: Mapping[str, Sequence[object]],
+    *,
+    target_name: str,
+    output_path: Path,
+) -> None:
+    """Project latent representations with PCA and create scatter plots."""
+
+    latent_blocks: List[np.ndarray] = []
+    dataset_keys: List[str] = []
+    for name, features in feature_map.items():
+        if features.empty:
+            continue
+        latents = model.encode(features)
+        if latents.size == 0:
+            continue
+        latent_blocks.append(latents)
+        dataset_keys.append(name)
+
+    if not latent_blocks:
+        return
+
+    concatenated = np.vstack(latent_blocks)
+    pca = PCA(n_components=2)
+    projected = pca.fit_transform(concatenated)
+
+    offsets = np.cumsum([0] + [block.shape[0] for block in latent_blocks])
+    fig, axes = plt.subplots(
+        1,
+        len(latent_blocks),
+        figsize=(6 * len(latent_blocks), 5),
+        sharex=True,
+        sharey=True,
+    )
+
+    if len(latent_blocks) == 1:
+        axes = [axes]
+
+    for idx, (ax, name) in enumerate(zip(axes, dataset_keys)):
+        start, end = offsets[idx], offsets[idx + 1]
+        subset = projected[start:end]
+        labels = np.asarray(label_map[name])
+        scatter = ax.scatter(
+            subset[:, 0],
+            subset[:, 1],
+            c=labels,
+            cmap="coolwarm",
+            alpha=0.7,
+            edgecolor="none",
+        )
+        ax.set_title(f"{name}")
+        ax.set_xlabel("PC1")
+        ax.set_ylabel("PC2")
+        legend = ax.legend(*scatter.legend_elements(), title="Label")
+        ax.add_artist(legend)
+
+    fig.suptitle(f"Latent space projection: {target_name}")
+    fig.tight_layout(rect=(0, 0, 1, 0.96))
+    fig.savefig(output_path, dpi=300)
+    plt.close(fig)
+
+
+def plot_benchmark_curves(
+    dataset_name: str,
+    y_true: np.ndarray,
+    model_probability_lookup: Mapping[str, np.ndarray],
+    *,
+    output_dir: Path,
+    target_label: str,
+    abbreviation_lookup: Optional[Mapping[str, str]] = None,
+    n_bins: int = 10,
+) -> Optional[Path]:
+    """Plot ROC and calibration curves for the supplied dataset."""
+
+    unique_labels = np.unique(y_true)
+    if unique_labels.size < 2:
+        print(f"Skipping {dataset_name} curves because only one class is present.")
+        return None
+
+    fig, (roc_ax, cal_ax) = plt.subplots(1, 2, figsize=(12, 5))
+
+    roc_ax.plot([0, 1], [0, 1], linestyle="--", color="gray", label="Chance")
+    roc_ax.set_title(f"ROC – {dataset_name}")
+    roc_ax.set_xlabel("False positive rate")
+    roc_ax.set_ylabel("True positive rate")
+
+    cal_ax.plot([0, 1], [0, 1], linestyle="--", color="gray", label="Perfect")
+    cal_ax.set_title(f"Calibration – {dataset_name}")
+    cal_ax.set_xlabel("Mean predicted probability")
+    cal_ax.set_ylabel("Fraction of positives")
+
+    for model_name, probs in model_probability_lookup.items():
+        abbrev = (
+            model_name
+            if abbreviation_lookup is None
+            else abbreviation_lookup.get(model_name, model_name)
+        )
+        positive_probs = extract_positive_probabilities(probs)
+        fpr, tpr, _ = roc_curve(y_true, positive_probs)
+        roc_ax.plot(fpr, tpr, label=abbrev)
+
+        try:
+            frac_pos, mean_pred = calibration_curve(
+                y_true, positive_probs, n_bins=n_bins, strategy="quantile"
+            )
+        except ValueError:
+            print(
+                f"Calibration curve for {model_name} on {dataset_name} skipped due to insufficient variation."
+            )
+        else:
+            cal_ax.plot(mean_pred, frac_pos, marker="o", label=abbrev)
+
+    roc_ax.legend(loc="lower right")
+    cal_ax.legend(loc="upper left")
+    fig.suptitle(f"Benchmark ROC & calibration – {dataset_name}")
+    fig.tight_layout()
+
+    dataset_slug = dataset_name.lower().replace(" ", "_")
+    figure_path = output_dir / f"benchmark_curves_{dataset_slug}_{target_label}.png"
+    fig.savefig(figure_path, dpi=300, bbox_inches="tight")
+    plt.close(fig)
+    print(f"Saved benchmark curves for {dataset_name} to {figure_path}")
+    return figure_path
+
+
+def plot_transfer_metric_bars(
+    metric_df: pd.DataFrame,
+    *,
+    metric: str,
+    evaluation_dataset: str,
+    training_order: Sequence[str],
+    model_order: Sequence[str],
+    output_dir: Path,
+    target_label: str,
+) -> Optional[Path]:
+    """Plot grouped bar charts with error bars for TSTR/TRTR comparisons."""
+
+    subset = metric_df[
+        (metric_df["metric"] == metric)
+        & (metric_df["evaluation_dataset"] == evaluation_dataset)
+    ]
+    if subset.empty:
+        print(
+            f"Skipping {metric} bars for {evaluation_dataset} because no data was provided."
+        )
+        return None
+
+    training_order = list(training_order)
+    model_order = list(model_order)
+    x_positions = np.arange(len(training_order), dtype=float)
+    width = 0.8 / max(len(model_order), 1)
+
+    fig, ax = plt.subplots(figsize=(12, 6))
+
+    for idx, model_name in enumerate(model_order):
+        model_subset = (
+            subset[subset["model"] == model_name]
+            .set_index("training_dataset")
+            .reindex(training_order)
+        )
+        estimates = model_subset["estimate"].to_numpy()
+        lower = estimates - model_subset["ci_low"].to_numpy()
+        upper = model_subset["ci_high"].to_numpy() - estimates
+        lower = np.nan_to_num(lower, nan=0.0, posinf=0.0, neginf=0.0)
+        upper = np.nan_to_num(upper, nan=0.0, posinf=0.0, neginf=0.0)
+        offsets = (idx - (len(model_order) - 1) / 2) * width
+        ax.bar(
+            x_positions + offsets,
+            estimates,
+            width=width,
+            label=model_name,
+            yerr=np.vstack([lower, upper]),
+            capsize=4,
+            alpha=0.9,
+        )
+
+    ax.set_xticks(x_positions)
+    ax.set_xticklabels(training_order, rotation=20, ha="right")
+    ax.set_ylabel(metric.upper())
+    ax.set_ylim(0.0, 1.0)
+    ax.set_title(f"{metric.upper()} – {evaluation_dataset}")
+    ax.legend()
+    fig.tight_layout()
+
+    dataset_slug = slugify_identifier(evaluation_dataset)
+    figure_path = (
+        output_dir
+        / f"tstr_trtr_{dataset_slug}_{metric.lower()}_{slugify_identifier(target_label)}.png"
+    )
+    fig.savefig(figure_path, dpi=300, bbox_inches="tight")
+    plt.close(fig)
+    print(f"Saved {metric.upper()} bars for {evaluation_dataset} to {figure_path}")
+    return figure_path
+
+
+def build_prediction_dataframe(
+    probabilities: np.ndarray,
+    labels: Sequence[object],
+    predictions: Sequence[object],
+    class_names: Sequence[str],
+) -> pd.DataFrame:
+    """Assemble a dataframe compatible with :func:`evaluate_predictions`."""
+
+    prob_matrix = np.asarray(probabilities)
+    class_names = list(class_names)
+    if prob_matrix.ndim == 1:
+        if len(class_names) == 2:
+            negative_name, positive_name = class_names[0], class_names[-1]
+            proba_dict = {
+                f"pred_proba_{negative_name}": 1.0 - prob_matrix,
+                f"pred_proba_{positive_name}": prob_matrix,
+            }
+        else:
+            proba_dict = {"pred_proba_0": prob_matrix}
+    else:
+        if prob_matrix.shape[1] == len(class_names) and len(class_names) > 0:
+            proba_dict = {
+                f"pred_proba_{class_names[idx]}": prob_matrix[:, idx]
+                for idx in range(prob_matrix.shape[1])
+            }
+        else:
+            proba_dict = {
+                f"pred_proba_{idx}": prob_matrix[:, idx]
+                for idx in range(prob_matrix.shape[1])
+            }
+
+    base_df = pd.DataFrame(
+        {
+            "label": np.asarray(labels),
+            "y_pred": np.asarray(predictions),
+        }
+    )
+    if proba_dict:
+        proba_df = pd.DataFrame(proba_dict)
+        base_df = pd.concat([base_df.reset_index(drop=True), proba_df], axis=1)
+    else:
+        base_df = base_df.reset_index(drop=True)
+    return base_df
+
+
+def resolve_classification_loss_weight(params: Mapping[str, object]) -> Optional[float]:
+    """Normalise ``classification_loss_weight`` from Optuna parameters."""
+
+    use_weight = params.get("use_classification_loss_weight")
+    if isinstance(use_weight, str):
+        use_weight = use_weight.lower() in {"1", "true", "yes"}
+    elif isinstance(use_weight, (np.bool_,)):
+        use_weight = bool(use_weight)
+    if not use_weight:
+        return None
+    weight = params.get("classification_loss_weight")
+    if weight is None:
+        return 1.0
+    if isinstance(weight, (np.floating, np.integer)):
+        return float(weight)
+    return float(weight)
+
+
+def build_suave_model(
+    params: Mapping[str, object],
+    schema: Schema,
+    *,
+    random_state: int,
+) -> SUAVE:
+    """Instantiate :class:`SUAVE` using Optuna-style parameters."""
+
+    hidden_key = str(params.get("hidden_dims", "medium"))
+    head_hidden_key = str(params.get("head_hidden_dims", "medium"))
+    hidden_dims = HIDDEN_DIMENSION_OPTIONS.get(
+        hidden_key, HIDDEN_DIMENSION_OPTIONS["medium"]
+    )
+    head_hidden_dims = HEAD_HIDDEN_DIMENSION_OPTIONS.get(
+        head_hidden_key, HEAD_HIDDEN_DIMENSION_OPTIONS["medium"]
+    )
+    classification_loss_weight = resolve_classification_loss_weight(params)
+    return SUAVE(
+        schema=schema,
+        latent_dim=int(params.get("latent_dim", 16)),
+        n_components=int(params.get("n_components", 1)),
+        hidden_dims=hidden_dims,
+        head_hidden_dims=head_hidden_dims,
+        dropout=float(params.get("dropout", 0.1)),
+        learning_rate=float(params.get("learning_rate", 1e-3)),
+        batch_size=int(params.get("batch_size", 256)),
+        beta=float(params.get("beta", 1.5)),
+        classification_loss_weight=classification_loss_weight,
+        random_state=random_state,
+        behaviour="supervised",
+    )

--- a/suave/evaluate.py
+++ b/suave/evaluate.py
@@ -5,7 +5,12 @@ from __future__ import annotations
 from typing import Any, Callable, Dict, Tuple
 
 import numpy as np
-from sklearn.metrics import average_precision_score, brier_score_loss, roc_auc_score
+from sklearn.metrics import (
+    average_precision_score,
+    brier_score_loss,
+    mutual_info_score,
+    roc_auc_score,
+)
 
 
 def _prepare_inputs(
@@ -477,3 +482,185 @@ def simple_membership_inference(
         "attack_best_accuracy": float(accuracies[best_index]),
         "attack_majority_class_accuracy": majority_accuracy,
     }
+
+
+def kolmogorov_smirnov_statistic(real: np.ndarray, synthetic: np.ndarray) -> float:
+    """Compute the Kolmogorov–Smirnov statistic for univariate samples.
+
+    The Kolmogorov–Smirnov (KS) statistic measures the maximum distance between
+    the empirical cumulative distribution functions of the real and synthetic
+    samples. Values close to ``0.0`` indicate that the synthetic distribution is
+    indistinguishable from the reference sample, whereas scores approaching
+    ``1.0`` highlight large distributional shifts. A common heuristic is to flag
+    KS statistics above ``0.1`` as a sign that the feature is not faithfully
+    reproduced, although domain-specific tolerances should override this
+    general threshold.
+
+    Args:
+        real: One-dimensional array of observations drawn from the reference
+            dataset.
+        synthetic: One-dimensional array sampled from the generative model.
+
+    Returns:
+        The KS statistic in ``[0, 1]``. ``numpy.nan`` is returned when either
+        input is empty after removing non-finite values.
+
+    Example:
+        >>> import numpy as np
+        >>> ks = kolmogorov_smirnov_statistic(
+        ...     np.random.normal(size=256),
+        ...     np.random.normal(size=256),
+        ... )
+        >>> ks < 0.1
+        True
+    """
+
+    real = np.asarray(real, dtype=float)
+    synthetic = np.asarray(synthetic, dtype=float)
+    real = real[np.isfinite(real)]
+    synthetic = synthetic[np.isfinite(synthetic)]
+    if real.size == 0 or synthetic.size == 0:
+        return float("nan")
+
+    real_sorted = np.sort(real)
+    synthetic_sorted = np.sort(synthetic)
+    combined = np.concatenate([real_sorted, synthetic_sorted])
+    cdf_real = np.searchsorted(real_sorted, combined, side="right") / real_sorted.size
+    cdf_synth = (
+        np.searchsorted(synthetic_sorted, combined, side="right")
+        / synthetic_sorted.size
+    )
+    return float(np.max(np.abs(cdf_real - cdf_synth)))
+
+
+def rbf_mmd(
+    real: np.ndarray,
+    synthetic: np.ndarray,
+    *,
+    random_state: int,
+    max_samples: int = 5000,
+) -> float:
+    """Estimate the RBF maximum mean discrepancy between two samples.
+
+    The maximum mean discrepancy (MMD) compares the first-order moments of the
+    real and synthetic samples in a reproducing kernel Hilbert space. We use a
+    radial basis function (RBF) kernel with the median heuristic for the
+    bandwidth and subsample extremely large arrays for efficiency. Scores close
+    to ``0.0`` indicate that the generator matches the reference feature well;
+    higher scores denote a stronger distribution gap. Practitioners often
+    compare MMD magnitudes across features: values above ``0.05``–``0.1``
+    typically warrant inspection in structured clinical datasets.
+
+    Args:
+        real: One-dimensional array of reference observations.
+        synthetic: One-dimensional array of synthetic observations.
+        random_state: Seed used when subsampling large arrays prior to the
+            kernel computation.
+        max_samples: Maximum number of samples drawn from each array. Larger
+            inputs are subsampled without replacement.
+
+    Returns:
+        The estimated MMD value. ``numpy.nan`` is returned when either input is
+        empty after removing non-finite values.
+
+    Example:
+        >>> rng = np.random.default_rng(0)
+        >>> real = rng.normal(loc=0.0, scale=1.0, size=200)
+        >>> synth = rng.normal(loc=0.1, scale=1.1, size=200)
+        >>> score = rbf_mmd(real, synth, random_state=0)
+        >>> round(score, 3) >= 0.0
+        True
+    """
+
+    real = np.asarray(real, dtype=float)
+    synthetic = np.asarray(synthetic, dtype=float)
+    real = real[np.isfinite(real)]
+    synthetic = synthetic[np.isfinite(synthetic)]
+    if real.size == 0 or synthetic.size == 0:
+        return float("nan")
+
+    rng = np.random.default_rng(random_state)
+    if real.size > max_samples:
+        real = rng.choice(real, size=max_samples, replace=False)
+    if synthetic.size > max_samples:
+        synthetic = rng.choice(synthetic, size=max_samples, replace=False)
+
+    real = real[:, None]
+    synthetic = synthetic[:, None]
+    data = np.concatenate([real, synthetic], axis=0)
+    squared_distances = (data - data.T) ** 2
+    median_sq = float(np.median(squared_distances))
+    bandwidth = np.sqrt(0.5 * median_sq) if median_sq > 1e-12 else 1.0
+
+    def kernel(a: np.ndarray, b: np.ndarray) -> np.ndarray:
+        distances = (a - b.T) ** 2
+        return np.exp(-distances / (2.0 * bandwidth**2))
+
+    k_xx = kernel(real, real)
+    k_yy = kernel(synthetic, synthetic)
+    k_xy = kernel(real, synthetic)
+    mmd = k_xx.mean() + k_yy.mean() - 2.0 * k_xy.mean()
+    return float(max(mmd, 0.0))
+
+
+def mutual_information_feature(
+    real: np.ndarray, synthetic: np.ndarray, n_bins: int = 10
+) -> float:
+    """Estimate the mutual information between dataset identity and a feature.
+
+    The score quantifies how informative the feature is about whether a sample
+    originated from the real dataset or from the generator. ``0.0`` denotes no
+    detectable dependence, while higher scores indicate that a downstream
+    classifier could reliably separate the distributions. Analysts commonly use
+    ``n_bins`` in the ``10``–``20`` range and flag features whose mutual
+    information exceeds ``0.1`` bits as candidates for debugging.
+
+    Args:
+        real: One-dimensional array of reference observations.
+        synthetic: One-dimensional array of synthetic observations.
+        n_bins: Number of quantile-based bins used to discretise the feature.
+
+    Returns:
+        Mutual information measured in bits. ``numpy.nan`` is returned when the
+        metric is undefined (e.g., not enough unique values to form bins).
+
+    Example:
+        >>> import numpy as np
+        >>> score = mutual_information_feature(
+        ...     np.array([0.0, 0.2, 0.4, 0.6]),
+        ...     np.array([0.7, 0.8, 0.9, 1.0]),
+        ... )
+        >>> score >= 0.0
+        True
+    """
+
+    real = np.asarray(real, dtype=float)
+    synthetic = np.asarray(synthetic, dtype=float)
+    real = real[np.isfinite(real)]
+    synthetic = synthetic[np.isfinite(synthetic)]
+    if real.size == 0 or synthetic.size == 0:
+        return float("nan")
+
+    combined = np.concatenate([real, synthetic])
+    quantiles = np.quantile(combined, np.linspace(0.0, 1.0, n_bins + 1))
+    bin_edges = np.unique(quantiles)
+    if bin_edges.size <= 1:
+        return 0.0
+
+    interior = bin_edges[1:-1]
+    real_binned = np.digitize(real, interior, right=False)
+    synthetic_binned = np.digitize(synthetic, interior, right=False)
+
+    if np.unique(real_binned).size <= 1 and np.unique(synthetic_binned).size <= 1:
+        return 0.0
+
+    dataset_indicator = np.concatenate(
+        [
+            np.zeros(real_binned.size, dtype=int),
+            np.ones(synthetic_binned.size, dtype=int),
+        ]
+    )
+    feature_bins = np.concatenate([real_binned, synthetic_binned])
+    if np.unique(feature_bins).size <= 1:
+        return 0.0
+    return float(mutual_info_score(dataset_indicator, feature_bins))

--- a/suave/model.py
+++ b/suave/model.py
@@ -434,6 +434,7 @@ class SUAVE:
         self._is_fitted = False
         self._is_calibrated = False
         self._classes: np.ndarray | None = None
+        self.classes_: np.ndarray | None = None
         self._norm_stats_per_col: dict[str, dict[str, float | list[str]]] = {}
         self._temperature_scaler = TemperatureScaler()
         self._temperature_scaler_state: dict[str, float | bool] | None = None
@@ -1016,6 +1017,7 @@ class SUAVE:
         if self.behaviour == "supervised":
             y_train_array = np.asarray(y_train)
             self._classes = np.unique(y_train_array)
+            self.classes_ = self._classes
             if self._classes.size == 0:
                 raise ValueError("Training targets must contain at least one class")
             self._class_to_index = {
@@ -1036,6 +1038,7 @@ class SUAVE:
         else:
             self._classes = None
             self._class_to_index = None
+            self.classes_ = None
 
         (
             batch_size,
@@ -3656,6 +3659,15 @@ class SUAVE:
             DataFrame with shape ``(n_samples, n_features)`` whose columns match
             the training schema.
 
+        Notes
+        -----
+        When :attr:`behaviour` is ``"supervised"`` the unconditional mode
+        (``conditional=False``) emits a warning because the generated samples do
+        not include labels. To synthesise feature/label pairs for downstream
+        training provide labels via ``conditional=True``. For example::
+
+            model.sample(10, conditional=True, y=np.random.choice(model.classes_, size=10))
+
         Raises
         ------
         RuntimeError
@@ -3676,6 +3688,16 @@ class SUAVE:
             raise RuntimeError("Schema is required to generate samples")
         if n_samples <= 0:
             return pd.DataFrame(columns=list(self.schema.feature_names))
+
+        if self.behaviour == "supervised" and not conditional:
+            warnings.warn(
+                "model.sample(conditional=False) returns feature-only rows when "
+                "behaviour='supervised'. For downstream supervised training, use "
+                "conditional=True with labels, e.g. "
+                "model.sample(n, conditional=True, y=np.random.choice(model.classes_, size=n)).",
+                UserWarning,
+                stacklevel=2,
+            )
 
         device = self._select_device()
         latents, assignments = self._draw_latent_samples(
@@ -3985,6 +4007,9 @@ class SUAVE:
         classes = artefacts.get("classes")
         if classes is not None:
             model._classes = np.asarray(classes)
+            model.classes_ = model._classes
+        else:
+            model.classes_ = None
         cached_logits = artefacts.get("cached_logits")
         model._cached_logits = (
             None if cached_logits is None else np.asarray(cached_logits)


### PR DESCRIPTION
## Summary
- expose Kolmogorov–Smirnov, RBF-MMD, and mutual information utilities from `suave.evaluate` with detailed docstrings and guidance
- reuse the new helpers inside the MIMIC mortality toolkit and document the expanded evaluation surface in both READMEs

## Testing
- pytest -q
- ruff check suave/evaluate.py examples/mimic_mortality_utils.py
- black suave/evaluate.py examples/mimic_mortality_utils.py

------
https://chatgpt.com/codex/tasks/task_e_68d42adfb9b88320b12bac7fe70663ea