### PR TITLE
Refine supervised research outputs and add distribution shift visuals

### DIFF
--- a/docs/research_protocol.md
+++ b/docs/research_protocol.md
@@ -22,12 +22,12 @@
 1. 训练/内部验证/测试使用 `examples/data/sepsis_mortality_dataset/` 中基于 **MIMIC-IV** 抽样生成的 `mimic-mortality-train.tsv` 与 `mimic-mortality-test.tsv`，其样本均为入院 24h 内满足 Sepsis-3 标准的住院患者。
 2. 外部验证集来自 eICU-CRD（`eicu-mortality-external_val.tsv`），采用与 MIMIC-IV 相同的纳入标准，同样聚焦于入院 24h 内满足 Sepsis-3 标准的患者。
 3. MIMIC-IV 测试集与 eICU 外部验证集仅用于最终评估，不参与 Optuna 搜索或其他超参选择流程。
-4. 所有 TSV 均需保留原始列名；脚本在 `analysis_outputs_supervised/` 下派生的缓存、插补产物与评估文件应纳入审计归档。
+4. 所有 TSV 均需保留原始列名；脚本在 `research_outputs_supervised/` 下按阶段划分的子目录（如 `optuna/`、`model_training/`、`evaluation/`、`distribution_shift/` 等）会生成缓存、插补产物与评估文件，应整体纳入审计归档。
 
 ### 3. 准备阶段
 
 1. 确认目标标签（默认 `in_hospital_mortality`）存在于 `TARGET_COLUMNS` 列表，并记录所有候选标签以备扩展分析。
-2. 建立输出目录 `examples/analysis_outputs_supervised/`，若 Optuna 存储不存在则自动创建；必要时备份历史运行的 best trial JSON。
+2. 建立输出目录 `examples/research_outputs_supervised/`，同时创建 `optuna/`、`model_training/`、`evaluation/`、`synthetic_transfer/`、`distribution_shift/`、`privacy/` 等子目录区分各阶段产物；若 Optuna 存储不存在则自动创建，并在 `optuna/` 下放置 SQLite 数据库与 JSON 缓存。必要时备份历史运行的 best trial JSON。
 3. 若已有 Optuna trial 或 SUAVE 模型缓存，需在研究日志中记录其生成配置，以便差异分析。
 
 ### 4. 数据加载与 Schema 校验
@@ -60,21 +60,22 @@
 
 1. 通过 `fit_isotonic_calibrator` 在内部验证集上拟合等渗校准器，必要时回退至逻辑回归温度缩放，并保存校准对象。
 2. 使用 `evaluate_predictions` 对训练、验证、MIMIC-IV 测试与 eICU 集执行 bootstrap（默认 1000 次）以估计指标置信区间，并生成 Excel 汇总；除表格主列的 AUC、ACC、SPE、SEN、Brier 外，Excel 中还会给出 `accuracy`、`balanced_accuracy`、`f1_macro`、`recall_macro`、`specificity_macro`、`sensitivity_pos`、`specificity_pos`、`roc_auc`、`pr_auc` 及其置信区间，以支撑不同风险偏好的诊断分析。
-3. 将生成的 `evaluation_metrics.csv`、校准曲线 PNG 等评估产物写入输出目录，并在实验日志中登记路径，便于后续报告引用与审计复核。
+3. 将生成的 `evaluation_metrics.csv`、校准曲线图（PNG/SVG/PDF/JPG 四种格式）等评估产物写入 `evaluation/` 子目录，并在实验日志中登记路径，便于后续报告引用与审计复核。
 
 ### 9. 合成数据（TSTR/TRTR）与分布漂移分析
 
 1. 调用 `build_tstr_training_sets` 创建 `TRTR (real)`、`TSTR synthesis`、`TSTR synthesis-balance`、`TSTR synthesis-augment`、`TSTR synthesis-5x` 与 `TSTR synthesis-5x balance` 等方案，并在评估阶段对照 MIMIC-IV 测试集及（若标签可用）eICU 外部验证集。
 2. 通过 `make_baseline_model_factories` 注册 `Logistic regression`、`Random forest` 与 `XGBoost` 三类下游分类器，对每个训练方案分别拟合并在 `evaluate_transfer_baselines` 中统计 `accuracy` 与 `roc_auc`（含置信区间）。
 3. 分布漂移的主要结局指标采用 `classifier_two_sample_test`：以 `TRTR (real)` 与 `TSTR synthesis` 作为两类样本，使用 XGBoost 分类器执行 C2ST 并报告 ROC-AUC 及 95% bootstrap 置信区间；同一流程下的逻辑回归 AUC 作为次要敏感性指标。
