### PR TITLE
Handle Optuna visualisation legend compatibility

### DIFF
--- a/examples/mimic_mortality_utils.py
+++ b/examples/mimic_mortality_utils.py
@@ -575,7 +575,8 @@ def render_dataframe(
         print("(empty table)")
         return
     if is_interactive_session():
-        display(df)
+        with pd.option_context("display.max_columns", None):
+            display(df)
         return
     tabulate_kwargs = {"headers": "keys", "tablefmt": "github", "showindex": False}
     if floatfmt is not None:
@@ -1126,7 +1127,10 @@ def render_optuna_parameter_grid(
                 continue
 
             for trace in subplot_fig.data:
-                trace.showlegend = False
+                try:
+                    trace.showlegend = False
+                except ValueError:
+                    pass
                 row_fig.add_trace(trace, row=1, col=col_idx)
 
             # Attempt to propagate axis titles where available.

--- a/research_template/analysis_utils.py
+++ b/research_template/analysis_utils.py
@@ -421,7 +421,8 @@ def render_dataframe(
         print("(empty table)")
         return
     if is_interactive_session():
-        display(df)
+        with pd.option_context("display.max_columns", None):
+            display(df)
         return
     tabulate_kwargs = {"headers": "keys", "tablefmt": "github", "showindex": False}
     if floatfmt is not None:
@@ -971,7 +972,10 @@ def render_optuna_parameter_grid(
                 continue
 
             for trace in subplot_fig.data:
-                trace.showlegend = False
+                try:
+                    trace.showlegend = False
+                except ValueError:
+                    pass
                 row_fig.add_trace(trace, row=1, col=col_idx)
 
             xaxis = getattr(subplot_fig.layout, "xaxis", None)


### PR DESCRIPTION
## Summary
- prevent Plotly traces without a `showlegend` attribute from raising errors when building Optuna visualisations
- allow interactive dataframe rendering to display all columns so Optuna parameter tables are fully visible

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d9820b4e7c8320aae3d21bda38ab77