### PR TITLE
Unify manual override evaluation and prompt behaviour

### DIFF
--- a/docs/research_protocol.md
+++ b/docs/research_protocol.md
@@ -105,9 +105,11 @@ print(train_labels.head())</code></pre>
 3. 对于每个阶段，记录训练轮数、早停标准、最优模型路径以及 GPU/CPU 运行时长，用于技术报告的实验设置章节。
 4. Optuna 搜索完成后需导出参数重要性、最优值收敛轨迹与多目标帕累托前沿图（均保存为 PNG/SVG/PDF/JPG），便于后续调参与审计复核；默认输出位于 `03_optuna_search/figures/`。
 5. Trial 级别的搜索记录需写入 `optuna_trials_{label}.csv` 并在日志中展示前 10 个验证集 AUROC 最优的 trial，确保调参轨迹透明可追溯。帕累托前沿的完整元数据与指标同步保存于 `optuna_best_info_{label}.json`，供后续复核和多 trial 对比分析。
-6. `research-mimic_mortality_supervised.py` 在交互模式下会读取 Optuna 帕累托前沿并列出各 trial 的验证集 AUROC、TSTR/TRTR ΔAUC 与本地模型保存状态，等待人工输入 trial ID 以加载或重新训练；脚本模式可通过 `--trial-id`（或位置参数）指定目标 trial，若未提供则优先加载最近一次保存的模型，缺失时再按照硬阈值（AUROC>0.81、|ΔAUC|<0.035）自动选取帕累托前沿解重训模型。
-7. Optuna 优化脚本会在 `04_suave_training/` 下生成 `suave_model_manifest_{label}.json`，记录 trial 编号、目标函数值与模型/校准器路径；主流程在加载前需校验 manifest 所指向的 artefact 是否存在，不满足时回退至最近一次保存的权重或触发重新训练；当触发重新训练时会自动将新的 SUAVE 权重写入 `suave_best_{label}.pt` 以恢复后续运行的缓存链路。
-8. 若 Optuna study 与最佳参数均缺失，可设置环境变量 `FORCE_UPDATE_SUAVE=1` 强制刷新本地备份模型；该开关仅在 Optuna artefact 不可用时生效，用于确保重新训练覆盖旧的 SUAVE 权重。
+6. `research-mimic_mortality_supervised.py` 在交互模式下会读取 Optuna 帕累托前沿并列出各 trial 的验证集 AUROC、TSTR/TRTR ΔAUC 与本地模型保存状态，等待人工输入 trial ID 以加载或重新训练；脚本模式可通过 `--trial-id`（或位置参数）指定目标 trial，新增的 `manual` 关键字会加载人工登记的模型与校准器。若未提供参数，脚本会先检查 `suave_manual_manifest_{label}.json` 是否存在手动覆盖，其次复用最近一次保存的自动 trial，仍缺失时再按照硬阈值（AUROC>0.81、|ΔAUC|<0.035）自动选取帕累托前沿解重训模型。
+7. 在创建 `04_suave_training/` 目录时，脚本会自动生成（或补全）`manual_param_setting.py` 占位文件，并写入 `manual_param_setting: dict = {}` 默认体以便登记人工覆写的超参；若启用 `build_analysis_config()` 返回的 `interactive_manual_tuning` 配置，可在该字典中填入新的学习率、权重衰减等局部参数并即时生效。
+8. Optuna 优化脚本会在 `04_suave_training/` 下生成 `suave_model_manifest_{label}.json`，记录 trial 编号、目标函数值与模型/校准器路径；主流程在加载前需校验 manifest 所指向的 artefact 是否存在，不满足时回退至最近一次保存的权重或触发重新训练；当触发重新训练时会自动将新的 SUAVE 权重写入 `suave_best_{label}.pt` 以恢复后续运行的缓存链路。若以手动模式覆写模型与校准器，脚本也会同步生成/更新 `suave_manual_manifest_{label}.json`，确保后续运行能优先加载指定的手动 artefact。启用 `interactive_manual_tuning` 后，交互式运行优化脚本会在执行 Optuna 之前展示手动模型及既有 Pareto trial 摘要，并接受 `y/yes`（按当前覆写配置直接训练并登记手动模型）、`manual`（跳过搜索复用磁盘上的手动 artefact）或 `n/no`/回车（继续自动搜索）的输入；若在提示过程中触发键盘中断，脚本会提示确认是否直接回退至 Optuna 搜索。
+9. 手动覆写与 Optuna trial 的指标计算均调用 `examples/mimic_mortality_utils.py`（研究模板对应 `research_template/analysis_utils.py`）中的 `evaluate_candidate_model_performance`，该函数统一完成验证集指标、TSTR/TRTR 评估与 ΔAUC 计算。当需要调整模型评估逻辑时，只需修改这一函数即可同时覆盖手动与自动流程。
+10. 若 Optuna study 与最佳参数均缺失，可设置环境变量 `FORCE_UPDATE_SUAVE=1` 强制刷新本地备份模型；该开关仅在 Optuna artefact 不可用时生效，用于确保重新训练覆盖旧的 SUAVE 权重。
 
 ### 8. 分类/校准评估与不确定性量化（Bootstrap）
 

--- a/examples/mimic_mortality_utils.py
+++ b/examples/mimic_mortality_utils.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import argparse
 import hashlib
+import importlib
+import importlib.util
 import math
 import os
 import sys
@@ -22,6 +24,7 @@ from typing import (
     Sequence,
     Tuple,
     Union,
+    cast,
 )
 
 import joblib
