### PR TITLE
Handle binary SUAVE archive load failures

### DIFF
--- a/tests/test_model_serialization.py
+++ b/tests/test_model_serialization.py
@@ -1,0 +1,21 @@
+from pathlib import Path
+import sys
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from suave.model import SUAVE
+
+
+def test_load_binary_archive_reports_torch_error(tmp_path):
+    archive = tmp_path / "broken_model.pt"
+    archive.write_bytes(b"PK\x03\x04broken archive contents")
+
+    with pytest.raises(RuntimeError) as excinfo:
+        SUAVE.load(archive)
+
+    message = str(excinfo.value)
+    assert "Failed to load binary SUAVE archive" in message
+    assert "PytorchStreamReader failed reading zip archive" in message
+    assert "UnicodeDecodeError" not in message


### PR DESCRIPTION
## Summary
- capture torch.load failures during SUAVE.load and restrict JSON fallback to text archives
- raise a descriptive runtime error when binary archives cannot be loaded
- add a regression test covering the binary archive failure message

## Testing
- pytest tests/test_model_serialization.py

------
https://chatgpt.com/codex/tasks/task_e_68d983d031e88320a052b3451a2c7a4b