### PR TITLE
Align Optuna saved-trial detection across summaries

### DIFF
--- a/examples/mimic_mortality_utils.py
+++ b/examples/mimic_mortality_utils.py
@@ -1594,6 +1594,7 @@ def _build_trial_summary_rows(
 def _build_manual_optuna_ranked_table(
     *,
     manual_manifest: Mapping[str, Any],
+    model_manifest: Optional[Mapping[str, Any]],
     pareto_candidates: Sequence[Mapping[str, Any]],
     trials_df: pd.DataFrame,
     model_dir: Path,
@@ -1602,7 +1603,7 @@ def _build_manual_optuna_ranked_table(
 
     rows, metric_columns, param_columns = _build_trial_summary_rows(
         list(pareto_candidates),
-        manifest={},
+        manifest=model_manifest or {},
         manual_manifest=manual_manifest,
         model_dir=model_dir,
         capture_params=True,
@@ -1728,6 +1729,7 @@ def collect_manual_and_optuna_overview(
 
     ranked_df = _build_manual_optuna_ranked_table(
         manual_manifest=manual_manifest,
+        model_manifest=model_manifest,
         pareto_candidates=pareto_candidates,
         trials_df=trials_df,
         model_dir=model_dir,

--- a/research_template/RESEARCH_README.md
+++ b/research_template/RESEARCH_README.md
@@ -32,7 +32,7 @@
 
 4. **运行 Optuna 搜索**
    - 执行 `python research-suave_optimize.py` 生成帕累托前沿、最优 Trial JSON 与调参可视化。目录结构遵循 `analysis_config.py` 的 `ANALYSIS_SUBDIRECTORIES` 定义。
-  - 交互模式下的手动调参概览会复用帕累托摘要表展示本地保存状态，并仅呈现验证集 ROAUC 与 TSTR/TRTR ΔAUC 两个核心指标，同时展开 Optuna CSV 中的全部参数列，并在表格下方按验证集 ROAUC 与 TSTR/TRTR ΔAUC 绘制参数切片、平行坐标与参数重要性图（3 行 × 2 列），辅助人工覆写。为兼容 Plotly `parcoords` trace 的子图要求，平行坐标行会自动切换至 `domain` 类型，避免旧版本后端出现“Trace type 'parcoords' is not compatible with subplot type 'xy'”错误。
+  - 交互模式下的手动调参概览会复用帕累托摘要表展示本地保存状态，并仅呈现验证集 ROAUC 与 TSTR/TRTR ΔAUC 两个核心指标，同时展开 Optuna CSV 中的全部参数列，并在表格下方按验证集 ROAUC 与 TSTR/TRTR ΔAUC 绘制参数切片、平行坐标与参数重要性图（3 行 × 2 列），辅助人工覆写。为兼容 Plotly `parcoords` trace 的子图要求，平行坐标行会自动切换至 `domain` 类型，避免旧版本后端出现“Trace type 'parcoords' is not compatible with subplot type 'xy'”错误；当存在已持久化的 Optuna Trial manifest 时，“Saved locally” 列会与帕累托摘要共享同一 manifest 信息，确保已保存的 Trial 显示为 `✅`。
 
 5. **执行主分析**
    - 运行 `python research-supervised_analysis.py [--trial-id N]` 以加载或训练目标模型、拟合校准器并完成下游评估。交互模式会提示选择 Trial，脚本模式可通过参数或环境变量控制缓存策略。使用 `--help` 查看命令行提示，可知传入 `manual` 可直接加载手动模型 manifest。

--- a/research_template/analysis_utils.py
+++ b/research_template/analysis_utils.py
@@ -1436,6 +1436,7 @@ def _build_trial_summary_rows(
 def _build_manual_optuna_ranked_table(
     *,
     manual_manifest: Mapping[str, Any],
+    model_manifest: Optional[Mapping[str, Any]],
     pareto_candidates: Sequence[Mapping[str, Any]],
     trials_df: pd.DataFrame,
     model_dir: Path,
@@ -1444,7 +1445,7 @@ def _build_manual_optuna_ranked_table(
 
     rows, metric_columns, param_columns = _build_trial_summary_rows(
         list(pareto_candidates),
-        manifest={},
+        manifest=model_manifest or {},
         manual_manifest=manual_manifest,
         model_dir=model_dir,
         capture_params=True,
@@ -1570,6 +1571,7 @@ def collect_manual_and_optuna_overview(
 
     ranked_df = _build_manual_optuna_ranked_table(
         manual_manifest=manual_manifest,
+        model_manifest=model_manifest,
         pareto_candidates=pareto_candidates,
         trials_df=trials_df,
         model_dir=model_dir,


### PR DESCRIPTION
## Summary
- pass the persisted Optuna model manifest into the ranked table helper so saved-trial detection matches the summary output
- mirror the signature and call-site changes in the research template utilities and document the behaviour in the template README

## Testing
- python - <<'PY' ... (verifies the "Saved locally" column resolves to ✅ for the stored trial)


------
https://chatgpt.com/codex/tasks/task_e_68dbaad33ed48320b2b2983d61f472ee