### PR TITLE
Add Optuna diagnostics and latent correlation visuals

### DIFF
--- a/docs/research_protocol.md
+++ b/docs/research_protocol.md
@@ -56,6 +56,8 @@
 1. 若存在历史最优 trial，优先读取 `optuna_best_params_{label}.json`；否则调用 `build_suave_model` 以默认超参初始化模型，并记录关键参数（latent_dim、beta、dropout 等）。
 2. 训练顺序遵循脚本：先执行 VAE warm-up，再进行分类头独立训练，最后 joint fine-tuning，必要时启用分类损失权重自动调节。
 3. 对于每个阶段，记录训练轮数、早停标准、最优模型路径以及 GPU/CPU 运行时长，用于技术报告的实验设置章节。
+4. Optuna 搜索完成后需导出参数重要性、最优值收敛轨迹与多目标帕累托前沿图（均保存为 PNG/SVG/PDF/JPG），便于后续调参与审计复核；默认输出位于 `03_optuna_search/figures/`。
+5. Trial 级别的搜索记录需写入 `optuna_trials_{label}.csv` 并在日志中展示前 10 个验证集 AUROC 最优的 trial，确保调参轨迹透明可追溯。
 
 ### 8. 概率校准与不确定性量化
 
@@ -80,3 +82,4 @@
 1. 借助 `plot_latent_space` 对潜空间执行 PCA/UMAP（视脚本配置）投影，输出训练、验证、测试与外部集的可视化比较。
 2. 使用 `dataframe_to_markdown`、`render_dataframe` 与 `write_results_to_excel_unique` 汇总评估结果，最终通过 `build_prediction_dataframe` 与 `evaluate_predictions` 生成 `evaluation_summary_{label}.md` 技术报告草稿。
 3. 在归档目录保留所有原始数据引用、模型权重（`.pt`/`.joblib`）、插补缓存、图表、Markdown 报告及运行日志，以支持第三方审计与论文附录撰写。
+4. 在潜空间解释章节补充潜空间-临床特征相关性热图，并将对应 CSV 导出至 `11_visualizations/`，以量化隐空间与关键临床变量的线性关联。

--- a/examples/research-mimic_mortality_optimize.py
+++ b/examples/research-mimic_mortality_optimize.py
@@ -419,6 +419,18 @@ study, optuna_best_info, optuna_diagnostics = run_optuna_search(
     diagnostics_dir=OPTUNA_DIR / "figures",
 )
 
+best_trial_values = optuna_best_info.get("values", (float("nan"), float("nan")))
+print(
+    "\nBest Optuna trial:"
+    f" #{optuna_best_info.get('trial_number', 'N/A')}"
+    f" | Validation ROAUC: {best_trial_values[0]:.4f}"
+    f" | TSTR/TRTR ΔAUC: {best_trial_values[1]:.4f}"
+)
+if optuna_best_info.get("params"):
+    print("Selected hyperparameters:")
+    for key, value in sorted(optuna_best_info["params"].items()):
+        print(f"  - {key}: {value}")
+
 trial_rows: list[dict[str, object]] = []
 for trial in study.trials:
     values = trial.values or (float("nan"), float("nan"))


### PR DESCRIPTION
## Summary
- add reusable helper that exports Optuna parameter importance, optimisation history, and Pareto diagnostics in multi-format outputs and log the top trials
- extend the supervised workflow with a latent-versus-clinical correlation heatmap plus CSV export and include the artefact in the autogenerated summary
- document the updated research protocol steps covering new Optuna diagnostics, trial reporting, and latent correlation deliverables

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d5e01e328483208494e083d1c314ee