### PR TITLE
Preserve beta and gumbel temperature in saved SUAVE models

### DIFF
--- a/suave/model.py
+++ b/suave/model.py
@@ -3818,6 +3818,7 @@ class SUAVE:
             "behaviour": self.behaviour,
             "latent_dim": self.latent_dim,
             "n_components": self.n_components,
+            "beta": self.beta,
             "hidden_dims": list(self.hidden_dims),
             "head_hidden_dims": list(self.head_hidden_dims),
             "dropout": self.dropout,
@@ -3827,6 +3828,7 @@ class SUAVE:
             "val_split": self.val_split,
             "stratify": self.stratify,
             "random_state": self.random_state,
+            "gumbel_temperature": self.gumbel_temperature,
             "tau_start": self._tau_start,
             "tau_min": self._tau_min,
             "tau_decay": self._tau_decay,
@@ -4022,6 +4024,7 @@ class SUAVE:
         for key in (
             "latent_dim",
             "n_components",
+            "beta",
             "hidden_dims",
             "head_hidden_dims",
             "classification_loss_weight",
@@ -4032,6 +4035,7 @@ class SUAVE:
             "val_split",
             "stratify",
             "random_state",
+            "gumbel_temperature",
             "tau_start",
             "tau_min",
             "tau_decay",
@@ -4048,6 +4052,8 @@ class SUAVE:
                 elif key == "head_hidden_dims":
                     value = tuple(int(v) for v in value)
                 elif key in {
+                    "beta",
+                    "gumbel_temperature",
                     "tau_start",
                     "tau_min",
                     "tau_decay",

--- a/tests/test_training_schedule.py
+++ b/tests/test_training_schedule.py
@@ -65,6 +65,35 @@ def test_training_schedule_runs_all_phases():
     assert model._classifier is not None
 
 
+def test_save_load_preserves_beta_and_gumbel_temperature(tmp_path):
+    X, y, schema = _toy_dataset()
+    model = SUAVE(
+        schema=schema,
+        latent_dim=3,
+        n_components=2,
+        batch_size=2,
+        beta=2.75,
+        gumbel_temperature=0.42,
+    )
+
+    model.fit(
+        X,
+        y,
+        warmup_epochs=1,
+        head_epochs=1,
+        finetune_epochs=1,
+        early_stop_patience=0,
+    )
+
+    path = tmp_path / "model.pt"
+    model.save(path)
+
+    restored = SUAVE.load(path)
+
+    assert restored.beta == pytest.approx(model.beta)
+    assert restored.gumbel_temperature == pytest.approx(model.gumbel_temperature)
+
+
 def test_training_monitor_keeps_elbo_semantics(monkeypatch):
     X, y, schema = _toy_dataset()
     updates: list[tuple[int, dict[str, float | None], dict[str, float | None]]] = []


### PR DESCRIPTION
## Summary
- include `beta` and `gumbel_temperature` in the serialized metadata so checkpoints retain custom schedules
- restore those hyperparameters when loading archives by casting them back to floats
- cover the round-trip behaviour with a save/load regression test in `tests/test_training_schedule.py`

## Testing
- PYTHONPATH=. pytest tests/test_training_schedule.py

------
https://chatgpt.com/codex/tasks/task_e_68da1a375ef883209ea520b1ddba9c76