### PR TITLE
Ensure ranked Optuna table highlights objectives and params

### DIFF
--- a/examples/mimic_mortality_utils.py
+++ b/examples/mimic_mortality_utils.py
@@ -1649,33 +1649,36 @@ def _build_manual_optuna_ranked_table(
             identifier_key = str(trial_identifier)
             if identifier_key in seen_identifiers:
                 continue
+            record_dict = record.to_dict()
+            validation, delta = _extract_trial_metrics(record_dict)
             row: Dict[str, object] = {
                 "Source": "Optuna study",
                 "Saved locally": "",
                 "Trial ID": trial_identifier,
                 "Model path": "",
-                "Validation ROAUC": _coerce_float(
-                    record.get("validation_roauc")
-                ),
-                "TSTR/TRTR ΔAUC": _coerce_float(
-                    record.get("tstr_trtr_delta_auc")
-                ),
+                "Validation ROAUC": validation,
+                "TSTR/TRTR ΔAUC": delta,
             }
 
-            for column_name, value in _collect_metric_columns(record.to_dict()).items():
+            for column_name, value in _collect_metric_columns(record_dict).items():
                 row[column_name] = value
                 _append_unique(metric_columns, column_name)
+
+            for column_name, value in _collect_param_columns(record_dict).items():
+                row[column_name] = value
+                _append_unique(param_columns, column_name)
 
             for column_name in record.index:
                 if column_name in {
                     "trial_number",
                     "validation_roauc",
                     "tstr_trtr_delta_auc",
+                    "params",
                 }:
                     continue
                 value = record.get(column_name)
-                row[column_name] = value
                 _append_unique(param_columns, str(column_name))
+                row[column_name] = value
 
             rows.append(row)
 

--- a/research_template/analysis_utils.py
+++ b/research_template/analysis_utils.py
@@ -1493,33 +1493,36 @@ def _build_manual_optuna_ranked_table(
             identifier_key = str(trial_identifier)
             if identifier_key in seen_identifiers:
                 continue
+            record_dict = record.to_dict()
+            validation, delta = _extract_trial_metrics(record_dict)
             row: Dict[str, object] = {
                 "Source": "Optuna study",
                 "Saved locally": "",
                 "Trial ID": trial_identifier,
                 "Model path": "",
-                "Validation ROAUC": _coerce_float(
-                    record.get("validation_roauc")
-                ),
-                "TSTR/TRTR ΔAUC": _coerce_float(
-                    record.get("tstr_trtr_delta_auc")
-                ),
+                "Validation ROAUC": validation,
+                "TSTR/TRTR ΔAUC": delta,
             }
 
-            for column_name, value in _collect_metric_columns(record.to_dict()).items():
+            for column_name, value in _collect_metric_columns(record_dict).items():
                 row[column_name] = value
                 _append_unique(metric_columns, column_name)
+
+            for column_name, value in _collect_param_columns(record_dict).items():
+                row[column_name] = value
+                _append_unique(param_columns, column_name)
 
             for column_name in record.index:
                 if column_name in {
                     "trial_number",
                     "validation_roauc",
                     "tstr_trtr_delta_auc",
+                    "params",
                 }:
                     continue
                 value = record.get(column_name)
-                row[column_name] = value
                 _append_unique(param_columns, str(column_name))
+                row[column_name] = value
 
             rows.append(row)
 


### PR DESCRIPTION
## Summary
- derive Optuna study trial objectives via the shared metric helper so the interactive ranked table always shows the optimisation targets
- include Optuna study parameter columns when present and ignore raw params mappings for cleaner display
- extend the regression test to assert that ranked summaries expose objective metrics and parameters from manual, Pareto and study sources

## Testing
- `pytest tests/test_manual_param_setting.py`


------
https://chatgpt.com/codex/tasks/task_e_68d98866e1cc83208d184540e34c7156