### PR TITLE
Handle fully missing clinical score columns during iterative imputation

### DIFF
--- a/examples/mimic_mortality_utils.py
+++ b/examples/mimic_mortality_utils.py
@@ -1546,11 +1546,14 @@ def iteratively_impute_clinical_scores(
     reference_features = feature_frames[reference_key]
 
     for column in available_columns:
+        reference_column = reference_scores[column]
+        if reference_column.isna().all():
+            continue
         imputer = IterativeImputer(max_iter=100, tol=1e-2)
         training_matrix = pd.concat(
             [
                 reference_features.reset_index(drop=True),
-                reference_scores[[column]].reset_index(drop=True),
+                reference_column.to_frame().reset_index(drop=True),
             ],
             axis=1,
         )


### PR DESCRIPTION
## Summary
- skip fitting the iterative imputer when the reference cohort has no observations for a requested score

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d7f192b3f0832098ddc6e3a3d839d9