### PR TITLE
Align prediction DataFrame label and prediction dtypes

### DIFF
--- a/examples/mimic_mortality_utils.py
+++ b/examples/mimic_mortality_utils.py
@@ -2355,10 +2355,21 @@ def build_prediction_dataframe(
                 for idx in range(prob_matrix.shape[1])
             }
 
+    label_array = np.asarray(labels)
+    prediction_array = np.asarray(predictions)
+    if prediction_array.dtype != label_array.dtype:
+        try:
+            label_array = label_array.astype(prediction_array.dtype, copy=False)
+        except (TypeError, ValueError):
+            try:
+                prediction_array = prediction_array.astype(label_array.dtype, copy=False)
+            except (TypeError, ValueError):
+                label_array = label_array.astype(object)
+                prediction_array = prediction_array.astype(object)
     base_df = pd.DataFrame(
         {
-            "label": np.asarray(labels),
-            "y_pred": np.asarray(predictions),
+            "label": label_array,
+            "y_pred": prediction_array,
         }
     )
     if proba_dict:


### PR DESCRIPTION
## Summary
- ensure `build_prediction_dataframe` converts label and prediction inputs to numpy arrays and synchronises their dtypes before building the evaluation DataFrame
- add a final object-cast fallback so downstream evaluation sees matching class identifiers even when external labels are boolean

## Testing
- `python - <<'PY'` (logistic regression bootstrap sanity check for the eICU cohort)


------
https://chatgpt.com/codex/tasks/task_e_68d7a88c4f5883209c3d3243435184c9