### PR TITLE
docs: update roadmap, add research protocol and align mortality protocol with sepsis cohorts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,3 +47,4 @@ data-dependent and stored in the **same directory as the user's data** (e.g., sc
 ## Documentation
 - Each public method must include an example code snippet.
 - Keep examples minimal and data-directory-centric (schema in the same folder as the CSV).
+- When example scripts change their research workflows, update `docs/research_protocol.md` in the same PR to stay aligned.

--- a/docs/Roadmap.md
+++ b/docs/Roadmap.md
@@ -10,7 +10,8 @@
 
 2. **低成本增强** ✅
    - [x] 追加似然头
-   - [x] 自动化：自动化识别数据类型和生成schema
+   - [x] 自动化：自动化识别数据类型和生成schema（`suave.schema_inference` + `suave.interactive.schema_builder`）
+   - [x] 启发式超参推荐与序列化（`suave.defaults`），覆盖 latent_dim/hidden_dim/batch_size/epoch 调度
 
    - [x] 条件生成（CVAE 开关 `conditional=True`）：`fit(..., y=...)` 时启用可控采样
 
@@ -27,6 +28,7 @@
    - [x] **TSTR/TRTR** 脚手架（独立评测器）
    - [x] 简单 **MIA**（membership inference）基线（影子模型/置信阈值法）
    - [x] 结果打包与示例 notebook（研究作 example）
+   - [x] 研究级 MIMIC/eICU 分析脚本整合：Optuna 最优试验、基线模型、SUAVE 校准、TSTR/TRTR、分布漂移与报告导出（`examples/research-mimic_mortality_supervised.py`）
 
 ------
 
@@ -35,8 +37,10 @@
 ```
 suave/
   __init__.py
+  defaults.py             # 超参启发式推荐与序列化
   types.py                 # Schema&枚举（用户手动提供，先不做自动推断）
   data.py                  # 缺失mask、标准化/反标准化、train内部分割
+  schema_inference.py      # 列类型启发式推断、info/interactive 模式
   modules/
     encoder.py             # MLP Encoder
     decoder.py             # 多头解码（real/cat 起步；pos/count/ordinal 后续加）
@@ -44,55 +48,62 @@ suave/
     heads.py               # 分类头（MLP/Logistic）
     losses.py              # ELBO(重构NLL+KL)、CE、Focal、对齐正则（预留）
     calibrate.py           # 温度缩放
+    prior.py               # 混合先验（含可学习均值）
   model.py                 # SUAVE 主类（下面给接口）
   sampling.py              # 条件采样/批量生成
   evaluate.py              # ROC/PR/Brier/ECE/可靠性图；TSTR/TRTR；MIA基线
   plots.py                 # 可视化
+  interactive/
+    __init__.py
+    schema_builder.py      # 交互式 schema 构建/校对工具
 examples/
   sepsis_minimal.py        # 端到端最小示例（你的研究）
 ```
 