-4. `rbf_mmd` 与 `mutual_information_feature` 继续按特征逐列计算，用于辅助定位非单调差异或潜在信息泄露风险的列，并与 C2ST 结果交叉验证。
-5. `plot_transfer_metric_bars` 负责绘制 TSTR/TRTR 方案在 `accuracy`、`roc_auc` 等指标上的分组柱状图（含置信区间），展示不同生成数据训练集对下游分类器的影响；其输出与分布漂移指标无直接对应关系，应单列在报告的“生成数据迁移性能”小节中说明。
-6. 在生成数据性能分析后运行 `simple_membership_inference`，补充隐私攻击基线并记录攻击 AUC/阈值，支撑隐私风险评估章节。
-7. 所有 TRTR/TSTR 指标、C2ST 结果及 MMD/互信息指标应保存为 CSV 与可视化 PNG，纳入附录及复现包。
+4. 次要结局指标包括全局 `rbf_mmd` 与 `energy_distance`，均基于置换检验给出 `p` 值，用于量化生成数据与真实分布之间的整体偏移程度。
+5. `rbf_mmd`、`energy_distance` 与 `mutual_information_feature` 继续按特征逐列计算，定位非单调差异或潜在信息泄露风险的列，并与 C2ST 结果交叉验证。
+6. `plot_transfer_metric_bars` 负责绘制 TSTR/TRTR 方案在 `accuracy`、`roc_auc` 等指标上的分组柱状图（含置信区间），展示不同生成数据训练集对下游分类器的影响；图像会在 `synthetic_transfer/` 中以 PNG/SVG/PDF/JPG 四种格式保存，其输出与分布漂移指标无直接对应关系，应单列在报告的“生成数据迁移性能”小节中说明。
+7. 在生成数据性能分析后运行 `simple_membership_inference`，补充隐私攻击基线并记录攻击 AUC/阈值，支撑隐私风险评估章节。
+8. 所有 TRTR/TSTR 指标、C2ST 结果及分布漂移指标需导出至同一个 Excel 工作簿：`overall` 工作表整合 C2ST 与全局 MMD/能量距离统计，`per_feature` 工作表罗列逐列 MMD/能量距离/互信息；同时在 `distribution_shift/` 子目录输出全局诊断与逐特征互信息图（PNG/SVG/PDF/JPG 四种格式），便于附录展示与审计复核。
 
 
 ### 10. 潜空间可视化、报告生成与归档
 
-1. 借助 `plot_latent_space` 对潜空间执行 PCA/UMAP（视脚本配置）投影，输出训练、验证、测试与外部集的可视化比较。
+1. 借助 `plot_latent_space` 对潜空间执行 PCA/UMAP（视脚本配置）投影，输出训练、验证、测试与外部集的可视化比较，图像统一保存在 `visualizations/` 子目录下，并生成 PNG/SVG/PDF/JPG 四种格式。
 2. 使用 `dataframe_to_markdown`、`render_dataframe` 与 `write_results_to_excel_unique` 汇总评估结果，最终通过 `build_prediction_dataframe` 与 `evaluate_predictions` 生成 `evaluation_summary_{label}.md` 技术报告草稿。
