### PR TITLE
Replace decision tree benchmark with gradient boosting

### DIFF
--- a/docs/research_protocol.md
+++ b/docs/research_protocol.md
@@ -46,7 +46,7 @@
 ### 6. 基线模型与对照实验
 
 1. 借助 `load_or_create_iteratively_imputed_features` 对各评估集执行迭代插补，生成可复用的 `*_imputed.joblib` 文件。
-2. 构建 Logistic Regression（带标准化）、KNN、Decision Tree、Random Forest 与 RBF-SVM 等 `Pipeline`，通过 `evaluate_transfer_baselines` 统一训练并评估；所有基线共享 `compute_binary_metrics` 统计 AUC、ACC、SPE、SEN 与 Brier，并写入 `baseline_models_{label}.csv`。
+2. 构建 Logistic Regression（带标准化）、KNN、Gradient Boosting、Random Forest 与 RBF-SVM 等 `Pipeline`，通过 `evaluate_transfer_baselines` 统一训练并评估；所有基线共享 `compute_binary_metrics` 统计 AUC、ACC、SPE、SEN 与 Brier，并写入 `baseline_models_{label}.csv`。
 3. 脚本在 `07_baseline_models/` 下缓存拟合后的 `baseline_estimators_{label}.joblib`，二次运行时默认复用；若需强制重新训练，可在执行前设置 `FORCE_UPDATE_BENCHMARK_MODEL=1`（默认为 `0`）。相关布尔参数统一通过 `mimic_mortality_utils.read_bool_env_flag` 解析，以便批量实验脚本复用。
 4. 在临床基准方面，保留传统 ICU 评分（如数据集中现成的 SOFA 及相关器官支持指标）作为零参数对照：当 `mimic_mortality_utils.py` 中登记了此类 `baseline_probability_map` 项时，同样纳入基线汇总并在 `Notes` 中标记“临床评分”。
 5. 输出的指标 CSV 与 Markdown 表格需包含训练/验证/测试/eICU 全量指标，若外部验证缺失标签需在脚注注明处理策略。

--- a/examples/research-mimic_mortality_supervised.py
+++ b/examples/research-mimic_mortality_supervised.py
@@ -36,14 +36,13 @@ import matplotlib.pyplot as plt
 import joblib
 import numpy as np
 import pandas as pd
-from sklearn.ensemble import RandomForestClassifier
+from sklearn.ensemble import GradientBoostingClassifier, RandomForestClassifier
 from sklearn.linear_model import LogisticRegression
 from sklearn.model_selection import train_test_split
 from sklearn.neighbors import KNeighborsClassifier
 from sklearn.pipeline import Pipeline
 from sklearn.preprocessing import StandardScaler
 from sklearn.svm import SVC
-from sklearn.tree import DecisionTreeClassifier
 
 EXAMPLES_DIR = Path(__file__).resolve().parent
 if not EXAMPLES_DIR.exists():
@@ -389,9 +388,12 @@ baseline_models: Dict[str, Pipeline] = {
             ("classifier", KNeighborsClassifier(n_neighbors=25)),
         ]
     ),
-    "Decision tree": Pipeline(
+    "Gradient boosting": Pipeline(
         [
-            ("classifier", DecisionTreeClassifier(random_state=RANDOM_STATE)),
+            (
+                "classifier",
+                GradientBoostingClassifier(random_state=RANDOM_STATE),
+            ),
         ]
     ),
     "Random forest": Pipeline(
@@ -430,7 +432,7 @@ baseline_probability_map: Dict[str, Dict[str, np.ndarray]] = {
 model_abbreviation_lookup = {
     "Logistic regression": "LR",
     "KNN": "KNN",
-    "Decision tree": "DT",
+    "Gradient boosting": "GB",
     "Random forest": "RF",
     "SVM (RBF)": "SVM",
 }


### PR DESCRIPTION
## Summary
- replace the decision tree baseline in the supervised mortality research workflow with gradient boosting to reduce overfitting risk and keep abbreviations consistent
- update the research protocol documentation to reflect the revised benchmark model roster

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d7a8db82288320ae376f90d2d6c4a6