### PR TITLE
Clarify manual override in trial selection CLI help

### DIFF
--- a/examples/mimic_mortality_utils.py
+++ b/examples/mimic_mortality_utils.py
@@ -1002,7 +1002,10 @@ def parse_script_arguments(argv: Sequence[str]) -> Optional[Union[str, int]]:
     """
 
     parser = argparse.ArgumentParser(
-        description="Select an Optuna trial for SUAVE model loading/training.",
+        description=(
+            "Select an Optuna trial for SUAVE model loading/training, or pass"
+            " 'manual' to load the manual tuning manifest."
+        ),
     )
 
     def _trial_argument(value: str) -> Union[str, int]:
@@ -1019,13 +1022,19 @@ def parse_script_arguments(argv: Sequence[str]) -> Optional[Union[str, int]]:
         "trial_id",
         nargs="?",
         type=_trial_argument,
-        help="Optuna trial identifier to load or train.",
+        help=(
+            "Optuna trial identifier to load or train; pass 'manual' to load the"
+            " manual tuning manifest."
+        ),
     )
     parser.add_argument(
         "--trial-id",
         dest="trial_id_flag",
         type=_trial_argument,
-        help="Optuna trial identifier to load or train.",
+        help=(
+            "Optuna trial identifier to load or train; pass 'manual' to load the"
+            " manual tuning manifest."
+        ),
     )
     args = parser.parse_args(list(argv))
     if args.trial_id_flag is not None:

--- a/research_template/RESEARCH_README.md
+++ b/research_template/RESEARCH_README.md
@@ -34,7 +34,7 @@
    - 执行 `python research-suave_optimize.py` 生成帕累托前沿、最优 Trial JSON 与调参可视化。目录结构遵循 `analysis_config.py` 的 `ANALYSIS_SUBDIRECTORIES` 定义。
 
 5. **执行主分析**
-   - 运行 `python research-supervised_analysis.py [--trial-id N]` 以加载或训练目标模型、拟合校准器并完成下游评估。交互模式会提示选择 Trial，脚本模式可通过参数或环境变量控制缓存策略。
+   - 运行 `python research-supervised_analysis.py [--trial-id N]` 以加载或训练目标模型、拟合校准器并完成下游评估。交互模式会提示选择 Trial，脚本模式可通过参数或环境变量控制缓存策略。使用 `--help` 查看命令行提示，可知传入 `manual` 可直接加载手动模型 manifest。
    - 若需刷新缓存，可按需设置 `FORCE_UPDATE_BENCHMARK_MODEL`、`FORCE_UPDATE_SYNTHETIC_DATA`、`FORCE_UPDATE_TSTR_MODEL`、`FORCE_UPDATE_TRTR_MODEL`、`FORCE_UPDATE_C2ST_MODEL`、`FORCE_UPDATE_DISTRIBUTION_SHIFT`。脚本模式下这些变量默认开启（值为 `1`）以保证批处理稳定性，交互模式默认关闭（值为 `0`）以节省时间。
 
 6. **整理与归档**

--- a/research_template/analysis_utils.py
+++ b/research_template/analysis_utils.py
@@ -847,7 +847,10 @@ def parse_script_arguments(argv: Sequence[str]) -> Optional[Union[str, int]]:
     """
 
     parser = argparse.ArgumentParser(
-        description="Select an Optuna trial for SUAVE model loading/training.",
+        description=(
+            "Select an Optuna trial for SUAVE model loading/training, or pass"
+            " 'manual' to load the manual tuning manifest."
+        ),
     )
 
     def _trial_argument(value: str) -> Union[str, int]:
@@ -864,13 +867,19 @@ def parse_script_arguments(argv: Sequence[str]) -> Optional[Union[str, int]]:
         "trial_id",
         nargs="?",
         type=_trial_argument,
-        help="Optuna trial identifier to load or train.",
+        help=(
+            "Optuna trial identifier to load or train; pass 'manual' to load the"
+            " manual tuning manifest."
+        ),
     )
     parser.add_argument(
         "--trial-id",
         dest="trial_id_flag",
         type=_trial_argument,
-        help="Optuna trial identifier to load or train.",
+        help=(
+            "Optuna trial identifier to load or train; pass 'manual' to load the"
+            " manual tuning manifest."
+        ),
     )
     args = parser.parse_args(list(argv))
     if args.trial_id_flag is not None:


### PR DESCRIPTION
## Summary
- mention the manual override manifest in the CLI description and trial-id help text for the MIMIC mortality example utilities
- mirror the description and help text updates in the research template utilities and note the manual flag in the template README

## Testing
- pytest tests/test_manual_param_setting.py
- python examples/research-mimic_mortality_supervised.py --help *(fails: missing optional dependency `IPython` in the test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d949b7b710832088e392f4f2b6a375