### PR TITLE
Add three-line Excel formatting utility for bootstrap benchmarks

### DIFF
--- a/examples/research-mimic_mortality_supervised.py
+++ b/examples/research-mimic_mortality_supervised.py
@@ -111,7 +111,11 @@ from mimic_mortality_utils import (  # noqa: E402
     _interpret_feature_shift,
     _interpret_global_shift,
 )
-from cls_eval import evaluate_predictions, write_results_to_excel_unique  # noqa: E402
+from cls_eval import (  # noqa: E402
+    evaluate_predictions,
+    write_results_to_excel_unique,
+    export_three_line_tables,
+)
 
 from suave.evaluate import (  # noqa: E402
     classifier_two_sample_test,
@@ -1430,6 +1434,37 @@ with pd.ExcelWriter(benchmark_excel_path) as writer:
     bootstrap_warning_df.to_excel(writer, sheet_name="Warnings", index=False)
 
 print("Saved consolidated bootstrap benchmark workbook to", benchmark_excel_path)
+
+three_line_benchmark_path = benchmark_excel_path.with_name(
+    f"{benchmark_excel_path.stem}_three_line.xlsx"
+)
+
+perclass_index_columns = ["Model"]
+if "class" in bootstrap_per_class_df.columns:
+    perclass_index_columns.append("class")
+elif "Class" in bootstrap_per_class_df.columns:
+    perclass_index_columns.append("Class")
+
+export_three_line_tables(
+    {
+        "Summary": bootstrap_summary_df,
+        "overall": bootstrap_overall_df,
+        "Perclass": bootstrap_per_class_df,
+    },
+    three_line_benchmark_path,
+    index_columns={
+        "Summary": ["Model"],
+        "overall": ["Model"],
+        "Perclass": perclass_index_columns,
+    },
+    dataset_column="Dataset",
+    dataset_order=required_datasets,
+    drop_columns=("Target",),
+    decimals=3,
+    ci_label_text="95%",
+)
+
+print("Saved formatted three-line benchmark workbook to", three_line_benchmark_path)
 # %% [markdown]
 # ## Synthetic data – TSTR/TRTR, distribution shift, and privacy
 #

--- a/research_template/research-supervised_analysis.py
+++ b/research_template/research-supervised_analysis.py
@@ -117,7 +117,11 @@ from analysis_utils import (  # noqa: E402
     _interpret_feature_shift,
     _interpret_global_shift,
 )
-from cls_eval import evaluate_predictions, write_results_to_excel_unique  # noqa: E402
+from cls_eval import (  # noqa: E402
+    evaluate_predictions,
+    write_results_to_excel_unique,
+    export_three_line_tables,
+)
 
 from suave.evaluate import (  # noqa: E402
     classifier_two_sample_test,
@@ -1428,6 +1432,37 @@ with pd.ExcelWriter(benchmark_excel_path) as writer:
     bootstrap_warning_df.to_excel(writer, sheet_name="Warnings", index=False)
 
 print("Saved consolidated bootstrap benchmark workbook to", benchmark_excel_path)
+
+three_line_benchmark_path = benchmark_excel_path.with_name(
+    f"{benchmark_excel_path.stem}_three_line.xlsx"
+)
+
+perclass_index_columns = ["Model"]
+if "class" in bootstrap_per_class_df.columns:
+    perclass_index_columns.append("class")
+elif "Class" in bootstrap_per_class_df.columns:
+    perclass_index_columns.append("Class")
+
+export_three_line_tables(
+    {
+        "Summary": bootstrap_summary_df,
+        "overall": bootstrap_overall_df,
+        "Perclass": bootstrap_per_class_df,
+    },
+    three_line_benchmark_path,
+    index_columns={
+        "Summary": ["Model"],
+        "overall": ["Model"],
+        "Perclass": perclass_index_columns,
+    },
+    dataset_column="Dataset",
+    dataset_order=required_datasets,
+    drop_columns=("Target",),
+    decimals=3,
+    ci_label_text="95%",
+)
+
+print("Saved formatted three-line benchmark workbook to", three_line_benchmark_path)
 # %% [markdown]
 # ## TSTR/TRTR, distribution shift, and privacy checks
 #


### PR DESCRIPTION
## Summary
- add a reusable three-line table exporter that formats metrics, confidence intervals, and workbook styling for benchmark sheets
- hook the supervised analysis notebooks to emit a formatted bootstrap benchmark workbook alongside the raw export

## Testing
- python -m compileall research_template/cls_eval.py
- python -m compileall research_template/research-supervised_analysis.py examples/research-mimic_mortality_supervised.py

------
https://chatgpt.com/codex/tasks/task_e_68d897a702588320a639c26a95fc3a72