### PR TITLE
Add optional bootstrap progress bar to evaluation pipeline

### DIFF
--- a/examples/research-mimic_mortality_supervised.py
+++ b/examples/research-mimic_mortality_supervised.py
@@ -1070,6 +1070,8 @@ for model_name, dataset_tables in model_prediction_frames.items():
             positive_label=positive_label_name,
             bootstrap_n=1000,
             random_state=RANDOM_STATE,
+            show_progress=True,
+            progress_desc=f"Bootstrap | {model_name} @ {dataset_name}",
         )
         model_results[dataset_name] = results
 

--- a/research_template/research-supervised_analysis.py
+++ b/research_template/research-supervised_analysis.py
@@ -1070,6 +1070,8 @@ for model_name, dataset_tables in model_prediction_frames.items():
             positive_label=positive_label_name,
             bootstrap_n=1000,
             random_state=RANDOM_STATE,
+            show_progress=True,
+            progress_desc=f"Bootstrap | {model_name} @ {dataset_name}",
         )
         model_results[dataset_name] = results
 


### PR DESCRIPTION
## Summary
- add a `show_progress` flag to `evaluate_predictions` so bootstrap iterations can display a tqdm progress bar with contextual descriptions
- surface bootstrap progress for each model and dataset in the supervised analysis workflow templates

## Testing
- not run (documentation and plumbing change only)


------
https://chatgpt.com/codex/tasks/task_e_68d8004f34008320b6245becc7ead1d0