### PR TITLE
Fix bootstrap cache reuse before evaluation

### DIFF
--- a/docs/research_protocol.md
+++ b/docs/research_protocol.md
@@ -207,7 +207,7 @@ print(train_labels.head())</code></pre>
 
 ### 缓存判定信息
 
-- `07_bootstrap_analysis/`：针对 SUAVE 主模型与临床基线的分类/校准评估，`evaluate_predictions` 会按“模型 × 数据集”落盘 `*_bootstrap.joblib`，其中包含 `overall`、`per_class` 等 DataFrame。命中缓存时直接读取；若设置 `FORCE_UPDATE_BOOTSTRAP=True` 则忽略缓存重新计算。
+- `07_bootstrap_analysis/`：针对 SUAVE 主模型与临床基线的分类/校准评估，`evaluate_predictions` 会按“模型 × 数据集”落盘 `*_bootstrap.joblib`，其中包含 `overall`、`per_class` 等 DataFrame。命中缓存时直接读取，避免重复触发 bootstrap 进度条；若设置 `FORCE_UPDATE_BOOTSTRAP=True` 则忽略缓存重新计算。
 - `10_tstr_trtr_transfer/training_sets/`：`build_tstr_training_sets` 保存 `manifest_{label}.json` 与对应的 TSV，manifest 内记录特征列、生成时间与 SUAVE manifest 的 SHA256。脚本会校验 manifest 与当前配置/生成器签名一致，若 `FORCE_UPDATE_SYNTHETIC_DATA=True` 或签名不匹配则重建训练集并刷新后续缓存。
 - `10_tstr_trtr_transfer/tstr_results_{label}.joblib`、`trtr_results_{label}.joblib`：存储真实/合成训练下的基线模型预测表与指标。缓存载荷包含 `training_manifest_signature` 与当前 SUAVE manifest 的 SHA256（`data_generator_signature`），命中缓存需与最新训练集一致；可通过 `FORCE_UPDATE_TSTR_MODEL`、`FORCE_UPDATE_TRTR_MODEL` 控制重新拟合。
 - `10_tstr_trtr_transfer/bootstrap_cache/`：`evaluate_transfer_baselines` 针对每个“训练方案 × 评估集 × 模型”单独缓存 bootstrap 明细。校验字段包含 `training_manifest_signature`、`data_generator_signature`、`prediction_signature`（基于概率与预测的哈希）及 `bootstrap_n`。任一信息变化或显式启用 `FORCE_UPDATE_TSTR_BOOTSTRAP` / `FORCE_UPDATE_TRTR_BOOTSTRAP` 时会重新执行 bootstrap。

--- a/examples/research-mimic_mortality_supervised.py
+++ b/examples/research-mimic_mortality_supervised.py
@@ -1209,22 +1209,10 @@ for model_name, dataset_tables in model_prediction_frames.items():
     model_warning_frames: List[pd.DataFrame] = []
 
     for dataset_name, prediction_df in dataset_tables.items():
-        results = evaluate_predictions(
-            prediction_df,
-            label_col="label",
-            pred_col="y_pred",
-            positive_label=positive_label_name,
-            bootstrap_n=1000,
-            random_state=RANDOM_STATE,
-            show_progress=True,
-            progress_desc=f"Bootstrap | {model_name} @ {dataset_name}",
-        )
-        model_results[dataset_name] = results
-
         dataset_slug = _sanitise_path_component(dataset_name.lower())
         dataset_cache_path = model_dir / f"{dataset_slug}_bootstrap.joblib"
 
-        cached_results: Optional[Dict[str, pd.DataFrame]] = None
+        results: Optional[Dict[str, pd.DataFrame]] = None
         if dataset_cache_path.exists() and not FORCE_UPDATE_BOOTSTRAP:
             try:
                 potential_results = joblib.load(dataset_cache_path)
@@ -1239,7 +1227,7 @@ for model_name, dataset_tables in model_prediction_frames.items():
                 if isinstance(potential_results, dict) and required_keys.issubset(
                     potential_results.keys()
                 ):
-                    cached_results = potential_results
+                    results = potential_results
                     print(
                         "Loaded cached bootstrap metrics for",
                         f"{model_name} @ {dataset_name}",
@@ -1250,7 +1238,7 @@ for model_name, dataset_tables in model_prediction_frames.items():
                         f"{model_name} @ {dataset_name} due to missing keys.",
                     )
 
-        if cached_results is None:
+        if results is None:
             results = evaluate_predictions(
                 prediction_df,
                 label_col="label",
@@ -1263,9 +1251,6 @@ for model_name, dataset_tables in model_prediction_frames.items():
             )
             joblib.dump(results, dataset_cache_path)
             print("Saved bootstrap metrics to", dataset_cache_path)
-        else:
-            results = cached_results
-
         model_results[dataset_name] = results
 
         overall_df = results["overall"].copy()

--- a/research_template/RESEARCH_README.md
+++ b/research_template/RESEARCH_README.md
@@ -204,7 +204,7 @@
 
 ### 缓存判定信息
 
-- `07_bootstrap_analysis/`：主分析脚本会将每个“模型 × 数据集”的 bootstrap 结果保存为 `*_bootstrap.joblib`，其中包含总体/分层指标与抽样记录。命中缓存时直接读取；若 `FORCE_UPDATE_BOOTSTRAP=True` 则重新计算。
+- `07_bootstrap_analysis/`：主分析脚本会将每个“模型 × 数据集”的 bootstrap 结果保存为 `*_bootstrap.joblib`，其中包含总体/分层指标与抽样记录。命中缓存时直接读取，避免重复展示 bootstrap 进度条；若 `FORCE_UPDATE_BOOTSTRAP=True` 则重新计算。
 - `10_tstr_trtr_transfer/training_sets/`：`build_tstr_training_sets` 会生成 TSV 与 `manifest_{label}.json`，manifest 记录特征列、生成时间以及 SUAVE manifest 的 SHA256。若签名与当前配置不一致或启用了 `FORCE_UPDATE_SYNTHETIC_DATA`，训练集会被重建，后续依赖同一签名的缓存也会失效。
 - `10_tstr_trtr_transfer/tstr_results_{label}.joblib`、`trtr_results_{label}.joblib`：存储真实/合成训练下的基线预测结果与指标，并携带 `training_manifest_signature`、`data_generator_signature` 等元数据。只有当签名匹配且未启用 `FORCE_UPDATE_TSTR_MODEL` / `FORCE_UPDATE_TRTR_MODEL` 时才会复用。
 - `10_tstr_trtr_transfer/bootstrap_cache/`：`evaluate_transfer_baselines` 在完成一次 bootstrap 后立即写入缓存，校验字段包括 `training_manifest_signature`、`data_generator_signature`、`prediction_signature` 与 `bootstrap_n`。当预测发生变化或启用 `FORCE_UPDATE_TSTR_BOOTSTRAP`、`FORCE_UPDATE_TRTR_BOOTSTRAP` 时会重新采样。


### PR DESCRIPTION
## Summary
- ensure bootstrap results in the supervised research workflow reuse the cache before recomputing
- mirror the caching change into the research template and refresh the protocol notes

## Testing
- python - <<'PY' ... (see 23b953)


------
https://chatgpt.com/codex/tasks/task_e_68d9493f306083208f6518d46da2c68a