-### `SUAVE` 主类（超参全在方法/构造器里）
+
+### `SUAVE` 主类（关键参数与训练阶段）
+
+- `schema`: 列名 → {`type`, `n_classes`} 的显式声明，可在 `fit()` 时覆盖；若缺省会调用 `SchemaInferencer` 给出 info/review 模式提示。
+- `behaviour`: 选择 `"supervised"` 或 `"unsupervised"` 流程，控制是否启用分类头与联合微调。
+- `latent_dim`、`hidden_dims`、`classification_loss_weight`、`dropout`、`learning_rate`、`batch_size`、`warmup_epochs`、`head_epochs`、`finetune_epochs` 等参数缺省为 `None` 时，会在 `fit()` 前通过 `defaults.recommend_hyperparameters` 自动补全，并记录到 `auto_hyperparameters_`。
+- `head_hidden_dims` 与 `joint_decoder_lr_scale` 支持自定义分类头容量与联合微调时 decoder/prior 的学习率缩放。
+- 训练默认内部划分验证集（`val_split`、`stratify`），并在 `fit()` 的 warm-up → head-only → joint 三阶段中自动调节分类损失权重与早停策略。
 
 ```python
-m = SUAVE(
-    schema: Dict[str, Dict],              # 用户手动提供：{"col":{"type":"real|cat|pos|count|ordinal","nclass":...}}
-    latent_dim: int = 32,
-    beta: float = 1.5,                    # β-VAE权重
-    conditional: bool = False,            # 是否CVAE
-    hidden_dims: Tuple[int,...] = (256,128),
-    dropout: float = 0.1,
-    lr: float = 1e-3,
-    weight_decay: float = 1e-4,
-    kl_warmup_epochs: int = 8,
-    val_split: float = 0.1,               # 训练内部划验证集（从train切）
-    class_weight: Optional[Dict[int,float]] = None,
-    focal_gamma: Optional[float] = None,
-    device: str = "auto",                 # "auto"|"cpu"|"cuda"
+import numpy as np
+from suave import SUAVE
+
+model = SUAVE(
+    schema=schema,
+    behaviour="supervised",
+    latent_dim=None,              # None 触发启发式 latent_dim 推断
+    hidden_dims=None,             # None 触发多层隐藏单元推荐
+    classification_loss_weight=None,  # None 时将基于 ELBO/CE 自动调节
+    dropout=None,
+    learning_rate=None,
+    batch_size=None,
+    warmup_epochs=None,
+    head_epochs=None,
+    finetune_epochs=None,
+    val_split=0.1,
+    stratify=True,
 )
 
-m.fit(
-    X_train: pd.DataFrame,
-    y_train: Optional[pd.Series] = None,
-    max_epochs: int = 60,
-    batch_size: int = 256,
-    joint_ft_epochs: int = 10,            # 轻联合微调轮数
-    freeze_decoder_on_head: bool = True,
-    early_stop_patience: int = 5,
-    random_state: int = 42,
+model.fit(
+    X_train,
+    y_train,
+    plot_monitor=True,            # 可视化训练/验证曲线
 )
 
-proba = m.predict_proba(X_test)           # 预测概率
-m.calibrate(X_val=None, y_val=None)       # 若未传则使用fit时的内部验证集
-Z = m.encode(X_train)                     # 潜表示
-X_syn = m.sample(n=10000, y=1)            # 条件生成（若conditional=True）
-m.save("path/to/ckpt"); m2 = SUAVE.load("path/to/ckpt")
-
-# 评测（独立函数）
-evaluate.calibration_curves(y_true, proba)
-evaluate.tstr(X_syn, X_test, y_test, clf="xgboost")
-evaluate.mia_baseline(m, X_train)
+proba = model.predict_proba(X_test)
+model.calibrate()                 # 未显式传入验证集时复用内部切分
+latent = model.encode(X_train)
+synthetic = model.sample(1000, conditional=True, y=np.random.choice(model.classes_, size=1000))
+model.save("path/to/ckpt")
+reloaded = SUAVE.load("path/to/ckpt")
 ```
+
+**评测（独立函数）**：`evaluate.evaluate_classification`、`evaluate_tstr`、`evaluate_trtr`、`simple_membership_inference` 等函数可直接消费 `predict_proba` 的输出，补充 ROC/PR/Brier/ECE、TSTR/TRTR 与隐私攻击基线结果。
 
 ------
 
