### PR TITLE
Limit manual overview metrics to ROAUC delta

### DIFF
--- a/examples/mimic_mortality_utils.py
+++ b/examples/mimic_mortality_utils.py
@@ -1421,6 +1421,8 @@ TRIAL_SUMMARY_BASE_COLUMNS = [
     "TSTR/TRTR ΔAUC",
 ]
 
+TRIAL_SUMMARY_ALLOWED_METRICS = {"Validation ROAUC"}
+
 
 def _format_metric_column(prefix: str, metric_key: object) -> str:
     """Return a human-readable column name for metric ``metric_key``."""
@@ -1463,6 +1465,8 @@ def _collect_metric_columns(source: object) -> Dict[str, float]:
                 continue
             for metric_key, metric_value in raw_metrics.items():
                 column_name = _format_metric_column(prefix, metric_key)
+                if column_name not in TRIAL_SUMMARY_ALLOWED_METRICS:
+                    continue
                 metric_columns[column_name] = _coerce_float(metric_value)
 
     return metric_columns

--- a/research_template/analysis_utils.py
+++ b/research_template/analysis_utils.py
@@ -1266,6 +1266,8 @@ TRIAL_SUMMARY_BASE_COLUMNS = [
     "TSTR/TRTR ΔAUC",
 ]
 
+TRIAL_SUMMARY_ALLOWED_METRICS = {"Validation ROAUC"}
+
 
 def _format_metric_column(prefix: str, metric_key: object) -> str:
     """Return a human-readable column name for metric ``metric_key``."""
@@ -1308,6 +1310,8 @@ def _collect_metric_columns(source: object) -> Dict[str, float]:
                 continue
             for metric_key, metric_value in raw_metrics.items():
                 column_name = _format_metric_column(prefix, metric_key)
+                if column_name not in TRIAL_SUMMARY_ALLOWED_METRICS:
+                    continue
                 metric_columns[column_name] = _coerce_float(metric_value)
 
     return metric_columns


### PR DESCRIPTION
## Summary
- restore Optuna CSV validation and transfer metrics in the manual tuning overview so study rows keep their true scores
- mirror the CSV metric handling in the research template helper and document the preserved metrics in the template README
- limit the manual overview metrics to Validation ROAUC and TSTR/TRTR ΔAUC and document the trimmed display in the template guide

## Testing
- pytest tests/test_manual_param_setting.py

------
https://chatgpt.com/codex/tasks/task_e_68d98ec1ca1c832089869f7b2645dc1c