### PR TITLE
Refine energy distance weighting and encoding

### DIFF
--- a/README-CN.md
+++ b/README-CN.md
@@ -170,7 +170,7 @@ mi_unit = mutual_information_feature(real_unit.values, synthetic_unit.values)
 attack = simple_membership_inference(train_probs, train_labels, test_probs, test_labels)
 ```
 
-`evaluate_tstr` / `evaluate_trtr` 可以搭配任意监督模型验证迁移性能；`classifier_two_sample_test` 接收一个模型工厂映射（默认组合 XGBoost 主模型与逻辑回归敏感性分析），而 RBF-MMD 与互信息则聚焦单个特征的差异程度。C2ST AUC 接近 `0.5`、MMD 接近 `0.0`、互信息接近 `0` 通常表示较好的拟合。成员推断攻击给出区分训练样本与保留样本的 AUROC 与准确率，用于监控潜在的隐私泄露。
+`evaluate_tstr` / `evaluate_trtr` 可以搭配任意监督模型验证迁移性能；`classifier_two_sample_test` 接收一个模型工厂映射（默认组合 XGBoost 主模型与逻辑回归敏感性分析），而 RBF-MMD、按维度归一的欧氏 + 汉明能量距离（支持置换检验 `p` 值）以及互信息则聚焦单个特征的差异程度。C2ST AUC 接近 `0.5`、MMD/能量距离接近 `0.0`、互信息接近 `0` 通常表示较好的拟合。成员推断攻击给出区分训练样本与保留样本的 AUROC 与准确率，用于监控潜在的隐私泄露。
 
 ### 潜变量编码
 

--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ mi_unit = mutual_information_feature(real_unit.values, synthetic_unit.values)
 attack = simple_membership_inference(train_probs, train_labels, test_probs, test_labels)
 ```
 
-The `evaluate_tstr`/`evaluate_trtr` pair supports model-agnostic baselines for benchmarking synthetic cohorts. `classifier_two_sample_test` accepts a mapping of estimator factories—by default we pair an XGBoost endpoint with a logistic regression sensitivity check—while the RBF-MMD and mutual information helpers quantify per-feature fidelity. Low C2ST AUCs (≈`0.5`), low MMD (≈`0.0`), and near-zero mutual information indicate strong alignment; larger values call for manual inspection. The membership attack reports AUROC and accuracy for separating training members from held-out data, highlighting potential privacy leakage.
+The `evaluate_tstr`/`evaluate_trtr` pair supports model-agnostic baselines for benchmarking synthetic cohorts. `classifier_two_sample_test` accepts a mapping of estimator factories—by default we pair an XGBoost endpoint with a logistic regression sensitivity check—while the RBF-MMD, energy distance (dimension-normalised Euclidean + Hamming with optional permutation `p`-values), and mutual information helpers quantify per-feature fidelity. Low C2ST AUCs (≈`0.5`), low MMD/energy distance (≈`0.0`), and near-zero mutual information indicate strong alignment; larger values call for manual inspection. The membership attack reports AUROC and accuracy for separating training members from held-out data, highlighting potential privacy leakage.
 
 ### Latent representations
 

--- a/docs/Roadmap.md
+++ b/docs/Roadmap.md
@@ -175,5 +175,5 @@ reloaded = SUAVE.load("path/to/ckpt")
 
 - **分类损失权重自动调节**：`fit()` 会在联合微调阶段根据 warm-up ELBO 与验证集交叉熵自动推导分类损失权重，并在用户未显式传入时完成裁剪与回填，兼顾稳定性与易用性。【F:suave/model.py†L574-L604】【F:suave/model.py†L1188-L1228】
 - **超参启发式自动推荐**：默认设置会根据输入维度、样本规模与类别统计调用 `recommend_hyperparameters`，动态更新潜变量维度、隐藏层、dropout、学习率及训练日程等关键超参，并记录到 `auto_hyperparameters_` 便于排查。【F:suave/model.py†L619-L760】
-- **合成数据评估闭环**：`evaluate_tstr`/`evaluate_trtr` 与 `simple_membership_inference` 提供 TSTR/TRTR 指标、Brier/ECE 计算与隐私攻击基线，覆盖真实与合成数据的性能诊断需求。【F:suave/evaluate.py†L288-L370】【F:suave/evaluate.py†L373-L460】
+- **合成数据评估闭环**：`evaluate_tstr`/`evaluate_trtr`、`rbf_mmd`/`energy_distance` 以及 `simple_membership_inference` 覆盖 TSTR/TRTR 指标、按维度归一的 MMD/能量距离（含置换检验）、Brier/ECE 计算与隐私攻击基线，满足真实与合成数据的性能诊断需求。【F:suave/evaluate.py†L288-L370】【F:suave/evaluate.py†L1032-L1566】
 - **研究级 MIMIC/eICU 流水线**：`examples/research-mimic_mortality_supervised.py` 集成 Optuna 最优试验回放、特征工程缓存、基线模型、SUAVE 校准、TSTR/TRTR 与报告导出，支持住院死亡率等关键任务的全流程复现。【F:examples/research-mimic_mortality_supervised.py†L1-L200】


### PR DESCRIPTION
## Summary
- normalise energy distance continuous/categorical contributions, encode categories via shared codes, and lower the default sample cap while computing pairwise distances in blocks
- extend the energy distance test suite to cover categorical normalisation, shared level alignment, and continuous scaling heuristics
- document the dimension-normalised energy distance behaviour in both READMEs and the roadmap

## Testing
- PYTHONPATH=. pytest tests/test_evaluate_metrics.py

------
https://chatgpt.com/codex/tasks/task_e_68d58e1addbc8320a45eebcc8f2da55f