### PR TITLE
Adjust imputer settings and expand component search

### DIFF
--- a/examples/mimic_mortality_utils.py
+++ b/examples/mimic_mortality_utils.py
@@ -260,7 +260,7 @@ def load_or_create_iteratively_imputed_features(
     from sklearn.experimental import enable_iterative_imputer  # noqa: F401
     from sklearn.impute import IterativeImputer
 
-    imputer = IterativeImputer()
+    imputer = IterativeImputer(max_iter=50, tol=1e-2)
     imputer.fit(feature_sets[reference_key])
 
     imputed_features: Dict[str, pd.DataFrame] = {}
@@ -289,7 +289,7 @@ def make_logistic_pipeline(random_state: Optional[int] = None) -> Pipeline:
 
     return Pipeline(
         [
-            ("imputer", IterativeImputer()),
+            ("imputer", IterativeImputer(max_iter=50, tol=1e-2)),
             ("scaler", StandardScaler()),
             (
                 "classifier",
@@ -314,7 +314,7 @@ def make_random_forest_pipeline(random_state: Optional[int] = None) -> Pipeline:
 
     return Pipeline(
         [
-            ("imputer", IterativeImputer()),
+            ("imputer", IterativeImputer(max_iter=50, tol=1e-2)),
             (
                 "classifier",
                 RandomForestClassifier(
@@ -343,7 +343,7 @@ def make_xgboost_pipeline(random_state: Optional[int] = None) -> Pipeline:
 
     return Pipeline(
         [
-            ("imputer", IterativeImputer()),
+            ("imputer", IterativeImputer(max_iter=50, tol=1e-2)),
             (
                 "classifier",
                 XGBClassifier(

--- a/examples/research-mimic_mortality_optimize.py
+++ b/examples/research-mimic_mortality_optimize.py
@@ -151,7 +151,7 @@ def run_optuna_search(
 
     def objective(trial: "optuna.trial.Trial") -> Tuple[float, float]:
         trial.suggest_categorical("latent_dim", [8, 16, 24, 32, 48, 64])
-        trial.suggest_categorical("n_components", [1, 2, 4, 6])
+        trial.suggest_int("n_components", 1, 10)
         trial.suggest_categorical("hidden_dims", list(HIDDEN_DIMENSION_OPTIONS.keys()))
         trial.suggest_categorical(
             "head_hidden_dims", list(HEAD_HIDDEN_DIMENSION_OPTIONS.keys())


### PR DESCRIPTION
## Summary
- increase the iterative imputer iterations and tolerance used for cached features and evaluation pipelines
- expand the Optuna search space for the number of PCA components

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d5d0af55b8832094a3784d86abb647