### PR TITLE
Fix Optuna figure saving for research mortality optimisation

### DIFF
--- a/examples/research-mimic_mortality_optimize.py
+++ b/examples/research-mimic_mortality_optimize.py
@@ -154,8 +154,17 @@ def _target_accessor(index: int) -> Callable[["optuna.trial.FrozenTrial"], float
     return _target
 
 
-def _save_optuna_figure(figure: "plt.Figure", output_path: Path) -> Path:
+def _save_optuna_figure(figure_or_axes: "plt.Figure", output_path: Path) -> Path:
     """Persist Optuna diagnostic figures in multiple formats."""
+
+    # Optuna's Matplotlib helpers return ``Axes`` instances while our utility
+    # expects a ``Figure``. Normalise the object so saving succeeds regardless
+    # of the exact return type.
+    figure = getattr(figure_or_axes, "figure", figure_or_axes)
+    if not hasattr(figure, "savefig"):
+        raise TypeError(
+            "Unsupported Matplotlib object returned from Optuna visualisation"
+        )
 
     _save_figure_multiformat(figure, output_path.with_suffix(""))
     plt.close(figure)


### PR DESCRIPTION
## Summary
- normalise Optuna visualisation outputs so figure saving handles both Figures and Axes
- add explicit error handling for unsupported Matplotlib objects before writing diagnostics

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d6ee544b288320acafbf1eada277fe