### PR TITLE
Handle notebook execution fallback for supervised analysis scripts

### DIFF
--- a/examples/research-mimic_mortality_supervised.py
+++ b/examples/research-mimic_mortality_supervised.py
@@ -65,11 +65,29 @@ from sklearn.pipeline import Pipeline
 from sklearn.preprocessing import StandardScaler
 from sklearn.svm import SVC
 
-EXAMPLES_DIR = Path(__file__).resolve().parent
-if not EXAMPLES_DIR.exists():
+def _resolve_examples_dir() -> Path:
+    """Resolve the examples directory for both scripts and notebooks."""
+
+    candidates = []
+    try:
+        candidates.append(Path(__file__).resolve().parent)
+    except NameError:
+        # ``__file__`` is not defined inside notebooks executed via Jupyter.
+        pass
+
+    cwd = Path.cwd()
+    candidates.extend([cwd, cwd / "examples"])
+
+    for candidate in candidates:
+        if candidate.exists() and (candidate / "mimic_mortality_utils.py").exists():
+            return candidate
+
     raise RuntimeError(
         "Run this notebook from the repository root so 'examples' is available."
     )
+
+
+EXAMPLES_DIR = _resolve_examples_dir()
 if str(EXAMPLES_DIR) not in sys.path:
     sys.path.insert(0, str(EXAMPLES_DIR))
 

--- a/research_template/research-supervised_analysis.py
+++ b/research_template/research-supervised_analysis.py
@@ -70,11 +70,29 @@ from analysis_config import (
     PATH_GRAPH_NODE_LABELS,
 )
 
-EXAMPLES_DIR = Path(__file__).resolve().parent
-if not EXAMPLES_DIR.exists():
+def _resolve_examples_dir() -> Path:
+    """Resolve the template directory for both scripts and notebooks."""
+
+    candidates = []
+    try:
+        candidates.append(Path(__file__).resolve().parent)
+    except NameError:
+        # ``__file__`` is not defined when executing inside a notebook.
+        pass
+
+    cwd = Path.cwd()
+    candidates.extend([cwd, cwd / "research_template"])
+
+    for candidate in candidates:
+        if candidate.exists() and (candidate / "analysis_config.py").exists():
+            return candidate
+
     raise RuntimeError(
-        "Run this notebook from the repository root so 'examples' is available."
+        "Run this notebook from the repository root so 'research_template' is available."
     )
+
+
+EXAMPLES_DIR = _resolve_examples_dir()
 if str(EXAMPLES_DIR) not in sys.path:
     sys.path.insert(0, str(EXAMPLES_DIR))
 


### PR DESCRIPTION
## Summary
- add helpers that resolve the examples directory when __file__ is unavailable in notebook runs
- ensure both the research script and its template counterpart fall back to cwd-based locations

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d95da147908320af05aa47b7404e4a