### PR TITLE
Document mortality workflows, abbreviate path graph labels, and fix Pareto fallback selection

### DIFF
--- a/examples/mimic_mortality_utils.py
+++ b/examples/mimic_mortality_utils.py
@@ -776,14 +776,15 @@ def choose_preferred_pareto_trial(
     if constrained:
         return max(constrained, key=lambda trial: _objective_values(trial)[0])
 
-    eligible = [
-        trial
-        for trial in trials
-        if np.isfinite(_objective_values(trial)[0])
-        and _objective_values(trial)[0] > min_validation_roauc
-    ]
+    eligible: List[Tuple[float, "optuna.trial.FrozenTrial"]] = []
+    for trial in trials:
+        primary, _ = _objective_values(trial)
+        if np.isfinite(primary) and primary > min_validation_roauc:
+            # Track each eligible trial alongside its validation ROC-AUC so we can
+            # deterministically recover the strongest performer.
+            eligible.append((primary, trial))
     if eligible:
-        return eligible[0]
+        return max(eligible, key=lambda item: item[0])[1]
 
     return max(trials, key=lambda trial: _objective_values(trial)[0])
 


### PR DESCRIPTION
## Summary
- document the interactive versus script-mode behaviour for the supervised mortality workflow and clarify that the optimisation run behaves identically in both contexts
- abbreviate long path-graph node labels with standard clinical shorthand to improve plot readability while preserving latex where appropriate
- ensure the Pareto fallback helper returns the highest validation ROC-AUC trial when constraints are relaxed

## Testing
- black examples/mimic_mortality_utils.py

------
https://chatgpt.com/codex/tasks/task_e_68d6e68f23d483208c3335ee722935b0