@@ -120,191 +131,49 @@ evaluate.mia_baseline(m, X_train)
     suave/{sampling.py,evaluate.py,plots.py} examples/sepsis_minimal.py
   ```
 
-## 2) **首批 codex 任务与指令模板**
 
-> ### ✅ Task-0｜包骨架 & 最小 API（空实现 + 文档 + 单测）
->
-> **Prompt 给 codex：**
->
-> > 目标：创建最小可运行的包架构，仅提供空实现和文档，占位单测能跑通导入与最小流程。
-> >
-> > - 生成目录：
-> >
-> >   ```
-> >   suave/
-> >     __init__.py
-> >     types.py
-> >     data.py
-> >     model.py
-> >     modules/
-> >       encoder.py
-> >       decoder.py
-> >       distributions.py
-> >       heads.py
-> >       losses.py
-> >       calibrate.py
-> >     sampling.py
-> >     evaluate.py
-> >     plots.py
-> >   examples/sepsis_minimal.py
-> >   third_party/hivae_tf/  # 已预置官方TF源码（只读）
-> >   ```
-> >
-> > - `suave.model.SUAVE`：定义构造器与空方法 `fit / predict_proba / calibrate / encode / sample / save / load`，写完整 docstring（参数、形状、返回值、示例）。
-> >
-> > - `suave.types.Schema`：手动 schema 约定（列名→{type, nclass?}），v1 不做自动推断。
-> >
-> > - `suave.data`：实现
-> >
-> >   - `split_train_val(X, y, val_split: float, stratify: bool)`（从 train 内部分出 val）
-> >   - 缺失掩码构造（bool mask）
-> >   - 标准化/反标准化仅覆盖 `real / cat` 两类
-> >
-> > - `examples/sepsis_minimal.py`：演示从 CSV 读数据、构造 schema、实例化模型、调用 `fit→predict→calibrate→plot`（可生成空图占位）。
-> >
-> > - 基础单测（pytest）：
-> >
-> >   - 包可导入；`SUAVE` 可实例化；
-> >   - `fit` 跑通日志打印（占位训练循环可仅 sleep/print）；
-> >   - `predict_proba` 返回形状与输入行数一致。
->
-> **验收**：`pytest -q` 通过；`black . && ruff .` 无报错。
->
-> ------
->
-> ### ✅ Task-1｜对照 HI-VAE(TF) 迁移 Encoder/Decoder（real+cat）与 ELBO
->
-> **核心变更**：不是凭空实现，而是**逐函数对照** `third_party/hivae_tf/hivae/loglik_models_missing_normalize.py` 与 `VAE_functions.py`，在 PyTorch 中复现 **real / pos / count / cat / ordinal** 的**接口雏形**，但 **本任务只启用 real + cat 训练路径**，其余先实现为**可调用但默认禁用**（返回 `NotImplementedError` 或 `@experimental` 提示）。ELBO 先覆盖 mask-aware 重构 + KL；Warm-start 仅训 ELBO。
->
-> **Prompt 给 codex：**
->
-> > 目标：在 PyTorch 中**对照迁移** HI-VAE(TF) 的解码与 NLL 计算，先打通 `real + cat` 的端到端训练（仅 ELBO）。
-> >
-> > **阅读参考（只读）：**
-> >  `third_party/hivae_tf/hivae/loglik_models_missing_normalize.py`
-> >  `third_party/hivae_tf/hivae/VAE_functions.py`
-> >
-> > **实现要求：**
-> >
-> > 1. `modules/encoder.py`
-> >    - `EncoderMLP(input_dim: int, hidden=(256,128), dropout=0.1, out_dim: int)`：返回 `mu_z, logvar_z`（Normal 近似后验）。
-> >    - 数值稳定：对 `logvar_z` clamp 到 [-15, 15] 范围。
-> > 2. `modules/decoder.py`（仿 HI-VAE 的“按列类型选择头”机制）
-> >    - 统一接口 `class LikelihoodHead(nn.Module)`：
-> >      - `forward(x, params, norm_stats, mask) -> dict`，键包括：
-> >        - `"log_px"`（按样本聚合的对数似然，**已乘以 mask**）
-> >        - `"log_px_missing"`（缺失项 loglik，用于评估）
-> >        - `"params"`（分布参数，反标准化后）
-> >        - `"sample"`（`torch.distributions` 采样得到的样本）
-> >    - 实现 `RealHead`（Gaussian）：softplus 确保方差正，反标准化（对齐 TF 中的 affine transform）；
-> >    - 实现 `CatHead`（Categorical）：输出 logits，NLL= `F.cross_entropy(logits, onehot_labels, reduction='none')` 的负号；采样用 `Categorical(logits=...)`；
-> >    - 占位头（先不在训练图中启用）：
-> >       `PosHead`（LogNormal：对数域NLL + 反标准化 + exp-1 采样）、
-> >       `CountHead`（Poisson：rate=softplus）、
-> >       `OrdinalHead`（cumulative-link：阈值单调性用 `softplus`+`cumsum`）。
-> >       —— 保留 forward 骨架与 TODO 注释，单测暂跳过。
-> > 3. `modules/distributions.py`
-> >    - 封装 `nll_gaussian(x, mu, var, mask)`、`nll_categorical(x_onehot, logits, mask)`；
-> >    - 提供 `sample_gaussian(mu, var)`、`sample_categorical(logits)`；
-> >    - 常数 `EPS=1e-6`，`softplus(var_raw)+EPS` 保正。
-> > 4. `modules/losses.py`
-> >    - `elbo(recon_terms: List[Tensor], kl: Tensor) -> Tensor`，`recon_terms` 是各列 loglik 之和（已含 mask）；
-> >    - `kl_warmup(step, total_steps, beta_target)` 线性退火；
-> >    - `kl_normal(mu, logvar)`。
-> > 5. `model.SUAVE.fit`（Warm-start 版）
-> >    - 仅优化 ELBO（重构 + β·KL），**支持 mask-aware**；
-> >    - KL 线性退火 0→β（`kl_warmup_epochs`）；
-> >    - 训练循环 + `tqdm` 日志；
-> >    - 保存：`self._norm_stats_per_col`（模仿 TF 的 normalization parameters）；
-> >    - 仅启用 `real + cat` 列；其它类型遇到时抛出清晰错误，提示“启用后续 Task-4”。
-> >
-> > **数值一致性与单测：**
-> >
-> > - 在 `tests/test_nll_math.py` 写**闭式对照**（不是对 TF 求值）：
-> >   - 随机小张量上验证：Gaussian/Categorical 的 NLL 与手写公式一致（容差 `1e-6`）。
-> > - 在 `tests/test_elbo_sanity.py`：
-> >   - 合成数据（混合 real/cat 列）训练 5–10 个 epoch，验证 `NLL` 下降、`KL > 0`。
-> > - 在 `tests/test_masking.py`：构造缺失掩码，确认只在观测项累计 NLL。
-> >
-> > **风格与文档：**
-> >  所有公开函数写 type hints 与示例；对照 TF 代码处增加行内注释 `# parity: loglik_real TF lines XX-YY`。
->
-> **验收**：
->  ELBO 训练可在混合 real/cat 的玩具数据上稳定下降；单测全部通过；遇到 pos/count/ordinal 列能给出明确错误信息与启用提示。
->
-> ------
->
-> ### ✅ Task-2（微调）｜分类头 + 轻联合微调 + 不平衡 & 校准
->
-> **Prompt 给 codex：**
->
-> > - `modules/heads.py`：实现 `LogisticHead` 与可选 `MLPHead`；支持 `class_weight` 与 `focal(gamma)`。
-> > - `model.SUAVE.fit`：加入阶段 B（冻结解码器训练 head）与阶段 C（全模型 small-lr 轻联合微调；解码器 lr 更小）。
-> > - `modules/calibrate.py`：温度缩放（验证集拟合 T，最小化 NLL）。
-> > - `evaluate.py`：实现 `auroc/auprc/brier/ece` 与可靠性曲线。
-> > - 单测：
-> >   - 小数据上温度缩放后 `ECE` 明显下降；
-> >   - 阶段 C 后验证 `AUPRC` 不下降（相对阶段 B）。
->
-> ------
->
-> ### ✅ Task-3（增强）｜追加似然头（pos/count/ordinal）与数值稳定
->
-> **Prompt 给 codex：**
->
-> > - 完成 `PosHead/CountHead/OrdinalHead` 的 forward，实现：
-> >   - `pos`：LogNormal（对 log(1+x) 计算高斯 NLL，采样时 `exp(sample)-1`，对负值 clamp 0）；
-> >   - `count`：Poisson（rate=softplus(raw)+EPS；`torch.poisson`/`Poisson(rate)` 采样；NLL 用 `log_poisson_loss` 等价式）；
-> >   - `ordinal`：cumulative-link（分段阈值 `softplus`+`cumsum` 单调，类别概率用差分 sigmoid）。
-> > - 单测：
-> >   - 在 `tests/test_heads_math.py` 用手写闭式或稳定实现对照（容差 `1e-4`）；
-> >   - 随机数据 sanity-check：开启相应列后，ELBO 可下降。
->
-> ------
->
-> ### ✅ Task-4｜评测闭环（TSTR/TRTR、MIA基线）
->
-> **Prompt 给 codex：**
->
-> > - `evaluate.tstr(X_syn, X_test, y_test, clf='xgboost')` 与 `evaluate.trtr(...)`：训练独立分类器（XGBoost/LightGBM/LogReg 任选其一）并返回 JSON 摘要（AUROC/AUPRC/Brier）。
-> > - `evaluate.mia_baseline(model, X_train)`：实现影子模型/置信阈值攻击占位，无外网依赖。
-> > - 产出图表：分布学（直方/核密度）、可靠性曲线、PR/ROC。
-> > - 单测：API 正常返回关键字段；在极小数据上可运行至结束。
->
-> ------
->
-> ### ⏳ Task-5｜文档与示例
->
-> **Prompt 给 codex：**
->
-> > - 完善 docstring；
-> > - 在 `examples/sepsis_minimal.py` 展示：训练→校准→外检→潜变量相关热图（`plots`）；
-> > - 提供 `SUAVE.dump_schema(data_dir)` 与 `SUAVE.load_schema(data_dir)`（如需 `schema.json`，只写到**数据目录**）；
-> > - 确保 README 片段：如何准备 schema、如何开启条件生成、如何做 TSTR。
+## 2) 主干任务
 