@@ -62,6 +65,8 @@ from suave import Schema, SchemaInferencer, SUAVE  # noqa: E402
 from suave.evaluate import (  # noqa: E402
     compute_auroc,
     evaluate_classification,
+    evaluate_tstr,
+    evaluate_trtr,
     kolmogorov_smirnov_statistic,
     mutual_information_feature,
     rbf_mmd,
@@ -129,6 +134,12 @@ HEAD_HIDDEN_DIMENSION_OPTIONS: Dict[str, Tuple[int, ...]] = {
     "deep": (128, 64, 32),
 }
 
+INTERACTIVE_MANUAL_TUNING: Dict[str, str] = {
+    "module": "manual_param_setting",
+    "attribute": "manual_param_setting",
+}
+
+
 DEFAULT_ANALYSIS_CONFIG: Dict[str, object] = {
     "optuna_trials": 20,
     "optuna_timeout": 3600 * 48,
@@ -144,6 +155,7 @@ DEFAULT_ANALYSIS_CONFIG: Dict[str, object] = {
         "delta_roc_auc": "ΔAUROC",
     },
     "training_color_palette": None,
+    "interactive_manual_tuning": INTERACTIVE_MANUAL_TUNING,
 }
 
 #: Default script-mode flags that determine whether cached artefacts should be
@@ -345,6 +357,7 @@ def build_analysis_config(**overrides: object) -> Dict[str, object]:
     config = dict(DEFAULT_ANALYSIS_CONFIG)
     config.update(overrides)
     config.setdefault("optuna_storage", None)
+    config.setdefault("interactive_manual_tuning", INTERACTIVE_MANUAL_TUNING)
     return config
 
 
@@ -362,7 +375,31 @@ def prepare_analysis_output_directories(
         path = output_root / subdir_name
         path.mkdir(parents=True, exist_ok=True)
         directories[key] = path
+        if subdir_name == ANALYSIS_SUBDIRECTORIES.get("suave_model"):
+            _initialise_manual_param_script(path)
     return directories
+
+
+def _initialise_manual_param_script(directory: Path) -> None:
+    """Ensure ``manual_param_setting.py`` exists with a default placeholder."""
+
+    script_path = directory / "manual_param_setting.py"
+    default_content = (
+        '"""Manual hyper-parameter overrides for SUAVE training.\n\n'
+        "Populate ``manual_param_setting`` with overrides when interactive tuning is enabled.\n"
+        '"""\n\n'
+        "manual_param_setting: dict = {}\n"
+    )
+
+    if script_path.exists():
+        try:
+            existing = script_path.read_text(encoding="utf-8")
+        except OSError:
+            existing = None
+        if existing and existing.strip():
+            return
+
+    script_path.write_text(default_content, encoding="utf-8")
 
 
 def resolve_analysis_output_root(
@@ -423,10 +460,17 @@ __all__ = [
     "PATH_GRAPH_NODE_COLORS",
     "choose_preferred_pareto_trial",
     "load_model_manifest",
+    "load_manual_model_manifest",
     "load_optuna_results",
     "manifest_artifact_paths",
     "manifest_artifacts_exist",
     "record_model_manifest",
+    "record_manual_model_manifest",
+    "collect_manual_and_optuna_overview",
+    "load_manual_tuning_overrides",
+    "prompt_manual_override_action",
+    "evaluate_candidate_model_performance",
+    "run_manual_override_training",
     "build_prediction_dataframe",
     "compute_auc",
     "compute_binary_metrics",
@@ -457,6 +501,7 @@ __all__ = [
     "rbf_mmd",
     "make_study_name",
     "DEFAULT_ANALYSIS_CONFIG",
+    "INTERACTIVE_MANUAL_TUNING",
     "ANALYSIS_SUBDIRECTORIES",
     "build_analysis_config",
     "prepare_analysis_output_directories",
@@ -694,7 +739,7 @@ def record_model_manifest(
     model_dir: Path,
     target_label: str,
     *,
-    trial_number: Optional[int],
+    trial_number: Optional[Union[str, int]],
     values: Sequence[float],
     params: Mapping[str, object],
     model_path: Path,
@@ -711,7 +756,7 @@ def record_model_manifest(
     target_label
         Prediction target associated with the artefacts.
     trial_number
-        Optuna trial identifier used to train the artefacts.
+        Optuna trial identifier or override label used to train the artefacts.
     values
         Objective values reported by Optuna for the selected trial.
     params
@@ -772,6 +817,153 @@ def record_model_manifest(
     return manifest_path
 
 
+def load_manual_model_manifest(model_dir: Path, target_label: str) -> Dict[str, object]:
+    """Load metadata describing manually managed SUAVE artefacts.
+
+    Parameters
+    ----------
+    model_dir
+        Directory storing SUAVE checkpoints and calibrators.
+    target_label
+        Name of the prediction target the artefacts correspond to.
+
+    Returns
+    -------
+    dict
+        Manifest metadata. An empty dictionary is returned when no manual
+        manifest is present on disk.
+
+    Examples
+    --------
+    >>> tmp = Path("/tmp/manual_manifest")
+    >>> _ = tmp.mkdir(parents=True, exist_ok=True)
+    >>> load_manual_model_manifest(tmp, "mortality")
+    {}
+    """
+
+    manifest_path = model_dir / f"suave_manual_manifest_{target_label}.json"
+    if not manifest_path.exists():
+        return {}
+    return json.loads(manifest_path.read_text())
+
+
+def record_manual_model_manifest(
+    model_dir: Path,
+    target_label: str,
+    *,
+    model_path: Path,
+    calibrator_path: Optional[Path] = None,
+    params: Optional[Mapping[str, object]] = None,
+    values: Optional[Sequence[float]] = None,
+    validation_metrics: Optional[Mapping[str, object]] = None,
+    tstr_metrics: Optional[Mapping[str, object]] = None,
+    trtr_metrics: Optional[Mapping[str, object]] = None,
+    description: Optional[str] = None,
+) -> Path:
+    """Persist metadata describing manually managed SUAVE artefacts.
+
+    Parameters
+    ----------
+    model_dir
+        Directory storing SUAVE checkpoints and calibrators.
+    target_label
+        Prediction target associated with the artefacts.
+    model_path
+        Filesystem path to the serialised SUAVE checkpoint.
+    calibrator_path
+        Optional filesystem path to an isotonic calibrator produced alongside
+        the manual model.
+    params
+        Optional hyperparameter mapping used to construct the manual artefacts.
+    values
+        Optional Optuna-style objective tuple ``(validation_roauc, delta_auc)``
+        describing the manual artefacts. When provided the values are stored in
+        the manifest for downstream summaries.
+    validation_metrics
+        Optional dictionary of validation metrics computed for the manual
+        artefacts.
+    tstr_metrics
+        Optional dictionary containing transfer-to-synthetic-to-real (TSTR)
+        evaluation metrics for the manual artefacts.
+    trtr_metrics
+        Optional dictionary containing transfer-to-real-to-real (TRTR)
+        evaluation metrics for the manual artefacts.
+    description
+        Optional free-form text describing the origin of the manual artefacts.
+
+    Returns
+    -------
+    Path
+        Location of the manual manifest file written to disk.
+
+    Examples
+    --------
+    >>> tmp = Path("/tmp/manual_manifest_example")
+    >>> _ = tmp.mkdir(parents=True, exist_ok=True)
+    >>> model = tmp / "manual_model.pt"
+    >>> calibrator = tmp / "manual_calibrator.joblib"
+    >>> _ = model.write_text("dummy")
+    >>> _ = calibrator.write_text("dummy")
+    >>> manifest = record_manual_model_manifest(
+    ...     tmp,
+    ...     "mortality",
+    ...     model_path=model,
+    ...     calibrator_path=calibrator,
+    ...     params={"lr": 1e-3},
+    ... )
+    >>> manifest.exists()
+    True
+    """
+
+    manifest_path = model_dir / f"suave_manual_manifest_{target_label}.json"
+    manifest: Dict[str, object] = {
+        "target_label": target_label,
+        "model_path": _normalise_manifest_path(model_path, model_dir),
+        "saved_at": datetime.now(tz=timezone.utc)
+        .isoformat(timespec="seconds")
+        .replace("+00:00", "Z"),
+        "source": "manual",
+    }
+    if calibrator_path is not None:
+        manifest["calibrator_path"] = _normalise_manifest_path(
+            calibrator_path, model_dir
+        )
+    if params is not None:
+        manifest["params"] = dict(params)
+    if values is not None:
+        manifest["values"] = [float(value) for value in values]
+
+    def _serialise_metrics(
+        metrics: Optional[Mapping[str, object]]
+    ) -> Optional[Dict[str, float]]:
+        if not isinstance(metrics, Mapping):
+            return None
+        serialised: Dict[str, float] = {}
+        for key, raw_value in metrics.items():
+            try:
+                serialised[str(key)] = float(raw_value)  # type: ignore[arg-type]
+            except (TypeError, ValueError):
+                continue
+        return serialised or None
+
+    validation_payload = _serialise_metrics(validation_metrics)
+    if validation_payload is not None:
+        manifest["validation_metrics"] = validation_payload
+
+    tstr_payload = _serialise_metrics(tstr_metrics)
+    if tstr_payload is not None:
+        manifest["tstr_metrics"] = tstr_payload
+
+    trtr_payload = _serialise_metrics(trtr_metrics)
+    if trtr_payload is not None:
+        manifest["trtr_metrics"] = trtr_payload
+
+    if description:
+        manifest["description"] = description
+    manifest_path.write_text(json.dumps(manifest, indent=2, ensure_ascii=False))
+    return manifest_path
+
+
 # =============================================================================
 # === Optuna study discovery and selection utilities =========================
 # =============================================================================
@@ -785,7 +977,7 @@ def make_study_name(prefix: Optional[str], target_label: str) -> Optional[str]:
     return f"{prefix}_{target_label}"
 
 
-def parse_script_arguments(argv: Sequence[str]) -> Optional[int]:
+def parse_script_arguments(argv: Sequence[str]) -> Optional[Union[str, int]]:
     """Parse ``argv`` and return the requested Optuna trial identifier.
 
     Parameters
@@ -795,13 +987,16 @@ def parse_script_arguments(argv: Sequence[str]) -> Optional[int]:
 
     Returns
     -------
-    Optional[int]
-        The requested Optuna trial identifier, if provided.
+    Optional[Union[str, int]]
+        The requested Optuna trial identifier or ``"manual"`` override, if
+        provided.
 
     Examples
     --------
     >>> parse_script_arguments(["--trial-id", "12"])
     12
+    >>> parse_script_arguments(["manual"])
+    'manual'
     >>> parse_script_arguments([]) is None
     True
     """
@@ -809,16 +1004,27 @@ def parse_script_arguments(argv: Sequence[str]) -> Optional[int]:
     parser = argparse.ArgumentParser(
         description="Select an Optuna trial for SUAVE model loading/training.",
     )
+
+    def _trial_argument(value: str) -> Union[str, int]:
+        if value.lower() == "manual":
+            return "manual"
+        try:
+            return int(value)
+        except ValueError as error:  # pragma: no cover - argparse normalises
+            raise argparse.ArgumentTypeError(
+                "Provide an integer Optuna trial ID or the keyword 'manual'."
+            ) from error
+
     parser.add_argument(
         "trial_id",
         nargs="?",
-        type=int,
+        type=_trial_argument,
         help="Optuna trial identifier to load or train.",
     )
     parser.add_argument(
         "--trial-id",
         dest="trial_id_flag",
-        type=int,
+        type=_trial_argument,
         help="Optuna trial identifier to load or train.",
     )
     args = parser.parse_args(list(argv))
@@ -1069,36 +1275,624 @@ def load_optuna_results(
     return best_info, best_params
 
 
+def _coerce_float(value: object) -> float:
+    """Return ``value`` converted to ``float`` when possible."""
+
+    try:
+        return float(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return float("nan")
+
+
+def _format_artifact_path(path: Optional[Path], base_dir: Path) -> str:
+    """Return ``path`` relative to ``base_dir`` when feasible."""
+
+    if path is None:
+        return ""
+    try:
+        return str(path.relative_to(base_dir))
+    except ValueError:
+        return str(path)
+
+
+def _extract_trial_metrics(trial: object) -> Tuple[float, float]:
+    """Return ``(validation_roauc, delta_auc)`` for ``trial`` or manifests."""
+
+    validation = float("nan")
+    delta = float("nan")
+
+    if hasattr(trial, "values"):
+        values = getattr(trial, "values")  # type: ignore[attr-defined]
+    elif isinstance(trial, Mapping):
+        raw_values = cast(Mapping[str, object], trial).get("values")
+        values = raw_values if isinstance(raw_values, Sequence) else None
+    else:
+        values = None
+
+    if values:
+        try:
+            numeric = [float(item) for item in values]
+        except (TypeError, ValueError):
+            numeric = []
+        if numeric:
+            validation = float(numeric[0])
+            if len(numeric) > 1:
+                delta = float(numeric[1])
+
+    if np.isnan(validation) and isinstance(trial, Mapping):
+        metrics = cast(Mapping[str, object], trial).get("validation_metrics")
+        if isinstance(metrics, Mapping):
+            for key in ("ROAUC", "roauc", "AUROC", "auroc"):
+                if key in metrics:
+                    validation = _coerce_float(metrics[key])
+                    break
+
+    if np.isnan(delta) and isinstance(trial, Mapping):
+        mapping = cast(Mapping[str, object], trial)
+        delta_value = mapping.get("tstr_trtr_delta_auc")
+        if delta_value is not None:
+            delta = _coerce_float(delta_value)
+        else:
+            tstr_metrics = mapping.get("tstr_metrics")
+            trtr_metrics = mapping.get("trtr_metrics")
+            if isinstance(tstr_metrics, Mapping) and isinstance(trtr_metrics, Mapping):
+                tstr_auc = _coerce_float(
+                    tstr_metrics.get("auroc", tstr_metrics.get("ROAUC"))
+                )
+                trtr_auc = _coerce_float(
+                    trtr_metrics.get("auroc", trtr_metrics.get("ROAUC"))
+                )
+                if np.isfinite(tstr_auc) and np.isfinite(trtr_auc):
+                    delta = abs(float(trtr_auc) - float(tstr_auc))
+
+    return validation, delta
+
+
+def _build_trial_summary_rows(
+    trials: Sequence[object],
+    *,
+    manifest: Mapping[str, Any],
+    manual_manifest: Mapping[str, Any],
+    model_dir: Path,
+) -> List[Dict[str, object]]:
+    """Return DataFrame-ready rows describing manual and Pareto artefacts."""
+
+    rows: List[Dict[str, object]] = []
+
+    if manual_manifest:
+        manual_identifier = manual_manifest.get("trial_number", "manual")
+        manual_paths = manifest_artifact_paths(manual_manifest, model_dir)
+        manual_model_path = manual_paths.get("model")
+        manual_saved = manifest_artifacts_exist(manual_manifest, model_dir)
+        validation, delta = _extract_trial_metrics(manual_manifest)
+        rows.append(
+            {
+                "Source": "Manual override",
+                "Saved locally": "✅" if manual_saved else "❌",
+                "Trial ID": manual_identifier,
+                "Model path": _format_artifact_path(manual_model_path, model_dir),
+                "Validation ROAUC": validation,
+                "TSTR/TRTR ΔAUC": delta,
+            }
+        )
+
+    saved_trial_number = manifest.get("trial_number") if manifest else None
+    manifest_paths = manifest_artifact_paths(manifest, model_dir) if manifest else {}
+    saved_model_path = manifest_paths.get("model") if manifest_paths else None
+
+    for trial in trials:
+        if trial is None:
+            continue
+        if hasattr(trial, "number"):
+            identifier: object = getattr(trial, "number")  # type: ignore[attr-defined]
+        elif isinstance(trial, Mapping):
+            identifier = cast(Mapping[str, object], trial).get("trial_number")
+        else:
+            identifier = None
+        validation, delta = _extract_trial_metrics(trial)
+        saved_locally = bool(
+            identifier is not None and saved_trial_number == identifier
+        )
+        rows.append(
+            {
+                "Source": "Optuna Pareto",
+                "Saved locally": "✅" if saved_locally else "❌",
+                "Trial ID": identifier if identifier is not None else "",
+                "Model path": _format_artifact_path(saved_model_path, model_dir)
+                if saved_locally
+                else "",
+                "Validation ROAUC": validation,
+                "TSTR/TRTR ΔAUC": delta,
+            }
+        )
+
+    return rows
+
+
+def _build_manual_optuna_ranked_table(
+    *,
+    manual_manifest: Mapping[str, Any],
+    pareto_candidates: Sequence[Mapping[str, Any]],
+    trials_df: pd.DataFrame,
+    model_dir: Path,
+) -> pd.DataFrame:
+    """Return a ranked table prioritising manual overrides then Pareto trials."""
+
+    rows = _build_trial_summary_rows(
+        list(pareto_candidates),
+        manifest={},
+        manual_manifest=manual_manifest,
+        model_dir=model_dir,
+    )
+
+    seen_identifiers = {
+        str(row.get("Trial ID")) for row in rows if row.get("Trial ID") not in {None, ""}
+    }
+    for candidate in pareto_candidates:
+        seen_identifiers.add(str(candidate.get("trial_number")))
+
+    if not trials_df.empty:
+        for _, record in trials_df.iterrows():
+            trial_identifier = record.get("trial_number")
+            identifier_key = str(trial_identifier)
+            if identifier_key in seen_identifiers:
+                continue
+            rows.append(
+                {
+                    "Source": "Optuna study",
+                    "Saved locally": "",
+                    "Trial ID": trial_identifier,
+                    "Model path": "",
+                    "Validation ROAUC": _coerce_float(
+                        record.get("validation_roauc")
+                    ),
+                    "TSTR/TRTR ΔAUC": _coerce_float(
+                        record.get("tstr_trtr_delta_auc")
+                    ),
+                }
+            )
+
+    if not rows:
+        return pd.DataFrame(
+            columns=
+            [
+                "Source",
+                "Saved locally",
+                "Trial ID",
+                "Model path",
+                "Validation ROAUC",
+                "TSTR/TRTR ΔAUC",
+            ]
+        )
+
+    source_order = {"Manual override": 0, "Optuna Pareto": 1, "Optuna study": 2}
+
+    def _sort_key(entry: Dict[str, object]) -> Tuple[int, float, float]:
+        group = source_order.get(str(entry.get("Source")), 3)
+        validation = _coerce_float(entry.get("Validation ROAUC"))
+        delta = _coerce_float(entry.get("TSTR/TRTR ΔAUC"))
+        validation_key = -validation if np.isfinite(validation) else float("inf")
+        delta_key = abs(delta) if np.isfinite(delta) else float("inf")
+        return (group, validation_key, delta_key)
+
+    ranked_rows = sorted(rows, key=_sort_key)[:50]
+
+    return pd.DataFrame(
+        ranked_rows,
+        columns=
+        [
+            "Source",
+            "Saved locally",
+            "Trial ID",
+            "Model path",
+            "Validation ROAUC",
+            "TSTR/TRTR ΔAUC",
+        ],
+    )
+
+
+def collect_manual_and_optuna_overview(
+    *,
+    target_label: str,
+    model_dir: Path,
+    optuna_dir: Path,
+    study_prefix: Optional[str],
+    storage: Optional[str],
+) -> Tuple[pd.DataFrame, pd.DataFrame]:
+    """Return manual manifest and Optuna trial summaries as dataframes."""
+
+    manual_manifest = load_manual_model_manifest(model_dir, target_label)
+    model_manifest = load_model_manifest(model_dir, target_label)
+    best_info, _ = load_optuna_results(
+        optuna_dir,
+        target_label,
+        study_prefix=study_prefix,
+        storage=storage,
+    )
+
+    pareto_raw = best_info.get("pareto_front", [])
+    pareto_candidates: List[Mapping[str, Any]] = []
+    if isinstance(pareto_raw, Sequence):
+        for entry in pareto_raw:
+            if isinstance(entry, Mapping):
+                pareto_candidates.append(dict(entry))
+
+    summary_rows = _build_trial_summary_rows(
+        pareto_candidates,
+        manifest=model_manifest,
+        manual_manifest=manual_manifest,
+        model_dir=model_dir,
+    )
+    summary_df = pd.DataFrame(
+        summary_rows,
+        columns=
+        [
+            "Source",
+            "Saved locally",
+            "Trial ID",
+            "Model path",
+            "Validation ROAUC",
+            "TSTR/TRTR ΔAUC",
+        ],
+    )
+
+    trials_path = optuna_dir / f"optuna_trials_{target_label}.csv"
+    if trials_path.exists():
+        try:
+            trials_df = pd.read_csv(trials_path)
+        except Exception:
+            trials_df = pd.DataFrame()
+    else:
+        trials_df = pd.DataFrame()
+
+    ranked_df = _build_manual_optuna_ranked_table(
+        manual_manifest=manual_manifest,
+        pareto_candidates=pareto_candidates,
+        trials_df=trials_df,
+        model_dir=model_dir,
+    )
+
+    return summary_df, ranked_df
+
+
 def summarise_pareto_trials(
     trials: Sequence["optuna.trial.FrozenTrial"],
     *,
     manifest: Mapping[str, Any],
     model_dir: Path,
+    manual_manifest: Optional[Mapping[str, Any]] = None,
 ) -> pd.DataFrame:
     """Return a tidy summary of Pareto-optimal Optuna trials."""
 
-    if not trials:
-        return pd.DataFrame()
+    rows = _build_trial_summary_rows(
+        list(trials),
+        manifest=manifest,
+        manual_manifest=manual_manifest or {},
+        model_dir=model_dir,
+    )
+    return pd.DataFrame(
+        rows,
+        columns=
+        [
+            "Source",
+            "Saved locally",
+            "Trial ID",
+            "Model path",
+            "Validation ROAUC",
+            "TSTR/TRTR ΔAUC",
+        ],
+    )
 
-    saved_trial_number = None
-    if manifest and manifest_artifacts_exist(manifest, model_dir):
-        saved_trial_number = manifest.get("trial_number")
 
-    rows: List[Dict[str, object]] = []
-    for trial in trials:
-        values = trial.values or (float("nan"), float("nan"))
-        validation_roauc = float(values[0])
-        delta_auc = float(values[1]) if len(values) > 1 else float("nan")
-        saved_locally = bool(saved_trial_number == trial.number)
-        rows.append(
-            {
-                "Saved locally": "✅" if saved_locally else "❌",
-                "Trial ID": trial.number,
-                "Validation ROAUC": validation_roauc,
-                "TSTR/TRTR ΔAUC": delta_auc,
-            }
+def load_manual_tuning_overrides(
+    manual_config: Mapping[str, Any], manual_dir: Path
+) -> Dict[str, Any]:
+    """Return manual hyper-parameter overrides defined by ``manual_config``."""
+
+    if not isinstance(manual_config, Mapping):
+        return {}
+
+    module_name = manual_config.get("module")
+    attribute_name = str(manual_config.get("attribute", "manual_param_setting"))
+    if not module_name:
+        return {}
+
+    overrides: Dict[str, Any] = {}
+
+    try:
+        module: Any
+        module_path = manual_dir / f"{module_name}.py"
+        if module_path.exists():
+            spec = importlib.util.spec_from_file_location(module_name, module_path)
+            if spec is None or spec.loader is None:  # pragma: no cover - defensive
+                raise ImportError(
+                    f"Could not load manual overrides from {module_path!s}"
+                )
+            module = importlib.util.module_from_spec(spec)
+            sys.modules.setdefault(module_name, module)
+            spec.loader.exec_module(module)
+        else:
+            module = importlib.import_module(module_name)
+        raw_overrides = getattr(module, attribute_name)
+        if isinstance(raw_overrides, Mapping):
+            overrides = dict(raw_overrides)
+        else:
+            print(
+                f"Manual override attribute '{attribute_name}' on module '{module_name}' "
+                "is not a mapping; ignoring overrides."
+            )
+    except Exception as error:  # pragma: no cover - diagnostic logging only
+        print(
+            f"Failed to load manual overrides from {module_name}.{attribute_name}: {error}"
         )
-    return pd.DataFrame(rows)
+        return {}
+
+    return overrides
+
+
+def prompt_manual_override_action(
+    *, input_fn: Callable[[str], str] = input
+) -> str:
+    """Return the manual override action selected by the user.
+
+    The helper keeps the interactive experience identical across the example
+    and research template scripts while remaining straightforward to test. When
+    the caller runs in a non-interactive environment (``EOFError``), the helper
+    defaults to continuing with the automatic Optuna search.
+
+    Examples
+    --------
+    >>> prompt_manual_override_action(  # doctest: +SKIP
+    ...     input_fn=lambda prompt: "manual",
+    ... )
+    'reuse'
+
+    Parameters
+    ----------
+    input_fn
+        Callable compatible with ``input`` that returns user responses. Tests
+        can inject a stub to exercise the various decision branches.
+
+    Returns
+    -------
+    str
+        ``"train"`` when the user opts to fit overrides immediately,
+        ``"reuse"`` to load saved manual artefacts, and ``"optuna"`` when the
+        user chooses the automatic Optuna flow or leaves the prompt blank.
+    """
+
+    prompt = (
+        "Manual tuning is enabled. Enter 'y' to train using the manual overrides, "
+        "'manual' to reuse existing manual artefacts, 'n' to skip manual overrides, "
+        "or press Enter to continue with Optuna: "
+    )
+
+    while True:
+        try:
+            response = input_fn(prompt)
+        except EOFError:
+            return "optuna"
+        except KeyboardInterrupt:
+            print("\nManual override selection interrupted.")
+            try:
+                confirm = input_fn(
+                    "Cancel manual override selection and continue with Optuna? "
+                    "Enter 'y' to confirm or press Enter to resume selection: "
+                )
+            except (KeyboardInterrupt, EOFError):
+                print("\nContinuing with Optuna search.")
+                return "optuna"
+            if confirm.strip().lower() in {"y", "yes"}:
+                print("Continuing with Optuna search.")
+                return "optuna"
+            print("Resuming manual override prompt.")
+            continue
+
+        lowered = response.strip().lower()
+        if lowered in {"", "n", "no"}:
+            return "optuna"
+        if lowered in {"y", "yes"}:
+            return "train"
+        if lowered == "manual":
+            return "reuse"
+        print("Unrecognised response. Please enter 'y', 'n', 'manual', or press Enter.")
+
+
+def evaluate_candidate_model_performance(
+    model: SUAVE,
+    *,
+    feature_columns: Sequence[str],
+    X_train: pd.DataFrame,
+    y_train: pd.Series,
+    X_validation: pd.DataFrame,
+    y_validation: pd.Series,
+    random_state: int,
+    probability_fn: Optional[Callable[[SUAVE, pd.DataFrame], np.ndarray]] = None,
+) -> Dict[str, Any]:
+    """Compute validation and transfer metrics for a trained SUAVE candidate.
+
+    Parameters
+    ----------
+    model
+        Fitted SUAVE model to be assessed.
+    feature_columns
+        List of feature names used to build numeric matrices.
+    X_train, y_train
+        Training split used for TRTR evaluation.
+    X_validation, y_validation
+        Validation split used for calibration and TSTR evaluation.
+    random_state
+        Seed governing the synthetic label bootstrap used for TSTR metrics.
+    probability_fn
+        Optional callable that returns class probabilities for ``X_validation``.
+        Defaults to ``model.predict_proba``.
+
+    Returns
+    -------
+    Dict[str, Any]
+        Dictionary containing validation, TSTR, TRTR metrics alongside the
+        Optuna objective values (validation ROAUC and |ΔAUC|).
+
+    Examples
+    --------
+    >>> # ``model`` and dataset initialisation omitted for brevity
+    >>> metrics = evaluate_candidate_model_performance(  # doctest: +SKIP
+    ...     model,
+    ...     feature_columns=["age", "apache"],
+    ...     X_train=X_train,
+    ...     y_train=y_train,
+    ...     X_validation=X_val,
+    ...     y_validation=y_val,
+    ...     random_state=0,
+    ... )
+    >>> sorted(metrics.keys())  # doctest: +SKIP
+    ['delta_auc', 'tstr_metrics', 'trtr_metrics', 'validation_metrics', 'values']
+    """
+
+    proba_fn = probability_fn or (lambda candidate, frame: candidate.predict_proba(frame))
+    validation_probabilities = np.asarray(proba_fn(model, X_validation))
+    validation_metrics = compute_binary_metrics(validation_probabilities, y_validation)
+
+    roauc = _coerce_float(
+        validation_metrics.get("ROAUC", validation_metrics.get("roauc", float("nan")))
+    )
+    if not np.isfinite(roauc):
+        raise ValueError("Non-finite validation ROAUC")
+
+    numeric_train = to_numeric_frame(X_train.loc[:, feature_columns])
+    numeric_validation = to_numeric_frame(X_validation.loc[:, feature_columns])
+
+    rng = np.random.default_rng(random_state)
+    synthetic_labels = rng.choice(y_train, size=len(y_train), replace=True)
+    synthetic_samples = model.sample(
+        len(synthetic_labels), conditional=True, y=synthetic_labels
+    )
+    if isinstance(synthetic_samples, pd.DataFrame):
+        synthetic_features = synthetic_samples.loc[:, feature_columns].copy()
+    else:
+        synthetic_features = pd.DataFrame(synthetic_samples, columns=feature_columns)
+    numeric_synthetic = to_numeric_frame(synthetic_features)
+
+    tstr_metrics = evaluate_tstr(
+        (
+            numeric_synthetic.to_numpy(),
+            np.asarray(synthetic_labels),
+        ),
+        (
+            numeric_validation.to_numpy(),
+            y_validation.to_numpy(),
+        ),
+        make_logistic_pipeline,
+    )
+    trtr_metrics = evaluate_trtr(
+        (
+            numeric_train.to_numpy(),
+            y_train.to_numpy(),
+        ),
+        (
+            numeric_validation.to_numpy(),
+            y_validation.to_numpy(),
+        ),
+        make_logistic_pipeline,
+    )
+
+    trtr_auc = _coerce_float(trtr_metrics.get("auroc", trtr_metrics.get("ROAUC")))
+    tstr_auc = _coerce_float(tstr_metrics.get("auroc", tstr_metrics.get("ROAUC")))
+    delta_auc = (
+        abs(float(trtr_auc) - float(tstr_auc))
+        if np.isfinite(trtr_auc) and np.isfinite(tstr_auc)
+        else float("nan")
+    )
+
+    return {
+        "validation_metrics": validation_metrics,
+        "tstr_metrics": tstr_metrics,
+        "trtr_metrics": trtr_metrics,
+        "delta_auc": delta_auc,
+        "values": (
+            roauc,
+            delta_auc,
+        ),
+    }
+
+
+def run_manual_override_training(
+    *,
+    target_label: str,
+    manual_overrides: Mapping[str, Any],
+    base_params: Optional[Mapping[str, Any]],
+    schema: Schema,
+    feature_columns: Sequence[str],
+    X_train: pd.DataFrame,
+    y_train: pd.Series,
+    X_validation: pd.DataFrame,
+    y_validation: pd.Series,
+    model_dir: Path,
+    calibration_dir: Path,
+    random_state: int,
+) -> Dict[str, Any]:
+    """Train and persist a manual SUAVE model using ``manual_overrides``."""
+
+    merged_params: Dict[str, Any] = {}
+    if base_params:
+        merged_params.update(dict(base_params))
+    merged_params.update(dict(manual_overrides))
+
+    if not merged_params:
+        raise ValueError("Manual overrides and baseline parameters are empty.")
+
+    model = build_suave_model(merged_params, schema, random_state=random_state)
+    model.fit(X_train, y_train, **resolve_suave_fit_kwargs(merged_params))
+
+    calibrator = fit_isotonic_calibrator(model, X_validation, y_validation)
+
+    manual_model_path = model_dir / f"suave_manual_{target_label}.pt"
+    manual_calibrator_path = (
+        calibration_dir / f"isotonic_manual_calibrator_{target_label}.joblib"
+    )
+    manual_model_path.parent.mkdir(parents=True, exist_ok=True)
+    manual_calibrator_path.parent.mkdir(parents=True, exist_ok=True)
+    model.save(manual_model_path)
+    joblib.dump(calibrator, manual_calibrator_path)
+
+    evaluation = evaluate_candidate_model_performance(
+        model,
+        feature_columns=feature_columns,
+        X_train=X_train,
+        y_train=y_train,
+        X_validation=X_validation,
+        y_validation=y_validation,
+        random_state=random_state,
+        probability_fn=lambda _model, features: calibrator.predict_proba(features),
+    )
+    validation_metrics = evaluation["validation_metrics"]
+    tstr_metrics = evaluation["tstr_metrics"]
+    trtr_metrics = evaluation["trtr_metrics"]
+    values = evaluation["values"]
+
+    manifest_path = record_manual_model_manifest(
+        model_dir,
+        target_label,
+        model_path=manual_model_path,
+        calibrator_path=manual_calibrator_path,
+        params=merged_params,
+        values=values,
+        validation_metrics=validation_metrics,
+        tstr_metrics=tstr_metrics,
+        trtr_metrics=trtr_metrics,
+        description="Interactive manual tuning run",
+    )
+
+    return {
+        "model_path": manual_model_path,
+        "calibrator_path": manual_calibrator_path,
+        "manifest_path": manifest_path,
+        "validation_metrics": validation_metrics,
+        "tstr_metrics": tstr_metrics,
+        "trtr_metrics": trtr_metrics,
+        "values": values,
+        "params": merged_params,
+    }
 
 
 # =============================================================================
@@ -1113,9 +1907,10 @@ class ModelLoadingPlan:
     optuna_best_info: Dict[str, Any]
     optuna_best_params: Dict[str, Any]
     model_manifest: Dict[str, Any]
+    manual_model_manifest: Dict[str, Any]
     optuna_study: Optional["optuna.study.Study"]
     pareto_trials: List["optuna.trial.FrozenTrial"]
-    selected_trial_number: Optional[int]
+    selected_trial_number: Optional[Union[str, int]]
     selected_model_path: Optional[Path]
     selected_calibrator_path: Optional[Path]
     selected_params: Dict[str, Any]
@@ -1193,7 +1988,7 @@ def resolve_model_loading_plan(
     optuna_dir: Path,
     schema: Schema,
     is_interactive: bool,
-    cli_requested_trial_id: Optional[int] = None,
+    cli_requested_trial_id: Optional[Union[str, int]] = None,
     force_update_suave: bool = False,
     pareto_min_validation_roauc: float = PARETO_MIN_VALIDATION_ROAUC,
     pareto_max_abs_delta_auc: float = PARETO_MAX_ABS_DELTA_AUC,
@@ -1219,7 +2014,8 @@ def resolve_model_loading_plan(
         interactively; otherwise command-line arguments and sensible defaults
         drive the selection.
     cli_requested_trial_id
-        Optional Optuna trial identifier supplied via command-line arguments.
+        Optional Optuna trial identifier or ``"manual"`` override supplied via
+        command-line arguments.
     force_update_suave
         Boolean flag indicating whether cached SUAVE artefacts should be
         retrained when Optuna outputs are unavailable. When Optuna metadata can
@@ -1259,6 +2055,7 @@ def resolve_model_loading_plan(
         storage=analysis_config.get("optuna_storage"),
     )
     model_manifest = load_model_manifest(model_dir, target_label)
+    manual_model_manifest = load_manual_model_manifest(model_dir, target_label)
 
     if not optuna_best_params:
         print(
@@ -1286,6 +2083,18 @@ def resolve_model_loading_plan(
     saved_calibrator_path = manifest_paths.get("calibrator")
     saved_trial_number = model_manifest.get("trial_number")
 
+    manual_manifest_paths = manifest_artifact_paths(manual_model_manifest, model_dir)
+    manual_model_path = manual_manifest_paths.get("model")
+    manual_calibrator_path = manual_manifest_paths.get("calibrator")
+    manual_identifier: Optional[Union[str, int]] = manual_model_manifest.get(
+        "trial_number"
+    )
+    if manual_identifier is None and manual_model_path is not None:
+        manual_identifier = "manual"
+    manual_model_available = bool(
+        manual_model_path is not None and manual_model_path.exists()
+    )
+
     legacy_model_path = model_dir / f"suave_best_{target_label}.pt"
     legacy_calibrator_path = model_dir / f"isotonic_calibrator_{target_label}.joblib"
 
@@ -1296,32 +2105,60 @@ def resolve_model_loading_plan(
         else {}
     )
 
-    selected_trial_number: Optional[int] = None
+    selected_trial_number: Optional[Union[str, int]] = None
     selected_model_path: Optional[Path] = None
     selected_calibrator_path: Optional[Path] = None
     selected_trial: Optional["optuna.trial.FrozenTrial"] = None
 
     requested_id = cli_requested_trial_id
     if requested_id is not None:
-        if (
-            saved_trial_number == requested_id
-            and saved_model_path
-            and saved_model_path.exists()
-        ):
-            selected_trial_number = requested_id
-            selected_model_path = saved_model_path
-            selected_calibrator_path = saved_calibrator_path
-        else:
-            selected_trial = all_trials_lookup.get(requested_id)
-            if selected_trial is None:
-                print(
-                    f"Requested Optuna trial #{requested_id} could not be located; proceeding with fallback selection."
-                )
+        if requested_id == "manual":
+            if manual_model_available:
+                selected_trial_number = manual_identifier or "manual"
+                selected_model_path = manual_model_path
+                selected_calibrator_path = manual_calibrator_path
+                if not (
+                    manual_calibrator_path is not None
+                    and manual_calibrator_path.exists()
+                ):
+                    print(
+                        "Manual override selected but calibrator artefacts were not found; an isotonic calibrator will be fitted."
+                    )
             else:
+                print(
+                    "Manual override requested but suave_manual_manifest was not found; proceeding with Optuna selection."
+                )
+        else:
+            if (
+                saved_trial_number == requested_id
+                and saved_model_path
+                and saved_model_path.exists()
+            ):
                 selected_trial_number = requested_id
+                selected_model_path = saved_model_path
+                selected_calibrator_path = saved_calibrator_path
+            else:
+                selected_trial = all_trials_lookup.get(requested_id)
+                if selected_trial is None:
+                    print(
+                        f"Requested Optuna trial #{requested_id} could not be located; proceeding with fallback selection."
+                    )
+                else:
+                    selected_trial_number = requested_id
 
     if selected_model_path is None and selected_trial is None:
-        if saved_model_path and saved_model_path.exists():
+        if manual_model_available:
+            selected_trial_number = manual_identifier or "manual"
+            selected_model_path = manual_model_path
+            selected_calibrator_path = manual_calibrator_path
+            if not (
+                manual_calibrator_path is not None
+                and manual_calibrator_path.exists()
+            ):
+                print(
+                    "Manual override manifest detected but calibrator artefacts were not found; an isotonic calibrator will be fitted."
+                )
+        elif saved_model_path and saved_model_path.exists():
             selected_trial_number = saved_trial_number
             selected_model_path = saved_model_path
             selected_calibrator_path = saved_calibrator_path
@@ -1357,6 +2194,7 @@ def resolve_model_loading_plan(
         selected_model_path = None
         selected_calibrator_path = None
 
+    manual_params = manual_model_manifest.get("params")
     selected_params: Dict[str, Any] = {}
     if selected_trial is not None:
         selected_params = dict(selected_trial.params)
@@ -1365,6 +2203,12 @@ def resolve_model_loading_plan(
         and isinstance(model_manifest.get("params"), Mapping)
     ):
         selected_params = dict(model_manifest["params"])
+    elif (
+        isinstance(manual_params, Mapping)
+        and selected_trial_number
+        in {manual_identifier, "manual"}
+    ):
+        selected_params = dict(manual_params)
     elif optuna_best_params:
         selected_params = dict(optuna_best_params)
 
@@ -1391,6 +2235,7 @@ def resolve_model_loading_plan(
         optuna_best_info=dict(optuna_best_info),
         optuna_best_params=dict(optuna_best_params),
         model_manifest=dict(model_manifest),
+        manual_model_manifest=dict(manual_model_manifest),
         optuna_study=optuna_study,
         pareto_trials=list(pareto_trials),
         selected_trial_number=selected_trial_number,
@@ -1430,6 +2275,7 @@ def confirm_model_loading_plan_selection(
     ...     optuna_best_info={},
     ...     optuna_best_params={},
     ...     model_manifest={},
+    ...     manual_model_manifest={},
     ...     optuna_study=None,
     ...     pareto_trials=[],
     ...     selected_trial_number=None,
@@ -1454,16 +2300,46 @@ def confirm_model_loading_plan_selection(
     saved_calibrator_path = manifest_paths.get("calibrator")
     saved_trial_number = plan.model_manifest.get("trial_number")
 
-    default_hint = (
-        f"trial #{saved_trial_number}"
-        if saved_trial_number is not None
+    manual_manifest_paths = manifest_artifact_paths(
+        plan.manual_model_manifest, model_dir
+    )
+    manual_model_path = manual_manifest_paths.get("model")
+    manual_calibrator_path = manual_manifest_paths.get("calibrator")
+    manual_identifier: Optional[Union[str, int]] = plan.manual_model_manifest.get(
+        "trial_number"
+    )
+    if manual_identifier is None and manual_model_path is not None:
+        manual_identifier = "manual"
+    manual_available = bool(
+        manual_model_path is not None and manual_model_path.exists()
+    )
+    manual_params: Dict[str, Any] = (
+        dict(plan.manual_model_manifest["params"])
+        if isinstance(plan.manual_model_manifest.get("params"), Mapping)
+        else {}
+    )
+
+    default_hint = "a new training run"
+    if manual_available and plan.selected_trial_number in {
+        manual_identifier,
+        "manual",
+    }:
+        default_hint = "the manual override"
+    elif (
+        saved_trial_number is not None
         and saved_model_path is not None
         and saved_model_path.exists()
-        else "a new training run"
+    ):
+        default_hint = f"trial #{saved_trial_number}"
+
+    manual_prompt = (
+        " or type 'manual' to load the manual override"
+        if manual_available
+        else ""
     )
     prompt = (
-        "Enter the Optuna trial ID from the Pareto front to load or train "
-        f"(press Enter to reuse {default_hint}): "
+        "Enter the Optuna trial ID from the Pareto front to load or train"
+        f"{manual_prompt} (press Enter to reuse {default_hint}): "
     )
 
     pareto_lookup = {trial.number: trial for trial in plan.pareto_trials}
@@ -1474,6 +2350,14 @@ def confirm_model_loading_plan_selection(
     selected_params = dict(plan.selected_params)
     preloaded_model = plan.preloaded_model
 
+    if (
+        manual_available
+        and selected_trial_number in {manual_identifier, "manual"}
+        and not selected_params
+        and manual_params
+    ):
+        selected_params = dict(manual_params)
+
     while True:
         try:
             response = input(prompt).strip()
@@ -1483,11 +2367,32 @@ def confirm_model_loading_plan_selection(
         if not response:
             break
 
+        lowered = response.lower()
+        if manual_available and lowered == "manual":
+            selected_trial = None
+            selected_trial_number = manual_identifier or "manual"
+            selected_model_path = manual_model_path
+            selected_calibrator_path = manual_calibrator_path
+            selected_params = dict(manual_params)
+            if not (
+                manual_calibrator_path is not None
+                and manual_calibrator_path.exists()
+            ):
+                print(
+                    "Manual override selected but calibrator artefacts were not found; an isotonic calibrator will be fitted."
+                )
+            if not (
+                manual_model_path is not None
+                and plan.selected_model_path == manual_model_path
+            ):
+                preloaded_model = None
+            break
+
         try:
             candidate_id = int(response)
         except ValueError:
             print(
-                "Please enter a valid integer trial identifier from the listed Pareto front."
+                "Please enter a valid integer trial identifier from the listed Pareto front or the keyword 'manual'."
             )
             continue
 

--- a/research_template/RESEARCH_README.md
+++ b/research_template/RESEARCH_README.md
@@ -121,6 +121,11 @@
   1. 若存在历史最优 Trial，优先加载对应 JSON；否则使用默认超参重新搜索。
   2. 记录每个训练阶段（预训练、分类头、联合微调）的轮数、早停标准与耗时。
   3. 导出参数重要性、收敛曲线、帕累托前沿图，并保存到 `03_optuna_search/figures/`。
+  4. 模板会在 `04_suave_training/` 下生成 `manual_param_setting.py`，用于登记交互式手动调参的覆盖项；如需生效，请将 `build_analysis_config()` 返回的 `interactive_manual_tuning` 配置指向该模块并填写 `manual_param_setting` 字典。
+     > 🟡 提醒：`analysis_config.INTERACTIVE_MANUAL_TUNING` 仅为手动覆写钩子，不建议在不了解字段作用时修改，以免干扰批量流程的默认行为。
+  5. 交互式运行可输入 `manual` 直接加载 `suave_manual_manifest_{label}.json` 中登记的模型与校准器；命令行同样支持 `--trial-id manual`。未指定 trial 时脚本会优先检查手动 manifest，再回退至最近保存的自动 trial，最后依据帕累托阈值自动挑选候选。
+6. 启用 `interactive_manual_tuning` 并以交互模式运行优化脚本时，会在启动 Optuna 之前展示手动模型与历史帕累托解的摘要表；此时可输入 `y/yes` 依据 `manual_param_setting` 直接训练并登记手动模型，输入 `manual` 复用磁盘中的手动 artefact，或输入 `n/no`/回车继续自动搜索。若在提示期间触发键盘中断，脚本会提示是否直接回退至 Optuna 搜索。
+7. 手动调参训练与 Optuna trial 的评估逻辑统一封装在 `analysis_utils.evaluate_candidate_model_performance` 中，用于输出验证集指标、TSTR/TRTR 评估与 ΔAUC；如需调整评估流程，请更新该函数以保持两条路径一致。
 
 ### 8. 分类、校准与不确定性分析
 - **目的**：量化模型概率输出的可靠性，并汇总各指标的置信区间与可视化。

--- a/research_template/analysis_config.py
+++ b/research_template/analysis_config.py
@@ -137,6 +137,14 @@ HEAD_HIDDEN_DIMENSION_OPTIONS: Dict[str, Tuple[int, ...]] = {
     "deep": (128, 64, 32),
 }
 
+# 🟡 Caution: only update this hook when you need to override the manual tuning
+#     script and fully understand the downstream impact. Blind edits may break
+#     batch workflows.
+INTERACTIVE_MANUAL_TUNING: Dict[str, str] = {
+    "module": "manual_param_setting",
+    "attribute": "manual_param_setting",
+}
+
 # 🟡 Default configuration passed to :func:`build_analysis_config`.
 DEFAULT_ANALYSIS_CONFIG: Dict[str, object] = {
     "optuna_trials": 5,
@@ -153,6 +161,7 @@ DEFAULT_ANALYSIS_CONFIG: Dict[str, object] = {
         "delta_roc_auc": "ΔAUROC",
     },
     "training_color_palette": None,
+    "interactive_manual_tuning": INTERACTIVE_MANUAL_TUNING,
 }
 
 # 🟡 Script-mode defaults that force regeneration of cached artefacts。
@@ -398,6 +407,7 @@ __all__ = [
     "DATA_DIR",
     "DATASET_FILENAMES",
     "DEFAULT_ANALYSIS_CONFIG",
+    "INTERACTIVE_MANUAL_TUNING",
     "FORCE_UPDATE_FLAG_DEFAULTS",
     "HEAD_HIDDEN_DIMENSION_OPTIONS",
     "HIDDEN_DIMENSION_OPTIONS",

--- a/research_template/research-suave_optimize.py
+++ b/research_template/research-suave_optimize.py
@@ -46,18 +46,25 @@ from mimic_mortality_utils import (  # noqa: E402
     VALIDATION_SIZE,
     Schema,
     build_suave_model,
-    compute_binary_metrics,
+    collect_manual_and_optuna_overview,
     define_schema,
+    evaluate_candidate_model_performance,
     fit_isotonic_calibrator,
+    is_interactive_session,
     load_dataset,
+    load_manual_model_manifest,
+    load_manual_tuning_overrides,
+    load_optuna_results,
     make_logistic_pipeline,
     prepare_features,
     prepare_analysis_output_directories,
+    prompt_manual_override_action,
     resolve_analysis_output_root,
     render_dataframe,
     schema_to_dataframe,
     to_numeric_frame,
     record_model_manifest,
+    run_manual_override_training,
     _save_figure_multiformat,
     make_study_name,
     resolve_suave_fit_kwargs,
@@ -86,6 +93,8 @@ except ImportError as exc:  # pragma: no cover - optuna provided via requirement
 TARGET_LABEL = "in_hospital_mortality"
 
 analysis_config = build_analysis_config()
+
+IS_INTERACTIVE = is_interactive_session()
 
 
 # %% [markdown]
@@ -286,71 +295,40 @@ def run_optuna_search(
             **fit_kwargs,
         )
         fit_seconds = time.perf_counter() - start_time
-        validation_probs = model.predict_proba(X_validation)
-        validation_metrics = compute_binary_metrics(validation_probs, y_validation)
-        trial.set_user_attr("validation_metrics", validation_metrics)
-        trial.set_user_attr("fit_seconds", fit_seconds)
-
-        roauc = validation_metrics.get("ROAUC", float("nan"))
-        if not np.isfinite(roauc):
-            raise optuna.exceptions.TrialPruned("Non-finite validation ROAUC")
-
         try:
-            numeric_train = to_numeric_frame(X_train.loc[:, feature_columns])
-            numeric_validation = to_numeric_frame(X_validation.loc[:, feature_columns])
-
-            rng = np.random.default_rng(random_state + trial.number)
-            synthetic_labels = rng.choice(y_train, size=len(y_train), replace=True)
-            synthetic_samples = model.sample(
-                len(synthetic_labels), conditional=True, y=synthetic_labels
+            evaluation = evaluate_candidate_model_performance(
+                model,
+                feature_columns=feature_columns,
+                X_train=X_train,
+                y_train=y_train,
+                X_validation=X_validation,
+                y_validation=y_validation,
+                random_state=random_state + trial.number,
             )
-            if not isinstance(synthetic_samples, pd.DataFrame):
-                synthetic_features = pd.DataFrame(
-                    synthetic_samples, columns=feature_columns
-                )
-            else:
-                synthetic_features = synthetic_samples.loc[:, feature_columns].copy()
-            numeric_synthetic = to_numeric_frame(synthetic_features)
-
-            tstr_metrics = evaluate_tstr(
-                (
-                    numeric_synthetic.to_numpy(),
-                    np.asarray(synthetic_labels),
-                ),
-                (
-                    numeric_validation.to_numpy(),
-                    y_validation.to_numpy(),
-                ),
-                make_logistic_pipeline,
-            )
-            trtr_metrics = evaluate_trtr(
-                (
-                    numeric_train.to_numpy(),
-                    y_train.to_numpy(),
-                ),
-                (
-                    numeric_validation.to_numpy(),
-                    y_validation.to_numpy(),
-                ),
-                make_logistic_pipeline,
-            )
-            trial.set_user_attr("tstr_metrics", tstr_metrics)
-            trial.set_user_attr("trtr_metrics", trtr_metrics)
-
-            delta_auc = abs(
-                float(trtr_metrics.get("auroc", float("nan")))
-                - float(tstr_metrics.get("auroc", float("nan")))
-            )
-            if not np.isfinite(delta_auc):
-                raise ValueError("Non-finite TSTR/TRTR delta AUC")
         except Exception as error:
             trial.set_user_attr("tstr_trtr_error", repr(error))
             raise optuna.exceptions.TrialPruned(
-                f"Failed to compute TSTR/TRTR delta AUC: {error}"
+                f"Failed to evaluate candidate model: {error}"
             ) from error
 
+        validation_metrics = evaluation["validation_metrics"]
+        tstr_metrics = evaluation["tstr_metrics"]
+        trtr_metrics = evaluation["trtr_metrics"]
+        delta_auc = evaluation["delta_auc"]
+        values = evaluation["values"]
+
+        trial.set_user_attr("validation_metrics", validation_metrics)
+        trial.set_user_attr("fit_seconds", fit_seconds)
+        trial.set_user_attr("tstr_metrics", tstr_metrics)
+        trial.set_user_attr("trtr_metrics", trtr_metrics)
         trial.set_user_attr("tstr_trtr_delta_auc", delta_auc)
-        return roauc, delta_auc
+
+        if not np.isfinite(values[0]):
+            raise optuna.exceptions.TrialPruned("Non-finite validation ROAUC")
+        if not np.isfinite(values[1]):
+            raise optuna.exceptions.TrialPruned("Non-finite TSTR/TRTR delta AUC")
+
+        return float(values[0]), float(values[1])
 
     study = optuna.create_study(
         directions=("maximize", "minimize"),
@@ -445,6 +423,105 @@ y_validation = y_validation.reset_index(drop=True)
 # ## Execute Optuna search
 
 # %%
+
+manual_config = analysis_config.get("interactive_manual_tuning", {})
+manual_action = "optuna"
+
+if IS_INTERACTIVE and manual_config:
+    try:
+        manual_summary, manual_ranked = collect_manual_and_optuna_overview(
+            target_label=TARGET_LABEL,
+            model_dir=SUAVE_MODEL_DIR,
+            optuna_dir=OPTUNA_DIR,
+            study_prefix=analysis_config.get("optuna_study_prefix"),
+            storage=analysis_config.get("optuna_storage"),
+        )
+    except Exception as error:  # pragma: no cover - diagnostic aid
+        print(f"Failed to prepare manual tuning overview: {error}")
+        manual_summary = pd.DataFrame()
+        manual_ranked = pd.DataFrame()
+
+    if not manual_summary.empty:
+        render_dataframe(
+            manual_summary,
+            title="Manual override and Pareto summary",
+            floatfmt=".4f",
+        )
+    if not manual_ranked.empty:
+        render_dataframe(
+            manual_ranked,
+            title="Manual/Pareto candidates (top 50)",
+            floatfmt=".4f",
+        )
+
+    manual_action = prompt_manual_override_action()
+
+    if manual_action == "train":
+        manual_overrides = load_manual_tuning_overrides(manual_config, SUAVE_MODEL_DIR)
+        _base_info, base_params = load_optuna_results(
+            OPTUNA_DIR,
+            TARGET_LABEL,
+            study_prefix=analysis_config.get("optuna_study_prefix"),
+            storage=analysis_config.get("optuna_storage"),
+        )
+        if not manual_overrides and not base_params:
+            print(
+                "Manual overrides were empty and no Optuna parameters were found; continuing with Optuna search."
+            )
+            manual_action = "optuna"
+        else:
+            try:
+                manual_result = run_manual_override_training(
+                    target_label=TARGET_LABEL,
+                    manual_overrides=manual_overrides,
+                    base_params=base_params,
+                    schema=schema,
+                    feature_columns=FEATURE_COLUMNS,
+                    X_train=X_train_model,
+                    y_train=y_train_model,
+                    X_validation=X_validation,
+                    y_validation=y_validation,
+                    model_dir=SUAVE_MODEL_DIR,
+                    calibration_dir=CALIBRATION_DIR,
+                    random_state=RANDOM_STATE,
+                )
+            except Exception as error:  # pragma: no cover - diagnostic path
+                print(f"Manual override training failed: {error}")
+                manual_action = "optuna"
+            else:
+                validation_value, delta_value = manual_result["values"]
+                print(
+                    "\nManual override training summary:"
+                    f"\n  Validation ROAUC: {validation_value:.4f}"
+                    f"\n  TSTR/TRTR ΔAUC: {delta_value:.4f}"
+                )
+                if manual_result["params"]:
+                    print("Applied hyper-parameters:")
+                    for key, value in sorted(manual_result["params"].items()):
+                        print(f"  - {key}: {value}")
+                print(
+                    f"Saved manual SUAVE model to {manual_result['model_path']}."
+                )
+                print(
+                    "Saved manual calibrator to"
+                    f" {manual_result['calibrator_path']}."
+                )
+                print(
+                    f"Updated manual manifest at {manual_result['manifest_path']}."
+                )
+                raise SystemExit(0)
+
+    if manual_action == "reuse":
+        manual_manifest = load_manual_model_manifest(SUAVE_MODEL_DIR, TARGET_LABEL)
+        if manual_manifest:
+            print(
+                "Manual SUAVE artefacts detected on disk; Optuna search will be skipped. "
+                "Run the evaluation script to load the manual override."
+            )
+            raise SystemExit(0)
+        print(
+            "Manual manifest was not found; continuing with Optuna search."
+        )
 
 study_name = make_study_name(analysis_config["optuna_study_prefix"], TARGET_LABEL)
 

--- a/research_template/research-supervised_analysis.py
+++ b/research_template/research-supervised_analysis.py
@@ -5,15 +5,17 @@ Usage
 Interactive sessions (e.g. IPython, Jupyter)
     * Detect the active Optuna study and render the Pareto front for manual
       inspection.
-    * Prompt for a trial identifier; pressing Enter reuses the most recently
-      saved model when available, otherwise the chosen Pareto trial is trained.
+    * Prompt for a trial identifier; entering ``manual`` loads the manual
+      override when available, pressing Enter reuses the most recently saved
+      artefacts or trains the chosen Pareto trial.
 
 Script mode (command line execution)
     * Accepts an optional ``trial_id`` positional argument (or ``--trial-id``)
-      to force loading/training a specific Optuna trial.
-    * Without an argument, attempts to load the most recent saved model; if
-      absent, automatically trains the preferred Pareto-front trial or falls
-      back to stored best parameters.
+      to force loading/training a specific Optuna trial or ``manual`` override.
+    * Without an argument, attempts to load the manual override when present,
+      otherwise reuses the most recent saved model; if absent, automatically
+      trains the preferred Pareto-front trial or falls back to stored best
+      parameters.
 """
 
 # %% [markdown]
@@ -32,7 +34,7 @@ import json
 import re
 import sys
 from pathlib import Path
-from typing import Any, Dict, List, Mapping, Optional, Sequence, Tuple
+from typing import Any, Dict, List, Mapping, Optional, Sequence, Tuple, Union
 
 import matplotlib.pyplot as plt
 import joblib
@@ -116,7 +118,9 @@ from analysis_utils import (  # noqa: E402
     schema_to_dataframe,
     to_numeric_frame,
     load_model_manifest,
+    load_manual_model_manifest,
     record_model_manifest,
+    record_manual_model_manifest,
     build_training_color_map,
     DISTRIBUTION_SHIFT_OVERALL_NOTE,
     DISTRIBUTION_SHIFT_PER_FEATURE_NOTE,
@@ -180,7 +184,7 @@ INTERNAL_TEST_DATASET_NAME = DATASET_NAME_MAP.get("internal_test", "Internal tes
 EXTERNAL_DATASET_NAME = DATASET_NAME_MAP.get("external_validation")
 
 
-CLI_REQUESTED_TRIAL_ID: Optional[int] = None
+CLI_REQUESTED_TRIAL_ID: Optional[Union[str, int]] = None
 if not IS_INTERACTIVE:
     CLI_REQUESTED_TRIAL_ID = parse_script_arguments(sys.argv[1:])
 
@@ -625,6 +629,7 @@ if IS_INTERACTIVE and pareto_trials:
         pareto_trials,
         manifest=model_manifest,
         model_dir=SUAVE_MODEL_DIR,
+        manual_manifest=manual_model_manifest,
     )
     render_dataframe(
         pareto_summary,
@@ -653,17 +658,39 @@ selected_model_path = model_loading_plan.selected_model_path
 selected_calibrator_path = model_loading_plan.selected_calibrator_path
 selected_params: Dict[str, Any] = dict(model_loading_plan.selected_params)
 
+manual_model_manifest: Dict[str, Any] = dict(
+    model_loading_plan.manual_model_manifest
+)
+manual_identifier = manual_model_manifest.get("trial_number")
+if manual_identifier is None and manual_model_manifest.get("model_path"):
+    manual_identifier = "manual"
+manual_selection = bool(
+    manual_model_manifest
+    and selected_trial_number in {manual_identifier, "manual"}
+)
+
 if not selected_params and optuna_best_params:
     selected_params = dict(optuna_best_params)
+if (
+    manual_selection
+    and not selected_params
+    and isinstance(manual_model_manifest.get("params"), Mapping)
+):
+    selected_params = dict(manual_model_manifest["params"])
 
 model: Optional[SUAVE] = model_loading_plan.preloaded_model
 calibrator: Optional[Any] = None
 
 if model is not None and selected_model_path and selected_model_path.exists():
     if selected_trial_number is not None:
-        print(
-            f"Reusing cached SUAVE model for Optuna trial #{selected_trial_number} from {selected_model_path}."
-        )
+        if manual_selection:
+            print(
+                f"Reusing manually specified SUAVE model from {selected_model_path}."
+            )
+        else:
+            print(
+                f"Reusing cached SUAVE model for Optuna trial #{selected_trial_number} from {selected_model_path}."
+            )
     else:
         print(f"Reusing cached SUAVE model from {selected_model_path}.")
     if missing_optuna:
@@ -677,9 +704,14 @@ if selected_calibrator_path and selected_calibrator_path.exists():
     if embedded is not None:
         model = embedded
         if selected_trial_number is not None:
-            print(
-                f"Loaded isotonic calibrator for Optuna trial #{selected_trial_number} from {selected_calibrator_path}."
-            )
+            if manual_selection:
+                print(
+                    f"Loaded isotonic calibrator for the manual override from {selected_calibrator_path}."
+                )
+            else:
+                print(
+                    f"Loaded isotonic calibrator for Optuna trial #{selected_trial_number} from {selected_calibrator_path}."
+                )
         else:
             print(f"Loaded isotonic calibrator from {selected_calibrator_path}.")
     else:
@@ -689,9 +721,14 @@ if selected_calibrator_path and selected_calibrator_path.exists():
 if model is None and selected_model_path and selected_model_path.exists():
     model = SUAVE.load(selected_model_path)
     if selected_trial_number is not None:
-        print(
-            f"Loaded SUAVE model for Optuna trial #{selected_trial_number} from {selected_model_path}."
-        )
+        if manual_selection:
+            print(
+                f"Loaded manually specified SUAVE model from {selected_model_path}."
+            )
+        else:
+            print(
+                f"Loaded SUAVE model for Optuna trial #{selected_trial_number} from {selected_model_path}."
+            )
     else:
         print(f"Loaded SUAVE model from {selected_model_path}.")
     if missing_optuna:
@@ -707,7 +744,11 @@ if model is None:
         print(
             "Warning: Optuna tuning artefacts were not found; falling back to default SUAVE hyperparameters."
         )
-    if selected_trial_number is not None:
+    if manual_selection:
+        print(
+            "Training SUAVE for the manual override because no saved artefacts were available…"
+        )
+    elif selected_trial_number is not None:
         print(
             f"Training SUAVE for Optuna trial #{selected_trial_number} because no saved model artefacts were available…"
         )
@@ -737,7 +778,9 @@ if model_was_trained:
     model_output_path.parent.mkdir(parents=True, exist_ok=True)
     model.save(model_output_path)
     selected_model_path = model_output_path
-    if selected_trial_number is not None:
+    if manual_selection:
+        print(f"Saved SUAVE model for the manual override to {model_output_path}.")
+    elif selected_trial_number is not None:
         print(
             f"Saved SUAVE model for Optuna trial #{selected_trial_number} to {model_output_path}."
         )
@@ -768,7 +811,11 @@ if calibrator_was_fitted:
     calibrator_output_path.parent.mkdir(parents=True, exist_ok=True)
     joblib.dump(calibrator, calibrator_output_path)
     selected_calibrator_path = calibrator_output_path
-    if selected_trial_number is not None:
+    if manual_selection:
+        print(
+            f"Saved isotonic calibrator for the manual override to {calibrator_output_path}."
+        )
+    elif selected_trial_number is not None:
         print(
             "Saved isotonic calibrator for Optuna trial "
             f"#{selected_trial_number} to {calibrator_output_path}."
@@ -781,45 +828,59 @@ if (
     and selected_model_path is not None
     and selected_calibrator_path is not None
 ):
-    manifest_values: List[float] = []
-
-    if selected_trial_number is not None:
-        matching_trial = next(
-            (trial for trial in pareto_trials if trial.number == selected_trial_number),
-            None,
+    if manual_selection:
+        manifest_path = record_manual_model_manifest(
+            SUAVE_MODEL_DIR,
+            TARGET_LABEL,
+            model_path=selected_model_path,
+            calibrator_path=selected_calibrator_path,
+            params=selected_params,
         )
-        if matching_trial is not None and matching_trial.values is not None:
-            manifest_values = [float(value) for value in matching_trial.values]
+        print(f"Updated manual SUAVE model manifest at {manifest_path}.")
+        manual_model_manifest = load_manual_model_manifest(
+            SUAVE_MODEL_DIR, TARGET_LABEL
+        )
+        model_manifest = load_model_manifest(SUAVE_MODEL_DIR, TARGET_LABEL)
+    else:
+        manifest_values: List[float] = []
 
-    if not manifest_values:
-        previous_values = model_loading_plan.model_manifest.get("values")
-        if isinstance(previous_values, Sequence) and not isinstance(
-            previous_values, (str, bytes)
-        ):
-            manifest_values = [float(value) for value in previous_values]
+        if isinstance(selected_trial_number, int):
+            matching_trial = next(
+                (trial for trial in pareto_trials if trial.number == selected_trial_number),
+                None,
+            )
+            if matching_trial is not None and matching_trial.values is not None:
+                manifest_values = [float(value) for value in matching_trial.values]
 
-    if not manifest_values:
-        best_info_values = optuna_best_info.get("values")
-        if isinstance(best_info_values, Sequence) and not isinstance(
-            best_info_values, (str, bytes)
-        ):
-            manifest_values = [float(value) for value in best_info_values]
+        if not manifest_values:
+            previous_values = model_loading_plan.model_manifest.get("values")
+            if isinstance(previous_values, Sequence) and not isinstance(
+                previous_values, (str, bytes)
+            ):
+                manifest_values = [float(value) for value in previous_values]
 
-    manifest_path = record_model_manifest(
-        SUAVE_MODEL_DIR,
-        TARGET_LABEL,
-        trial_number=selected_trial_number,
-        values=manifest_values,
-        params=selected_params,
-        model_path=selected_model_path,
-        calibrator_path=selected_calibrator_path,
-        study_name=make_study_name(
-            analysis_config.get("optuna_study_prefix"), TARGET_LABEL
-        ),
-        storage=analysis_config.get("optuna_storage"),
-    )
-    print(f"Updated SUAVE model manifest at {manifest_path}.")
-    model_manifest = load_model_manifest(SUAVE_MODEL_DIR, TARGET_LABEL)
+        if not manifest_values:
+            best_info_values = optuna_best_info.get("values")
+            if isinstance(best_info_values, Sequence) and not isinstance(
+                best_info_values, (str, bytes)
+            ):
+                manifest_values = [float(value) for value in best_info_values]
+
+        manifest_path = record_model_manifest(
+            SUAVE_MODEL_DIR,
+            TARGET_LABEL,
+            trial_number=selected_trial_number,
+            values=manifest_values,
+            params=selected_params,
+            model_path=selected_model_path,
+            calibrator_path=selected_calibrator_path,
+            study_name=make_study_name(
+                analysis_config.get("optuna_study_prefix"), TARGET_LABEL
+            ),
+            storage=analysis_config.get("optuna_storage"),
+        )
+        print(f"Updated SUAVE model manifest at {manifest_path}.")
+        model_manifest = load_model_manifest(SUAVE_MODEL_DIR, TARGET_LABEL)
 
 
 # %% [markdown]

--- a/tests/test_manual_param_setting.py
+++ b/tests/test_manual_param_setting.py
@@ -1,0 +1,301 @@
+"""Tests for manual parameter tuning scaffolding."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+import types
+
+import importlib
+import json
+from typing import Iterable, Optional
+
+import pytest
+import numpy as np
+import pandas as pd
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+
+if "IPython" not in sys.modules:
+    ipython_stub = types.ModuleType("IPython")
+    display_stub = types.ModuleType("IPython.display")
+
+    def _noop_display(*_: object, **__: object) -> None:  # pragma: no cover - stub
+        return None
+
+    display_stub.display = _noop_display
+    ipython_stub.display = display_stub
+    ipython_stub.get_ipython = lambda: None  # pragma: no cover - stub attribute
+    ipython_stub.version_info = (0, 0)
+    sys.modules["IPython"] = ipython_stub
+    sys.modules["IPython.display"] = display_stub
+
+
+@pytest.mark.parametrize(
+    "module_path",
+    [
+        "examples.mimic_mortality_utils",
+        "research_template.analysis_utils",
+    ],
+)
+def test_prepare_analysis_output_directories_initialises_manual_script(
+    tmp_path: Path, module_path: str
+) -> None:
+    """Ensure manual_param_setting.py is created with a default dictionary."""
+
+    module = importlib.import_module(module_path)
+    output_root = tmp_path / module_path.replace(".", "_")
+    directories = module.prepare_analysis_output_directories(
+        output_root, ["suave_model"]
+    )
+
+    manual_script = directories["suave_model"] / "manual_param_setting.py"
+    assert manual_script.exists()
+    content = manual_script.read_text(encoding="utf-8")
+    assert "manual_param_setting: dict = {}" in content
+
+    manual_script.write_text(
+        "manual_param_setting: dict = {\n    'learning_rate': 0.01\n}\n",
+        encoding="utf-8",
+    )
+
+    # Running the directory preparation again should keep custom content intact.
+    module.prepare_analysis_output_directories(output_root, ["suave_model"])
+    assert manual_script.read_text(encoding="utf-8").strip().startswith(
+        "manual_param_setting: dict = {"
+    )
+
+
+@pytest.mark.parametrize(
+    "module_path",
+    [
+        "examples.mimic_mortality_utils",
+        "research_template.analysis_utils",
+    ],
+)
+def test_manual_manifest_round_trip(tmp_path: Path, module_path: str) -> None:
+    """Manual manifest helpers should normalise paths and persist params."""
+
+    module = importlib.import_module(module_path)
+    model_dir = tmp_path / f"{module_path.replace('.', '_')}_model"
+    model_dir.mkdir(parents=True, exist_ok=True)
+
+    model_path = model_dir / "manual.pt"
+    calibrator_path = model_dir / "manual_calibrator.joblib"
+    model_path.write_text("model", encoding="utf-8")
+    calibrator_path.write_text("calibrator", encoding="utf-8")
+
+    manifest_path = module.record_manual_model_manifest(
+        model_dir,
+        "mortality",
+        model_path=model_path,
+        calibrator_path=calibrator_path,
+        params={"learning_rate": 0.01},
+    )
+    assert manifest_path.exists()
+
+    manifest = module.load_manual_model_manifest(model_dir, "mortality")
+    assert manifest.get("model_path") == "manual.pt"
+    assert manifest.get("params", {}).get("learning_rate") == 0.01
+
+    resolved = module.manifest_artifact_paths(manifest, model_dir)
+    assert resolved["model"] == model_path
+    assert resolved["calibrator"] == calibrator_path
+
+
+@pytest.mark.parametrize(
+    "module_path",
+    [
+        "examples.mimic_mortality_utils",
+        "research_template.analysis_utils",
+    ],
+)
+def test_collect_manual_and_optuna_overview(
+    tmp_path: Path, module_path: str
+) -> None:
+    """Manual/Optuna overview should prioritise manual entries and Pareto rows."""
+
+    module = importlib.import_module(module_path)
+    model_dir = tmp_path / f"{module_path.replace('.', '_')}_model"
+    optuna_dir = tmp_path / f"{module_path.replace('.', '_')}_optuna"
+    model_dir.mkdir(parents=True, exist_ok=True)
+    optuna_dir.mkdir(parents=True, exist_ok=True)
+
+    manual_model = model_dir / "manual.pt"
+    manual_calibrator = model_dir / "manual_calibrator.joblib"
+    manual_model.write_text("model", encoding="utf-8")
+    manual_calibrator.write_text("calibrator", encoding="utf-8")
+
+    module.record_manual_model_manifest(
+        model_dir,
+        "mortality",
+        model_path=manual_model,
+        calibrator_path=manual_calibrator,
+        params={"learning_rate": 0.01},
+        values=(0.9, 0.02),
+        validation_metrics={"ROAUC": 0.9},
+        tstr_metrics={"auroc": 0.88},
+        trtr_metrics={"auroc": 0.91},
+    )
+
+    best_info_path = optuna_dir / "optuna_best_info_mortality.json"
+    best_info_payload = {
+        "preferred_trial_number": 1,
+        "pareto_front": [
+            {"trial_number": 1, "values": [0.92, 0.02]},
+            {"trial_number": 2, "values": [0.91, 0.015]},
+        ],
+    }
+    best_info_path.write_text(json.dumps(best_info_payload), encoding="utf-8")
+
+    best_params_path = optuna_dir / "optuna_best_params_mortality.json"
+    best_params_payload = {"preferred_params": {"latent_dim": 16}}
+    best_params_path.write_text(json.dumps(best_params_payload), encoding="utf-8")
+
+    trials_path = optuna_dir / "optuna_trials_mortality.csv"
+    trials_path.write_text(
+        "trial_number,validation_roauc,tstr_trtr_delta_auc\n1,0.92,0.02\n3,0.89,0.01\n",
+        encoding="utf-8",
+    )
+
+    summary_df, ranked_df = module.collect_manual_and_optuna_overview(
+        target_label="mortality",
+        model_dir=model_dir,
+        optuna_dir=optuna_dir,
+        study_prefix=None,
+        storage=None,
+    )
+
+    assert not summary_df.empty
+    assert summary_df.iloc[0]["Source"] == "Manual override"
+    assert "manual.pt" in summary_df.iloc[0]["Model path"]
+
+    assert not ranked_df.empty
+    assert ranked_df.iloc[0]["Source"] == "Manual override"
+    assert "Optuna study" in ranked_df["Source"].tolist()
+
+
+@pytest.mark.parametrize(
+    "module_path",
+    [
+        "examples.mimic_mortality_utils",
+        "research_template.analysis_utils",
+    ],
+)
+def test_parse_script_arguments_accepts_manual(module_path: str) -> None:
+    """The CLI parser should accept the manual override keyword."""
+
+    module = importlib.import_module(module_path)
+    assert module.parse_script_arguments(["manual"]) == "manual"
+    assert module.parse_script_arguments(["--trial-id", "manual"]) == "manual"
+    assert module.parse_script_arguments([]) is None
+
+
+@pytest.mark.parametrize(
+    "module_path",
+    [
+        "examples.mimic_mortality_utils",
+        "research_template.analysis_utils",
+    ],
+)
+def test_prompt_manual_override_action_accepts_manual(module_path: str) -> None:
+    """Manual selection helper should accept the 'manual' keyword."""
+
+    module = importlib.import_module(module_path)
+    responses = iter(["manual"])
+
+    action = module.prompt_manual_override_action(input_fn=lambda prompt: next(responses))
+    assert action == "reuse"
+
+
+@pytest.mark.parametrize(
+    "module_path",
+    [
+        "examples.mimic_mortality_utils",
+        "research_template.analysis_utils",
+    ],
+)
+def test_prompt_manual_override_action_handles_interrupt(module_path: str) -> None:
+    """Keyboard interrupts should default to continuing with Optuna once confirmed."""
+
+    module = importlib.import_module(module_path)
+
+    def _inputs() -> Iterable[object]:
+        yield KeyboardInterrupt()
+        yield "y"
+
+    responses = _inputs()
+
+    def _input(prompt: str) -> str:
+        result = next(responses)
+        if isinstance(result, BaseException):
+            raise result
+        return str(result)
+
+    action = module.prompt_manual_override_action(input_fn=_input)
+    assert action == "optuna"
+
+
+@pytest.mark.parametrize(
+    "module_path",
+    [
+        "examples.mimic_mortality_utils",
+        "research_template.analysis_utils",
+    ],
+)
+def test_evaluate_candidate_model_performance_shared(module_path: str) -> None:
+    """Both modules should expose the shared candidate evaluation helper."""
+
+    module = importlib.import_module(module_path)
+
+    X_train = pd.DataFrame({"age": [30, 40, 50, 60], "score": [0.1, 0.2, 0.3, 0.4]})
+    y_train = pd.Series([0, 1, 0, 1])
+    X_validation = pd.DataFrame({"age": [35, 45], "score": [0.15, 0.25]})
+    y_validation = pd.Series([0, 1])
+
+    class _DummyModel:
+        def __init__(self, sample_frame: pd.DataFrame) -> None:
+            self._sample_frame = sample_frame.reset_index(drop=True)
+
+        def predict_proba(self, X: pd.DataFrame) -> np.ndarray:  # pragma: no cover - unused
+            return np.tile(np.array([0.4, 0.6]), (len(X), 1))
+
+        def sample(
+            self,
+            n_samples: int,
+            conditional: bool = True,
+            y: Optional[pd.Series] = None,
+        ) -> pd.DataFrame:
+            reps = (n_samples + len(self._sample_frame) - 1) // len(self._sample_frame)
+            tiled = pd.concat([self._sample_frame] * reps, ignore_index=True)
+            return tiled.iloc[:n_samples].reset_index(drop=True)
+
+    dummy_model = _DummyModel(X_train)
+    validation_probs = np.column_stack(
+        [1 - y_validation.to_numpy(), y_validation.to_numpy()]
+    )
+
+    results = module.evaluate_candidate_model_performance(
+        dummy_model,  # type: ignore[arg-type]
+        feature_columns=["age", "score"],
+        X_train=X_train,
+        y_train=y_train,
+        X_validation=X_validation,
+        y_validation=y_validation,
+        random_state=0,
+        probability_fn=lambda _model, frame: validation_probs,
+    )
+
+    assert set(results.keys()) == {
+        "validation_metrics",
+        "tstr_metrics",
+        "trtr_metrics",
+        "delta_auc",
+        "values",
+    }
+    assert isinstance(results["values"], tuple)
+    assert len(results["values"]) == 2


### PR DESCRIPTION
## Summary
- add prompt_manual_override_action and evaluate_candidate_model_performance helpers so manual overrides and Optuna share the same evaluation flow
- update the example and template optimisation scripts to use the shared evaluation helper and improved manual action prompt
- document the shared helper and prompt behaviour in the research protocol and template README while extending manual tuning tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d911c42c608320be4a57f347dec016