-3. 在归档目录保留所有原始数据引用、模型权重（`.pt`/`.joblib`）、插补缓存、图表、Markdown 报告及运行日志，以支持第三方审计与论文附录撰写。
+3. 在归档目录保留所有原始数据引用、模型权重（`.pt`/`.joblib`）、插补缓存、图表、Markdown 报告及运行日志，以支持第三方审计与论文附录撰写；`research_outputs_supervised/` 根目录仅存放整体总结（如 `optimisation_summary_*.md`、`evaluation_summary_*.md`），其余产物归类于对应子目录。

--- a/examples/research-mimic_mortality_supervised.py
+++ b/examples/research-mimic_mortality_supervised.py
@@ -53,6 +53,7 @@ from mimic_mortality_utils import (  # noqa: E402
     load_or_create_iteratively_imputed_features,
     make_baseline_model_factories,
     plot_benchmark_curves,
+    plot_distribution_shift_diagnostics,
     plot_calibration_curves,
     plot_latent_space,
     plot_transfer_metric_bars,
@@ -65,6 +66,7 @@ from cls_eval import evaluate_predictions, write_results_to_excel_unique  # noqa
 
 from suave.evaluate import (  # noqa: E402
     classifier_two_sample_test,
+    energy_distance,
     mutual_information_feature,
     rbf_mmd,
     simple_membership_inference,
@@ -88,7 +90,7 @@ analysis_config = {
     "optuna_timeout": 3600 * 48,
     "optuna_study_prefix": "supervised",
     "optuna_storage": None,
-    "output_dir_name": "analysis_outputs_supervised",
+    "output_dir_name": "research_outputs_supervised",
 }
 
 
@@ -104,9 +106,31 @@ analysis_config = {
 DATA_DIR = (EXAMPLES_DIR / "data" / "sepsis_mortality_dataset").resolve()
 OUTPUT_DIR = EXAMPLES_DIR / analysis_config["output_dir_name"]
 OUTPUT_DIR.mkdir(exist_ok=True)
-analysis_config["optuna_storage"] = (
-    f"sqlite:///{OUTPUT_DIR}/{analysis_config['optuna_study_prefix']}_optuna.db"
+OUTPUT_SUBDIRS = {
+    "feature_engineering": OUTPUT_DIR / "feature_engineering",
+    "baselines": OUTPUT_DIR / "baselines",
+    "optuna": OUTPUT_DIR / "optuna",
+    "model": OUTPUT_DIR / "model_training",
+    "evaluation": OUTPUT_DIR / "evaluation",
+    "synthetic": OUTPUT_DIR / "synthetic_transfer",
+    "distribution": OUTPUT_DIR / "distribution_shift",
+    "privacy": OUTPUT_DIR / "privacy",
+    "visualizations": OUTPUT_DIR / "visualizations",
+}
+for path in OUTPUT_SUBDIRS.values():
+    path.mkdir(parents=True, exist_ok=True)
+optuna_db_path = (
+    OUTPUT_SUBDIRS["optuna"] / f"{analysis_config['optuna_study_prefix']}_optuna.db"
 )
+analysis_config["optuna_storage"] = f"sqlite:///{optuna_db_path}"
+
+
+def describe_multiformat(path_stem: Path) -> str:
+    """Return a readable reference for multi-format figure outputs."""
+
+    relative = path_stem.with_suffix("").relative_to(OUTPUT_DIR)
+    return f"{relative}.[png/svg/pdf/jpg]"
+
 
 train_df = load_dataset(DATA_DIR / "mimic-mortality-train.tsv")
 test_df = load_dataset(DATA_DIR / "mimic-mortality-test.tsv")
@@ -330,7 +354,7 @@ if external_features is not None:
     baseline_loaded_from_cache,
 ) = load_or_create_iteratively_imputed_features(
     baseline_feature_frames,
-    output_dir=OUTPUT_DIR,
+    output_dir=OUTPUT_SUBDIRS["feature_engineering"],
     target_label=TARGET_LABEL,
     reference_key="Train",
 )
@@ -439,7 +463,7 @@ for model_name, estimator in baseline_models.items():
 baseline_df = pd.DataFrame(baseline_rows)
 baseline_order = ["Model", "Dataset", *metric_columns, "Notes"]
 baseline_df = baseline_df.loc[:, baseline_order]
-baseline_path = OUTPUT_DIR / f"baseline_models_{TARGET_LABEL}.csv"
+baseline_path = OUTPUT_SUBDIRS["baselines"] / f"baseline_models_{TARGET_LABEL}.csv"
 baseline_df.to_csv(baseline_path, index=False)
 render_dataframe(
     baseline_df,
@@ -456,12 +480,12 @@ render_dataframe(
 # %%
 
 optuna_best_info, optuna_best_params = load_optuna_results(
-    OUTPUT_DIR,
+    OUTPUT_SUBDIRS["optuna"],
     TARGET_LABEL,
     study_prefix=analysis_config.get("optuna_study_prefix"),
     storage=analysis_config.get("optuna_storage"),
 )
-optuna_trials_path = OUTPUT_DIR / f"optuna_trials_{TARGET_LABEL}.csv"
+optuna_trials_path = OUTPUT_SUBDIRS["optuna"] / f"optuna_trials_{TARGET_LABEL}.csv"
 
 if not optuna_best_params:
     print(
@@ -479,8 +503,8 @@ if not optuna_best_params:
 
 # %%
 
-model_path = OUTPUT_DIR / f"suave_best_{TARGET_LABEL}.pt"
-calibrator_path = OUTPUT_DIR / f"isotonic_calibrator_{TARGET_LABEL}.joblib"
+model_path = OUTPUT_SUBDIRS["model"] / f"suave_best_{TARGET_LABEL}.pt"
+calibrator_path = OUTPUT_SUBDIRS["model"] / f"isotonic_calibrator_{TARGET_LABEL}.joblib"
 
 model: Optional[SUAVE] = None
 calibrator: Optional[Any] = None
@@ -574,7 +598,7 @@ existing_columns = [
 ]
 if existing_columns:
     metrics_df = metrics_df.loc[:, existing_columns]
-metrics_path = OUTPUT_DIR / "evaluation_metrics.csv"
+metrics_path = OUTPUT_SUBDIRS["evaluation"] / "evaluation_metrics.csv"
 metrics_df.to_csv(metrics_path, index=False)
 render_dataframe(
     metrics_df,
@@ -582,9 +606,12 @@ render_dataframe(
     floatfmt=".3f",
 )
 
-calibration_path = OUTPUT_DIR / f"calibration_{TARGET_LABEL}.png"
-plot_calibration_curves(
-    probability_map, label_map, target_name=TARGET_LABEL, output_path=calibration_path
+calibration_base = OUTPUT_SUBDIRS["evaluation"] / f"calibration_{TARGET_LABEL}"
+calibration_path = plot_calibration_curves(
+    probability_map,
+    label_map,
+    target_name=TARGET_LABEL,
+    output_path=calibration_base,
 )
 
 # %% [markdown]
@@ -620,7 +647,7 @@ for dataset_name in benchmark_datasets:
         dataset_name,
         label_map[dataset_name],
         model_probabilities,
-        output_dir=OUTPUT_DIR,
+        output_dir=OUTPUT_SUBDIRS["evaluation"],
         target_label=TARGET_LABEL,
         abbreviation_lookup=model_abbreviation_lookup,
     )
@@ -697,20 +724,26 @@ for dataset_name, (features, labels) in evaluation_datasets.items():
 
 bootstrap_overall_df = pd.concat(bootstrap_overall_frames, ignore_index=True)
 bootstrap_per_class_df = pd.concat(bootstrap_per_class_frames, ignore_index=True)
-bootstrap_overall_path = OUTPUT_DIR / f"bootstrap_overall_{TARGET_LABEL}.csv"
-bootstrap_per_class_path = OUTPUT_DIR / f"bootstrap_per_class_{TARGET_LABEL}.csv"
+bootstrap_overall_path = (
+    OUTPUT_SUBDIRS["evaluation"] / f"bootstrap_overall_{TARGET_LABEL}.csv"
+)
+bootstrap_per_class_path = (
+    OUTPUT_SUBDIRS["evaluation"] / f"bootstrap_per_class_{TARGET_LABEL}.csv"
+)
 bootstrap_overall_df.to_csv(bootstrap_overall_path, index=False)
 bootstrap_per_class_df.to_csv(bootstrap_per_class_path, index=False)
 
 bootstrap_warning_path: Optional[Path]
 if bootstrap_warnings_frames:
     bootstrap_warning_df = pd.concat(bootstrap_warnings_frames, ignore_index=True)
-    bootstrap_warning_path = OUTPUT_DIR / f"bootstrap_warnings_{TARGET_LABEL}.csv"
+    bootstrap_warning_path = (
+        OUTPUT_SUBDIRS["evaluation"] / f"bootstrap_warnings_{TARGET_LABEL}.csv"
+    )
     bootstrap_warning_df.to_csv(bootstrap_warning_path, index=False)
 else:
     bootstrap_warning_path = None
 
-bootstrap_excel_path = OUTPUT_DIR / f"bootstrap_{TARGET_LABEL}.xlsx"
+bootstrap_excel_path = OUTPUT_SUBDIRS["evaluation"] / f"bootstrap_{TARGET_LABEL}.xlsx"
 write_results_to_excel_unique(
     bootstrap_results,
     str(bootstrap_excel_path),
@@ -740,7 +773,9 @@ for metric_name in summary_metric_candidates:
             summary_columns.append(high_col)
 
 bootstrap_summary_df = bootstrap_overall_df.loc[:, summary_columns]
-bootstrap_summary_path = OUTPUT_DIR / f"bootstrap_summary_{TARGET_LABEL}.csv"
+bootstrap_summary_path = (
+    OUTPUT_SUBDIRS["evaluation"] / f"bootstrap_summary_{TARGET_LABEL}.csv"
+)
 bootstrap_summary_df.to_csv(bootstrap_summary_path, index=False)
 render_dataframe(
     bootstrap_summary_df,
@@ -766,6 +801,8 @@ tstr_figure_paths: List[Path] = []
 distribution_df: Optional[pd.DataFrame] = None
 distribution_path: Optional[Path] = None
 distribution_top: Optional[pd.DataFrame] = None
+distribution_figure_stems: Dict[str, Path] = {}
+membership_path = OUTPUT_SUBDIRS["privacy"] / "membership_inference.csv"
 
 if TARGET_LABEL != "in_hospital_mortality":
     print(
@@ -828,8 +865,12 @@ else:
         raw_training_sets=training_sets_raw,
         raw_evaluation_sets=evaluation_sets_raw,
     )
-    tstr_summary_path = OUTPUT_DIR / f"tstr_trtr_summary_{TARGET_LABEL}.csv"
-    tstr_plot_path = OUTPUT_DIR / f"tstr_trtr_plot_data_{TARGET_LABEL}.csv"
+    tstr_summary_path = (
+        OUTPUT_SUBDIRS["synthetic"] / f"tstr_trtr_summary_{TARGET_LABEL}.csv"
+    )
+    tstr_plot_path = (
+        OUTPUT_SUBDIRS["synthetic"] / f"tstr_trtr_plot_data_{TARGET_LABEL}.csv"
+    )
     tstr_summary_df.to_csv(tstr_summary_path, index=False)
     tstr_plot_df.to_csv(tstr_plot_path, index=False)
     render_dataframe(
@@ -848,7 +889,7 @@ else:
                 evaluation_dataset=evaluation_name,
                 training_order=training_order,
                 model_order=model_order,
-                output_dir=OUTPUT_DIR,
+                output_dir=OUTPUT_SUBDIRS["synthetic"],
                 target_label=TARGET_LABEL,
             )
             if figure_path is not None:
@@ -901,11 +942,41 @@ else:
         n_bootstrap=1000,
     )
     c2st_df = pd.DataFrame([{"target": TARGET_LABEL, **c2st_metrics}])
-    c2st_path = OUTPUT_DIR / "c2st_distribution_test.csv"
+    c2st_path = OUTPUT_SUBDIRS["distribution"] / "c2st_distribution_test.csv"
     c2st_df.to_csv(c2st_path, index=False)
     render_dataframe(
         c2st_df,
         title="Classifier two-sample test (C2ST)",
+        floatfmt=".3f",
+    )
+
+    global_mmd, global_mmd_p_value = rbf_mmd(
+        real_features_numeric,
+        synthesis_features_numeric,
+        random_state=RANDOM_STATE,
+        n_permutations=200,
+    )
+    global_energy, global_energy_p_value = energy_distance(
+        real_features_numeric,
+        synthesis_features_numeric,
+        random_state=RANDOM_STATE,
+        n_permutations=200,
+    )
+    distribution_overall_df = pd.DataFrame(
+        [
+            {
+                "target": TARGET_LABEL,
+                "global_mmd": global_mmd,
+                "global_mmd_p_value": global_mmd_p_value,
+                "global_energy_distance": global_energy,
+                "global_energy_p_value": global_energy_p_value,
+                **c2st_metrics,
+            }
+        ]
+    )
+    render_dataframe(
+        distribution_overall_df,
+        title="Distribution shift overview",
         floatfmt=".3f",
     )
 
@@ -919,19 +990,30 @@ else:
             random_state=RANDOM_STATE,
             n_permutations=200,
         )
+        energy_value, _ = energy_distance(
+            real_values,
+            synthetic_values,
+            random_state=RANDOM_STATE,
+            n_permutations=0,
+        )
         distribution_rows.append(
             {
                 "feature": column,
                 "mmd": mmd_value,
                 "mmd_p_value": mmd_p,
+                "energy_distance": energy_value,
                 "mutual_information": mutual_information_feature(
                     real_values, synthetic_values
                 ),
             }
         )
     distribution_df = pd.DataFrame(distribution_rows)
-    distribution_path = OUTPUT_DIR / "distribution_shift_metrics.csv"
-    distribution_df.to_csv(distribution_path, index=False)
+    distribution_path = (
+        OUTPUT_SUBDIRS["distribution"] / "distribution_shift_metrics.xlsx"
+    )
+    with pd.ExcelWriter(distribution_path) as writer:
+        distribution_overall_df.to_excel(writer, sheet_name="overall", index=False)
+        distribution_df.to_excel(writer, sheet_name="per_feature", index=False)
     distribution_top = (
         distribution_df.sort_values("mutual_information", ascending=False)
         .head(10)
@@ -941,6 +1023,13 @@ else:
         distribution_top,
         title="Top distribution shift features (mutual information)",
         floatfmt=".3f",
+    )
+    distribution_figure_stems = plot_distribution_shift_diagnostics(
+        distribution_overall_df,
+        distribution_df,
+        output_dir=OUTPUT_SUBDIRS["distribution"],
+        target_label=TARGET_LABEL,
+        top_n=10,
     )
 
     train_probabilities = probability_map["Train"]
@@ -952,7 +1041,7 @@ else:
         np.asarray(y_test),
     )
     membership_df = pd.DataFrame([{"target": TARGET_LABEL, **membership_metrics}])
-    membership_path = OUTPUT_DIR / "membership_inference.csv"
+    membership_path = OUTPUT_SUBDIRS["privacy"] / "membership_inference.csv"
     membership_df.to_csv(membership_path, index=False)
     render_dataframe(
         membership_df,
@@ -973,13 +1062,13 @@ latent_features = {
     name: features for name, (features, _) in evaluation_datasets.items()
 }
 latent_labels = {name: labels for name, (_, labels) in evaluation_datasets.items()}
-latent_path = OUTPUT_DIR / f"latent_{TARGET_LABEL}.png"
-plot_latent_space(
+latent_base = OUTPUT_SUBDIRS["visualizations"] / f"latent_{TARGET_LABEL}"
+latent_path = plot_latent_space(
     model,
     latent_features,
     latent_labels,
     target_name=TARGET_LABEL,
-    output_path=latent_path,
+    output_path=latent_base,
 )
 
 
@@ -1051,8 +1140,10 @@ summary_lines.append(dataframe_to_markdown(metrics_summary_df, floatfmt=".3f"))
 summary_lines.append(
     f"Optuna trials logged at: {optuna_trials_path.relative_to(OUTPUT_DIR)}"
 )
-summary_lines.append(f"Calibration plot: {calibration_path.relative_to(OUTPUT_DIR)}")
-summary_lines.append(f"Latent projection: {latent_path.relative_to(OUTPUT_DIR)}")
+if calibration_path is not None:
+    summary_lines.append(f"Calibration plot: {describe_multiformat(calibration_path)}")
+if latent_path is not None:
+    summary_lines.append(f"Latent projection: {describe_multiformat(latent_path)}")
 summary_lines.append("")
 
 summary_lines.append("Bootstrap evaluation artefacts:")
@@ -1085,7 +1176,7 @@ if tstr_summary_df is not None and tstr_summary_path is not None:
     if tstr_plot_path is not None:
         summary_lines.append(f"- Plot data: {tstr_plot_path.relative_to(OUTPUT_DIR)}")
     for figure_path in tstr_figure_paths:
-        summary_lines.append(f"- Figure: {figure_path.relative_to(OUTPUT_DIR)}")
+        summary_lines.append(f"- Figure: {describe_multiformat(figure_path)}")
     summary_lines.append("")
 
 summary_lines.append("## Distribution shift and privacy")
@@ -1093,13 +1184,18 @@ if distribution_df is not None and distribution_path is not None:
     summary_lines.append(
         f"- Distribution metrics: {distribution_path.relative_to(OUTPUT_DIR)}"
     )
+    summary_lines.append(f"- C2ST metrics: {c2st_path.relative_to(OUTPUT_DIR)}")
+for name, figure_path in distribution_figure_stems.items():
+    summary_lines.append(
+        f"- {name.replace('_', ' ').title()} plot: {describe_multiformat(figure_path)}"
+    )
 if membership_path.exists():
     summary_lines.append(
         f"- Membership inference: {membership_path.relative_to(OUTPUT_DIR)}"
     )
 summary_lines.append(f"- Baseline metrics: {baseline_path.relative_to(OUTPUT_DIR)}")
 for figure_path in benchmark_curve_paths:
-    summary_lines.append(f"- Benchmark curves: {figure_path.relative_to(OUTPUT_DIR)}")
+    summary_lines.append(f"- Benchmark curves: {describe_multiformat(figure_path)}")
 summary_lines.append("")
 
 summary_path = OUTPUT_DIR / f"evaluation_summary_{TARGET_LABEL}.md"


### PR DESCRIPTION
## Summary
- route supervised research artefacts into dedicated subdirectories under `examples/research_outputs_supervised` and adjust the pipeline summaries to reference multi-format figures
- extend the distribution shift stage with reusable plotting utilities that export global and per-feature diagnostics in PNG/SVG/PDF/JPG formats alongside the Excel workbook
- update the optimisation script and research protocol to mirror the new directory layout and document the expanded visual reporting requirements

## Testing
- black examples/mimic_mortality_utils.py examples/research-mimic_mortality_supervised.py examples/research-mimic_mortality_optimize.py
- ruff check examples/mimic_mortality_utils.py examples/research-mimic_mortality_supervised.py examples/research-mimic_mortality_optimize.py

------
https://chatgpt.com/codex/tasks/task_e_68d59554f92883209392fba4237d3c05