### PR TITLE
Add bootstrap caching and consolidated benchmark export

### DIFF
--- a/examples/mimic_mortality_utils.py
+++ b/examples/mimic_mortality_utils.py
@@ -114,10 +114,11 @@ DEFAULT_ANALYSIS_CONFIG: Dict[str, object] = {
 #: are unavailable, allowing callers to refresh the locally persisted SUAVE
 #: model that otherwise acts as a fallback.
 FORCE_UPDATE_FLAG_DEFAULTS: Dict[str, bool] = {
-    "FORCE_UPDATE_BENCHMARK_MODEL": False,
+    "FORCE_UPDATE_BENCHMARK_MODEL": True,
     "FORCE_UPDATE_TSTR_MODEL": True,
     "FORCE_UPDATE_TRTR_MODEL": True,
     "FORCE_UPDATE_SUAVE": False,
+    "FORCE_UPDATE_BOOTSTRAP": True,
 }
 
 ANALYSIS_SUBDIRECTORIES: Dict[str, str] = {

--- a/examples/research-mimic_mortality_supervised.py
+++ b/examples/research-mimic_mortality_supervised.py
@@ -138,22 +138,10 @@ IS_INTERACTIVE = is_interactive_session()
 
 cache_default = not IS_INTERACTIVE
 
-FORCE_UPDATE_BENCHMARK_MODEL = read_bool_env_flag(
-    "FORCE_UPDATE_BENCHMARK_MODEL",
-    cache_default,
-)
-FORCE_UPDATE_TSTR_MODEL = read_bool_env_flag(
-    "FORCE_UPDATE_TSTR_MODEL",
-    cache_default,
-)
-FORCE_UPDATE_TRTR_MODEL = read_bool_env_flag(
-    "FORCE_UPDATE_TRTR_MODEL",
-    cache_default,
-)
-FORCE_UPDATE_BOOTSTRAP = read_bool_env_flag(
-    "FORCE_UPDATE_BOOTSTRAP",
-    cache_default,
-)
+FORCE_UPDATE_BENCHMARK_MODEL = cache_default
+FORCE_UPDATE_TSTR_MODEL = cache_default
+FORCE_UPDATE_TRTR_MODEL = cache_default
+FORCE_UPDATE_BOOTSTRAP = cache_default
 FORCE_UPDATE_SUAVE = read_bool_env_flag(
     "FORCE_UPDATE_SUAVE",
     FORCE_UPDATE_FLAG_DEFAULTS["FORCE_UPDATE_SUAVE"],

--- a/research_template/analysis_utils.py
+++ b/research_template/analysis_utils.py
@@ -114,10 +114,11 @@ DEFAULT_ANALYSIS_CONFIG: Dict[str, object] = {
 #: are unavailable, allowing callers to refresh the locally persisted SUAVE
 #: model that otherwise acts as a fallback.
 FORCE_UPDATE_FLAG_DEFAULTS: Dict[str, bool] = {
-    "FORCE_UPDATE_BENCHMARK_MODEL": False,
+    "FORCE_UPDATE_BENCHMARK_MODEL": True,
     "FORCE_UPDATE_TSTR_MODEL": True,
     "FORCE_UPDATE_TRTR_MODEL": True,
     "FORCE_UPDATE_SUAVE": False,
+    "FORCE_UPDATE_BOOTSTRAP": True,
 }
 
 ANALYSIS_SUBDIRECTORIES: Dict[str, str] = {

--- a/research_template/research-supervised_analysis.py
+++ b/research_template/research-supervised_analysis.py
@@ -138,22 +138,10 @@ IS_INTERACTIVE = is_interactive_session()
 
 cache_default = not IS_INTERACTIVE
 
-FORCE_UPDATE_BENCHMARK_MODEL = read_bool_env_flag(
-    "FORCE_UPDATE_BENCHMARK_MODEL",
-    cache_default,
-)
-FORCE_UPDATE_TSTR_MODEL = read_bool_env_flag(
-    "FORCE_UPDATE_TSTR_MODEL",
-    cache_default,
-)
-FORCE_UPDATE_TRTR_MODEL = read_bool_env_flag(
-    "FORCE_UPDATE_TRTR_MODEL",
-    cache_default,
-)
-FORCE_UPDATE_BOOTSTRAP = read_bool_env_flag(
-    "FORCE_UPDATE_BOOTSTRAP",
-    cache_default,
-)
+FORCE_UPDATE_BENCHMARK_MODEL = cache_default
+FORCE_UPDATE_TSTR_MODEL = cache_default
+FORCE_UPDATE_TRTR_MODEL = cache_default
+FORCE_UPDATE_BOOTSTRAP = cache_default
 FORCE_UPDATE_SUAVE = read_bool_env_flag(
     "FORCE_UPDATE_SUAVE",
     FORCE_UPDATE_FLAG_DEFAULTS["FORCE_UPDATE_SUAVE"],


### PR DESCRIPTION
## Summary
- add FORCE_UPDATE_BOOTSTRAP defaults and make non-SUAVE FORCE_UPDATE flags default to cached behaviour in interactive mode while forcing refresh in script mode
- cache per-dataset bootstrap evaluations and reuse them unless FORCE_UPDATE_BOOTSTRAP is set
- export consolidated bootstrap benchmark workbooks with Summary/overall/Perclass/Warnings sheets for all models and datasets

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d80dde82e08320abe4d55367800915