### PR TITLE
Refactor bootstrap report export layout

### DIFF
--- a/examples/research-mimic_mortality_supervised.py
+++ b/examples/research-mimic_mortality_supervised.py
@@ -158,6 +158,7 @@ from mimic_mortality_utils import (  # noqa: E402
 from cls_eval import (  # noqa: E402
     evaluate_predictions,
     write_results_to_excel_unique,
+    export_dataset_grouped_tables,
     export_three_line_tables,
     _format_three_line_ci,
     _write_three_line_workbook,
@@ -1577,7 +1578,7 @@ if "class" in bootstrap_per_class_df.columns:
 elif "Class" in bootstrap_per_class_df.columns:
     perclass_index_columns.append("Class")
 
-export_three_line_tables(
+export_dataset_grouped_tables(
     {
         "Summary": bootstrap_summary_df,
         "overall": bootstrap_overall_df,
@@ -1594,6 +1595,7 @@ export_three_line_tables(
     drop_columns=("Target",),
     decimals=3,
     ci_label_text="95%",
+    ci_only=True,
 )
 
 print("Saved formatted three-line benchmark workbook to", three_line_benchmark_path)

--- a/research_template/RESEARCH_README.md
+++ b/research_template/RESEARCH_README.md
@@ -281,6 +281,7 @@ for cache_path in sorted(cache_dir.glob("*_bootstrap.joblib")):
     payload = joblib.load(cache_path)
     print(cache_path.name, payload.keys())
 </code></pre> |
+> **更新提示**：生成的 `report_bootstrap_{label}.xlsx` 现采用“数据集 × 模型”行分组结构，自动合并相邻行中的数据集单元格，并仅保留带 95% 置信区间的指标列（如 ACC/AUROC/AUPRC/F1 micro）。这样可直接得到 n×k 行、m 列的摘要表格，满足论文写作需求；原始数值仍可在 `bootstrap_benchmark_{label}.xlsx` 中查阅。
 | 10. 合成数据 - TSTR/TRTR | TSTR/TRTR箱线图 | 图像 | `plot_transfer_metric_boxes` 生成的 Accuracy/AUROC 与 ΔAccuracy/ΔAUROC 箱线图；单模型时按训练数据集排布，多模型时横轴展示模型、箱体按数据集着色 | TSTR/TRTR bootstrap 明细表（`combined_bootstrap_df`、`delta_bootstrap_df`） | `OUTPUT_DIR / "10_tstr_trtr_transfer" / f"tstr_results_{label}.joblib"`<br>`OUTPUT_DIR / "10_tstr_trtr_transfer" / f"trtr_results_{label}.joblib"` | <pre><code class="language-python">from pathlib import Path
 import joblib
 

--- a/research_template/research-supervised_analysis.py
+++ b/research_template/research-supervised_analysis.py
@@ -148,6 +148,7 @@ from analysis_utils import (  # noqa: E402
 from cls_eval import (  # noqa: E402
     evaluate_predictions,
     write_results_to_excel_unique,
+    export_dataset_grouped_tables,
     export_three_line_tables,
     _format_three_line_ci,
     _write_three_line_workbook,
@@ -1565,7 +1566,7 @@ if "class" in bootstrap_per_class_df.columns:
 elif "Class" in bootstrap_per_class_df.columns:
     perclass_index_columns.append("Class")
 
-export_three_line_tables(
+export_dataset_grouped_tables(
     {
         "Summary": bootstrap_summary_df,
         "overall": bootstrap_overall_df,
@@ -1582,6 +1583,7 @@ export_three_line_tables(
     drop_columns=("Target",),
     decimals=3,
     ci_label_text="95%",
+    ci_only=True,
 )
 
 print("Saved formatted three-line benchmark workbook to", three_line_benchmark_path)

--- a/tests/test_dataset_grouped_export.py
+++ b/tests/test_dataset_grouped_export.py
@@ -1,0 +1,70 @@
+"""Tests for dataset-grouped bootstrap report export utilities."""
+
+from pathlib import Path
+import sys
+
+import pandas as pd
+from openpyxl import load_workbook
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.append(str(ROOT / "research_template"))
+
+from cls_eval import export_dataset_grouped_tables
+
+
+def test_export_dataset_grouped_tables(tmp_path):
+    """Ensure dataset-grouped export merges dataset cells and formats CIs."""
+
+    df = pd.DataFrame(
+        {
+            "Target": ["demo"] * 3,
+            "Model": ["SUAVE", "LogReg", "Clinical"],
+            "Dataset": ["Test", "Test", "External"],
+            "accuracy": [0.9, 0.85, 0.8],
+            "accuracy_ci_low": [0.88, 0.83, 0.79],
+            "accuracy_ci_high": [0.92, 0.87, 0.81],
+            "roc_auc": [0.95, 0.9, 0.85],
+            "roc_auc_ci_low": [0.93, 0.88, 0.83],
+            "roc_auc_ci_high": [0.97, 0.92, 0.87],
+        }
+    )
+
+    output_path = tmp_path / "report.xlsx"
+    result = export_dataset_grouped_tables(
+        {"Summary": df},
+        output_path,
+        index_columns={"Summary": ["Model"]},
+        dataset_column="Dataset",
+        dataset_order=["Test", "External"],
+        drop_columns=("Target",),
+        ci_label_text="95%",
+        ci_only=True,
+    )
+
+    assert result == output_path
+    assert output_path.exists()
+
+    workbook = load_workbook(output_path)
+    sheet = workbook["Summary"]
+
+    assert sheet["A1"].value == "Dataset"
+    assert sheet["B1"].value == "Model"
+    assert sheet["C1"].value == "accuracy (95% CI)"
+    assert sheet["D1"].value == "roc_auc (95% CI)"
+
+    assert sheet["A2"].value == "Test"
+    assert sheet["B2"].value == "LogReg"
+    assert sheet["C2"].value == "0.850 (0.830–0.870)"
+    assert sheet["D2"].value == "0.900 (0.880–0.920)"
+
+    assert sheet["B3"].value == "SUAVE"
+    assert sheet["C3"].value == "0.900 (0.880–0.920)"
+    assert sheet["D3"].value == "0.950 (0.930–0.970)"
+
+    # Second row shares merged dataset cell with first row.
+    merged_ranges = {str(rng) for rng in sheet.merged_cells.ranges}
+    assert "A2:A3" in merged_ranges
+
+    # External dataset appears last with its own CI string.
+    assert sheet["A4"].value == "External"
+    assert sheet["C4"].value == "0.800 (0.790–0.810)"


### PR DESCRIPTION
## Summary
- add dataset-grouped export helpers for bootstrap reports in both template and example classifiers
- update supervised analysis pipelines to generate summary workbooks with merged dataset rows and CI-only columns
- document the new layout and cover it with a regression test for the exported workbook

## Testing
- pytest tests/test_dataset_grouped_export.py

------
https://chatgpt.com/codex/tasks/task_e_68d99364dbfc83208a604aeef05b8c00