### PR TITLE
Fix joblib loading recursion for isotonic calibrator

### DIFF
--- a/examples/mimic_mortality_utils.py
+++ b/examples/mimic_mortality_utils.py
@@ -2248,7 +2248,17 @@ class IsotonicProbabilityCalibrator:
         return self.classes_[indices]
 
     def __getattr__(self, name: str) -> Any:  # pragma: no cover - simple proxy
-        return getattr(self.base_estimator, name)
+        try:
+            base = object.__getattribute__(self, "base_estimator")
+        except AttributeError as exc:
+            raise AttributeError(
+                f"{type(self).__name__!s} has no attribute {name!r}"
+            ) from exc
+        if base is None or base is self:
+            raise AttributeError(
+                f"{type(self).__name__!s} has no attribute {name!r}"
+            )
+        return getattr(base, name)
 
 
 def fit_isotonic_calibrator(

--- a/research_template/analysis_utils.py
+++ b/research_template/analysis_utils.py
@@ -2248,7 +2248,17 @@ class IsotonicProbabilityCalibrator:
         return self.classes_[indices]
 
     def __getattr__(self, name: str) -> Any:  # pragma: no cover - simple proxy
-        return getattr(self.base_estimator, name)
+        try:
+            base = object.__getattribute__(self, "base_estimator")
+        except AttributeError as exc:
+            raise AttributeError(
+                f"{type(self).__name__!s} has no attribute {name!r}"
+            ) from exc
+        if base is None or base is self:
+            raise AttributeError(
+                f"{type(self).__name__!s} has no attribute {name!r}"
+            )
+        return getattr(base, name)
 
 
 def fit_isotonic_calibrator(


### PR DESCRIPTION
## Summary
- prevent the isotonic calibrator proxy from recursively delegating attribute lookups during unpickling
- mirror the defensive lookup logic in the research template utilities

## Testing
- python - <<'PY'
  import sys, types
  sys.modules.setdefault('IPython', types.SimpleNamespace(display=lambda *a, **k: None, get_ipython=lambda: None))
  sys.modules.setdefault('IPython.display', types.SimpleNamespace(display=lambda *a, **k: None))
  import joblib
  from pathlib import Path
  from SUAVE.examples.mimic_mortality_utils import IsotonicProbabilityCalibrator

  class DummyIso:
      def predict(self, X):
          return [0.8 for _ in X]

  class DummyModel:
      def __init__(self):
          self.value = 42
      def predict_proba(self, X):
          return [[0.2, 0.8] for _ in X]

  cal = IsotonicProbabilityCalibrator(DummyModel(), DummyIso(), [0, 1])
  assert cal.value == 42
  path = Path('tmp_cal.joblib')
  joblib.dump(cal, path)
  loaded = joblib.load(path)
  assert loaded.value == 42
  path.unlink()
  print('ok')
  PY

------
https://chatgpt.com/codex/tasks/task_e_68d7f7a63e7083209e7ea14e8544cff1