-## 3) 代码评审清单
+### ✅ Task-0｜包骨架 & 最小 API（空实现 + 文档 + 单测）
 
-- `fit()` 可仅凭 train（内部切 val）跑完三阶段；日志包含 NLL/KL/AUROC/AUPRC/Brier/ECE
-- `predict()` 输出 shape 正确、无 NaN
-- `predict_proba()` 输出 shape 正确、无 NaN
-- `calibrate()` 后 ECE 明显下降
-- `sample()` 可条件采样（若开启）
-- `save/load()` 往返一致
-- 单测通过：`pytest -q`
-- 风格：`black . && ruff .` 零错误
+- 目标：创建最小可运行的包架构，提供 `SUAVE` 空实现、类型约定与数据处理占位，确保 `pytest -q`、`black .` 与 `ruff .` 可通过。
+- 交付：模块化目录结构、`SUAVE` 类接口（`fit/predict/predict_proba/calibrate/encode/sample/save/load`）、schema 约定、最小示例与占位单测。
+- 验收：导入包即可运行最小流程，分类头暂为空实现但具有完整 docstring 与类型注解。
+
+### ✅ Task-1｜迁移 HI-VAE 核心训练（real+cat）
+
+- 目标：在 PyTorch 中复刻 HI-VAE 的 encoder/decoder 与重构 NLL，打通 `real` 与 `cat` 类型的 ELBO 训练路径。
+- 交付：`EncoderMLP`、`LikelihoodHead` 框架与 `RealHead/CatHead` 实现，`losses.elbo`、`losses.kl_warmup`、`distributions` 工具与 mask-aware 训练循环。
+- 验收：在混合 real/cat 玩具数据上 ELBO 稳定下降，遇到未实现列类型抛出清晰错误，相关单测覆盖 NLL 与 mask 行为。
+
+### ✅ Task-2｜分类头、轻联合微调与校准
+
+- 目标：扩展监督模式训练计划，引入分类头阶段、轻联合微调与温度缩放校准，初步支持类不平衡设置。
+- 交付：`LogisticHead/MLPHead`（含 `class_weight` 与 `focal_gamma` 支持）、三阶段训练调度、`TemperatureScaler` 实现与可靠性评估工具。
+- 验收：`fit()` 可自动拆分验证集完成三阶段训练，`calibrate()` 使 ECE 明显下降，分类评估指标在示例数据上可追踪。
+
+### ✅ Task-3｜追加似然头（pos/count/ordinal）与数值稳定
+
+- 目标：补齐剩余分布头，保证数值稳定性与采样一致性，使 ELBO 可在多类型列上收敛。
+- 交付：`PosHead/CountHead/OrdinalHead` forward & 采样逻辑、Poisson/LogNormal/Ordinal NLL 推导、针对阈值与 rate 的 softplus/clamp 处理、对应单测。
+- 验收：启用新增列类型后 ELBO 可下降，单测校验数值一致性与缺失掩码处理。
+
+### ✅ Task-4｜评测闭环（TSTR/TRTR、MIA 基线）
+
+- 目标：构建合成数据评测与隐私基线，完善可视化与结果打包流程。
+- 交付：TSTR/TRTR 评测函数、membership inference 基线、ROC/PR/可靠性图工具、可复用的基线模型工厂。
+- 验收：API 在小数据上可运行至结束，返回包含 AUROC/AUPRC/Brier 等关键指标的 JSON 摘要。
+
+### ⏳ Task-5｜文档与示例强化
+
+- 目标：补全用户文档、示例脚本与 schema 工具集成，突出条件生成与评测流程。
+- 交付：完善 docstring、`examples/sepsis_minimal.py` 的端到端流程、schema dump/load 辅助工具、README 中的使用指南。
+- 验收：文档示例可直接运行生成校准曲线与潜变量可视化，用户可按 README 指引完成条件生成与 TSTR 评测。
 
 
-------
+## 3) 重要 feature 更新
 
-## 附：“分布映射”速查
-
-| HI-VAE TF 名     | PyTorch 目标                                            |
-| ---------------- | ------------------------------------------------------- |
-| `loglik_real`    | Gaussian：`Normal(mu, sqrt(var))`                       |
-| `loglik_pos`     | LogNormal：对 `log(1+x)` 高斯 NLL；采样 `exp(sample)-1` |
-| `loglik_cat`     | Categorical：`Categorical(logits)`                      |
-| `loglik_ordinal` | Cumulative-link：`softplus` 阈值 + `cumsum`             |
-| `loglik_count`   | Poisson：`Poisson(rate=softplus(raw))`                  |
-
-> 缺失处理：所有 NLL 都要 **乘 mask**；评估需返回 `log_px_missing`。
-
+- **分类损失权重自动调节**：`fit()` 会在联合微调阶段根据 warm-up ELBO 与验证集交叉熵自动推导分类损失权重，并在用户未显式传入时完成裁剪与回填，兼顾稳定性与易用性。【F:suave/model.py†L574-L604】【F:suave/model.py†L1188-L1228】
+- **超参启发式自动推荐**：默认设置会根据输入维度、样本规模与类别统计调用 `recommend_hyperparameters`，动态更新潜变量维度、隐藏层、dropout、学习率及训练日程等关键超参，并记录到 `auto_hyperparameters_` 便于排查。【F:suave/model.py†L619-L760】
+- **合成数据评估闭环**：`evaluate_tstr`/`evaluate_trtr` 与 `simple_membership_inference` 提供 TSTR/TRTR 指标、Brier/ECE 计算与隐私攻击基线，覆盖真实与合成数据的性能诊断需求。【F:suave/evaluate.py†L288-L370】【F:suave/evaluate.py†L373-L460】
+- **研究级 MIMIC/eICU 流水线**：`examples/research-mimic_mortality_supervised.py` 集成 Optuna 最优试验回放、特征工程缓存、基线模型、SUAVE 校准、TSTR/TRTR 与报告导出，支持住院死亡率等关键任务的全流程复现。【F:examples/research-mimic_mortality_supervised.py†L1-L200】

--- a/docs/research_protocol.md
+++ b/docs/research_protocol.md
@@ -1,0 +1,73 @@
+# 研究协议（Research Protocol）
+
+本文档汇总 SUAVE 项目的研究流程约定，帮助在不同数据集上复现实验、整理结果并产出可审计的研究报告。核心实现围绕四个示例脚本协同展开：
+
+- `examples/research-mimic_mortality_supervised.py`：监督学习主流程脚本，串联数据加载、特征工程、模型训练、校准与报告生成。
+- `examples/cls_eval.py`：分类评估工具，提供标准化指标计算与图表输出，支撑内部验证与外部评估。
+- `examples/mimic_mortality_utils.py`：特征构建、缺失值处理与 schema 校验等通用函数库，确保数据处理步骤可复用。
+- `examples/research-mimic_mortality_optimize.py`：Optuna 超参搜索入口，负责调度试验、记录最佳结果并供主流程读取。
+
+## MIMIC-IV 住院死亡率（监督）分析方案
+
+以下流程对齐 `examples/research-mimic_mortality_supervised.py` 的实现，目标是在 MIMIC-IV 住院患者的死亡率预测任务上复现 SUAVE 研究级评估，并生成可直接纳入技术报告的成果物。
+
+### 1. 研究目标与核心指标
+
+1. 主要目标：基于 ICU 入科时刻前 24h 内的结构化特征预测 `in_hospital_mortality`。
+2. 判定指标：AUROC/AUPRC 作为判别性能主指标，Brier Score 与校准曲线衡量概率校准，ECE 作为补充。
+3. 次要分析：eICU 外部验证集的一致性评估、合成数据 TSTR/TRTR、潜空间可视化及隐私基线。
+
+### 2. 数据来源与管理
+
+1. 训练/内部验证/测试使用 `examples/data/sepsis_mortality_dataset/` 中基于 **MIMIC-IV** 抽样生成的 `mimic-mortality-train.tsv` 与 `mimic-mortality-test.tsv`，其样本均为入院 24h 内满足 Sepsis-3 标准的住院患者。
+2. 外部验证集来自 eICU-CRD（`eicu-mortality-external_val.tsv`），采用与 MIMIC-IV 相同的纳入标准，同样聚焦于入院 24h 内满足 Sepsis-3 标准的患者。
+3. MIMIC-IV 测试集与 eICU 外部验证集仅用于最终评估，不参与 Optuna 搜索或其他超参选择流程。
+4. 所有 TSV 均需保留原始列名；脚本在 `analysis_outputs_supervised/` 下派生的缓存、插补产物与评估文件应纳入审计归档。
+
+### 3. 准备阶段
+
+1. 确认目标标签（默认 `in_hospital_mortality`）存在于 `TARGET_COLUMNS` 列表，并记录所有候选标签以备扩展分析。
+2. 建立输出目录 `examples/analysis_outputs_supervised/`，若 Optuna 存储不存在则自动创建；必要时备份历史运行的 best trial JSON。
+3. 若已有 Optuna trial 或 SUAVE 模型缓存，需在研究日志中记录其生成配置，以便差异分析。
+
+### 4. 数据加载与 Schema 校验
+
+1. 调用 `load_dataset` 读取 MIMIC-IV 训练/测试及 eICU 外部验证集的 TSV，确保无缺失列并保留原始数据类型。
+2. 通过 `define_schema(train_df, FEATURE_COLUMNS, mode="interactive")` 生成初始 schema；对 BMI、呼吸支持等级（`Respiratory_Support`）和淋巴细胞百分比（`LYM%`）执行人工修正，以保证类型一致性。
+3. 使用 `schema_to_dataframe` 与 `render_dataframe` 输出列类型摘要并保存截图/Markdown，作为数据说明附件的一部分。
+
+### 5. 特征构建与内部验证划分
+
+1. 采用 `prepare_features` 对训练集进行特征工程；随后调用 `train_test_split`（`VALIDATION_SIZE`、`RANDOM_STATE`）在训练集内部创建分层验证集。
+2. 对测试集与外部验证集复用同一特征处理函数，确保列顺序与训练集匹配，并将结果缓存至 `baseline_feature_frames`。
+3. 若后续分析扩展到其他标签，需要复用相同的特征转换并记录生成时间及校验摘要。
+
+### 6. 基线模型与对照实验
+
+1. 借助 `load_or_create_iteratively_imputed_features` 对各评估集执行迭代插补，生成可复用的 `*_imputed.joblib` 文件。
+2. 构建 Logistic Regression（带标准化）、KNN、Decision Tree、Random Forest 与 RBF-SVM 等 `Pipeline`，通过 `evaluate_transfer_baselines` 统一训练并评估。
+3. 输出的指标 CSV 与 Markdown 表格需包含训练/验证/测试/eICU 全量指标，若外部验证缺失标签需在脚注注明处理策略。
+
+### 7. SUAVE 模型构建、调参与训练
+
+1. 若存在历史最优 trial，优先读取 `optuna_best_params_{label}.json`；否则调用 `build_suave_model` 以默认超参初始化模型，并记录关键参数（latent_dim、beta、dropout 等）。
+2. 训练顺序遵循脚本：先执行 VAE warm-up，再进行分类头独立训练，最后 joint fine-tuning，必要时启用分类损失权重自动调节。
+3. 对于每个阶段，记录训练轮数、早停标准、最优模型路径以及 GPU/CPU 运行时长，用于技术报告的实验设置章节。
+
+### 8. 概率校准与不确定性量化
+
+1. 通过 `fit_isotonic_calibrator` 在内部验证集上拟合等渗校准器，必要时回退至逻辑回归温度缩放，并保存校准对象。
+2. 使用 `evaluate_predictions` 对训练、验证、MIMIC-IV 测试与 eICU 集执行 bootstrap（默认 1000 次）以估计指标置信区间，并生成 Excel 汇总。
+3. 运行 `simple_membership_inference` 获得隐私攻击基线，将结果写入研究报告的风险评估章节。
+
+### 9. 合成数据（TSTR/TRTR）与分布漂移分析
+
+1. 调用 `build_tstr_training_sets` 创建真实与合成训练集，并通过 `make_baseline_model_factories` 构建一致的下游分类器族。
+2. 使用 `plot_transfer_metric_bars`、`kolmogorov_smirnov_statistic`、`rbf_mmd` 与 `mutual_information_feature` 评估分布一致性。
+3. 所有 TRTR/TSTR 指标、KS/MMD/互信息结果应保存为 CSV 与可视化 PNG，纳入附录及复现包。
+
+### 10. 潜空间可视化、报告生成与归档
+
+1. 借助 `plot_latent_space` 对潜空间执行 PCA/UMAP（视脚本配置）投影，输出训练、验证、测试与外部集的可视化比较。
+2. 使用 `dataframe_to_markdown`、`render_dataframe` 与 `write_results_to_excel_unique` 汇总评估结果，最终通过 `build_prediction_dataframe` 与 `evaluate_predictions` 生成 `evaluation_summary_{label}.md` 技术报告草稿。
+3. 在归档目录保留所有原始数据引用、模型权重（`.pt`/`.joblib`）、插补缓存、图表、Markdown 报告及运行日志，以支持第三方审计与论文附录撰写。


### PR DESCRIPTION
## Summary
- expand the roadmap to reflect the new defaults/schema tooling and research evaluation pipeline
- add a research protocol entry detailing the MIMIC-III supervised mortality analysis workflow
- clarify the research protocol introduction with the roles of the supervised mortality scripts
- document the Sepsis-3 inclusion criteria, and state that external and test cohorts are reserved for evaluation only
- add an AGENTS note to keep the research protocol synced with example workflow updates

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68d507d424f483208375fa29526f7e1b